### PR TITLE
fix nested build function calls

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1110,15 +1110,6 @@ class Runner:
             else:
                 loop = IterBasedTrainLoop(
                     **loop_cfg, runner=self, dataloader=self._train_dataloader)
-
-        # `build_optimizer` should be called before `build_param_scheduler`
-        #  because the latter depends on the former
-        self.optimizer = self.build_optimizer(self.optimizer)
-
-        if self.param_schedulers:
-            self.param_schedulers = self.build_param_scheduler(  # type: ignore
-                self.param_schedulers)  # type: ignore
-
         return loop  # type: ignore
 
     def build_val_loop(self, loop: Union[BaseLoop, Dict]) -> BaseLoop:
@@ -1240,6 +1231,14 @@ class Runner:
 
         self._train_loop = self.build_train_loop(
             self._train_loop)  # type: ignore
+
+        # `build_optimizer` should be called before `build_param_scheduler`
+        #  because the latter depends on the former
+        self.optimizer = self.build_optimizer(self.optimizer)
+
+        if self.param_schedulers:
+            self.param_schedulers = self.build_param_scheduler(  # type: ignore
+                self.param_schedulers)  # type: ignore
 
         if self._val_loop is not None:
             self._val_loop = self.build_val_loop(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When building a scheduler with `convert_to_iter_based=True`, the build function of param_scheduler requires train_loop, while the build function of train_loop will call build_param_scheduler.
Although it was somehow built successfully, the calling logic is nested and confusing.
To avoid these nested build function calls, we need to separate build_train_loop, build_optimizer, and build_param_scheduler.

## Modification

Move `build_optimizer` and `build_param_scheduler` out of `build_train_loop`.

