### PR TITLE
[Fix] fix collections.abc compatibility

### DIFF
--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -1,15 +1,22 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import functools
 import os
-import numpy as np
 import subprocess
 from typing import Callable, Optional, Tuple, Union
-from collections import Mapping, Iterable
+
+import numpy as np
 import torch
-from torch import Tensor
 import torch.multiprocessing as mp
+from torch import Tensor
 from torch import distributed as torch_dist
 from torch.distributed import ProcessGroup
+
+try:
+    # for python < 3.10
+    from collections import Iterable, Mapping
+except ImportError:
+    # for python >= 3.10
+    from collections.abc import Iterable, Mapping
 
 _LOCAL_PROCESS_GROUP = None
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix a compatibility issue of the package `collections` for python>=3.10.

## Modification

- `mmengine\dist\utils.py`

```python
# original (raise ImportError in python 3.10)
from collections import Mapping, Iterable

# changed
try:
    # for python < 3.10
    from collections import Iterable, Mapping
except ImportError:
    # for python >= 3.10
    from collections.abc import Iterable, Mapping
```

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
