### PR TITLE
[Fix] Fix test_config and Config.

### DIFF
--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -4,7 +4,6 @@ import copy
 import os
 import os.path as osp
 import platform
-import re
 import shutil
 import sys
 import tempfile
@@ -25,6 +24,11 @@ BASE_KEY = '_base_'
 DELETE_KEY = '_delete_'
 DEPRECATION_KEY = '_deprecation_'
 RESERVED_KEYS = ['filename', 'text', 'pretty_text']
+
+if platform.system() == 'Windows':
+    import regex as re
+else:
+    import re  # type: ignore
 
 
 class ConfigDict(Dict):

--- a/tests/data/config/py_config/test_code_in_config.py
+++ b/tests/data/config/py_config/test_code_in_config.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from mmcv import Config  # isort:skip
+from mmengine import Config  # isort:skip
 
 cfg = Config.fromfile('tests/data/config/py_config/simple_config.py')
 item5 = cfg.item1[0] + cfg.item2.a

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -169,7 +169,9 @@ class TestConfig:
             cfg.merge_from_dict(input_options, allow_list_keys=True)
 
     def test_auto_argparser(self):
-        tmp = sys.argv[1]
+        # Temporarily make sys.argv only has one argument and keep backups
+        tmp = sys.argv[1:]
+        sys.argv = sys.argv[:2]
         sys.argv[1] = osp.join(
             self.data_path,
             'config/py_config/test_merge_from_multiple_bases.py')
@@ -181,7 +183,7 @@ class TestConfig:
                 assert not getattr(args, key)
         # TODO currently do not support nested keys, bool args will be
         #  overwritten by int
-        sys.argv[1] = tmp
+        sys.argv.extend(tmp)
 
     def test_dump(self, tmp_path):
         file_path = 'config/py_config/test_merge_from_multiple_bases.py'


### PR DESCRIPTION
## Motivation

修复当 pytest 传入多个参数时， test_config 的 test_auto_argparser 函数报错的问题。补充 Config模块 windows兼容性代码。


