### PR TITLE
[Fix] Fix ddp duplicated warning.

### DIFF
--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -9,7 +9,6 @@ import torch.distributed as dist
 from termcolor import colored
 
 from .base_global_accsessible import BaseGlobalAccessible
-from mmengine.dist import master_only
 
 
 class MMFormatter(logging.Formatter):
@@ -138,12 +137,11 @@ class MMLogger(Logger, BaseGlobalAccessible):
             self.handlers.append(file_handler)
 
     def callHandlers(self, record):
-        """Overridden ``callHandlers`` method in logging.Logger to prevent
-        the logger from multiple warning message in ddp mode.
+        """Overridden ``callHandlers`` method in logging.Logger to prevent the
+        logger from multiple warning message in ddp mode.
 
-        Loop through all handlers for this logger and its parents in the
-        logger hierarchy. If no handler was found, the record will not be
-        output.
+        Loop through all handlers for this logger and its parents in the logger
+        hierarchy. If no handler was found, the record will not be output.
         """
         for handler in self.handlers:
             if record.levelno >= handler.level:

--- a/tests/test_logging/test_logger.py
+++ b/tests/test_logging/test_logger.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 import sys
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -45,7 +45,6 @@ class TestLogger:
         out, _ = capsys.readouterr()
         assert out
         logging.shutdown()
-
 
     @patch('torch.distributed.get_rank', MagicMock(return_value=1))
     @patch('torch.distributed.is_initialized', lambda: True)
@@ -101,9 +100,9 @@ class TestLogger:
         logger.error('welcome')
         file_path = __file__
         function_name = sys._getframe().f_code.co_name
-        pattern = self.regex_time + r' - test_error - (.*)ERROR(.*) - '\
+        pattern = self.regex_time + ' - test_error - (.*)ERROR(.*) - ' \
                                     f'{file_path} - {function_name} - ' \
-                                    '\d+ - welcome\n'
+                                    r'\d+ - welcome\n'
         out, _ = capsys.readouterr()
         match = re.fullmatch(pattern, out)
         assert match is not None


### PR DESCRIPTION
## Motivation
Fix multiple warnings in DDP modes. 
When `logger.level == logging.INFO`, even if the log level of `streamHandler` is `logging.ERROR`, there will still be a message shown in the terminal (This is the `logging` mechanism).  If we use `master_only`  to decorate `MMLogger.warning`, The error message line number will be wrong (The error line will be in `mmengine.logging.logger.py`).  Thus I override the `callHandler` method.
