### PR TITLE
[Fix] Stop using generic type `Sampler`.

### DIFF
--- a/mmengine/data/sampler.py
+++ b/mmengine/data/sampler.py
@@ -16,7 +16,7 @@ sync_random_seed = MagicMock(return_value=0)
 
 
 @DATA_SAMPLERS.register_module()
-class DefaultSampler(Sampler[int]):
+class DefaultSampler(Sampler):
     """The default data sampler for both distributed and non-distributed
     environment.
 
@@ -109,7 +109,7 @@ class DefaultSampler(Sampler[int]):
 
 
 @DATA_SAMPLERS.register_module()
-class InfiniteSampler(Sampler[int]):
+class InfiniteSampler(Sampler):
     """It's designed for iteration-based runner and yields a mini-batch indices
     each time.
 


### PR DESCRIPTION
## Motivation

The generic type `Sampler` is not supported in the early version PyTorch.

## Modification

Inherit `Sampler` instead of `Sampler[int]` in `DefaultSampler` and `InfiniteSampler`.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
