### PR TITLE
[Fix] Fix LoggerHook save mutiple ranks scalar in the same json file.

### DIFF
--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -420,7 +420,7 @@ class LoggerHook(Hook):
                 name = log_cfg.pop('log_name')
             else:
                 name = log_key
-            tag[name] = log_buffers[log_key].statistics(**log_cfg)
+            tag[name] = log_buffers[log_key].statistics(**log_cfg).item()
         else:
             raise ValueError('The structure of `LoggerHook.custom key` is '
                              'wrong, please make sure the type of each key is '


### PR DESCRIPTION
## Motivation

`LoggerHook` stores scalars of multiple ranks in the same JSON when using LocalWriter. Now only save rank0's scalar.