### PR TITLE
[Enhance] Refine registry logging info.

### DIFF
--- a/mmengine/registry/registry.py
+++ b/mmengine/registry/registry.py
@@ -333,7 +333,7 @@ class Registry:
             if real_key in self._module_dict:
                 obj_cls = self._module_dict[real_key]
 
-            if scope is None:
+            elif scope is None:
                 # try to get the target from its parent or ancestors
                 parent = self.parent
                 while parent is not None:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Refine the logging and error message when building modules from the registry.

## Changes

### Logging during building

- before
```
no info
```
- after
More information such as the **registry name**, the **package name (scope)**, the **class name**, and **where to find the implementation**.
```
04/26 19:52:23 - mmengine - INFO - Get class LocalVisBackend from "vis_backend" registry in "mmengine"
04/26 19:52:23 - mmengine - INFO - An `LocalVisBackend` instance is built from registry, its implementation can be found in mmengine.visualization.vis_backend
04/26 19:52:24 - mmengine - INFO - Get class `ResNet` from "models" registry in "mmdet"
04/26 19:52:24 - mmengine - INFO - An `ResNet` instance is built from registry, its implementation can be found in mmdet.models.backbones.resnet
04/26 19:52:24 - mmengine - INFO - Get class `L1Loss` from "models" registry in "mmdet"
04/26 19:52:24 - mmengine - INFO - An `L1Loss` instance is built from registry, its implementation can be found in mmdet.models.losses.smooth_l1_loss
```

### Error message when the build failed
- before
```
TypeError: RetinaNet : __init__() got an unexpected keyword argument 'preprocess_cfg'
```
- after
```
TypeError: class `RetinaNet` in mmdet/models/detectors/retinanet.py: __init__() got an unexpected keyword argument 'preprocess_cfg'
```

This PR should be merged after #205