### PR TITLE
[Enhance] Improve Exception in call_hook

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1296,6 +1296,9 @@ class Runner:
             fn_name (str): The function name in each hook to be called, such as
                 "before_train_epoch".
             **kwargs: Keyword arguments passed to hook.
+
+        Raises:
+            TypeError: if Hook got unexpected arguments.
         """
         for hook in self._hooks:
             # support adding additional custom hook methods

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -1035,15 +1035,25 @@ class TestRunner(TestCase):
     def test_call_hook(self):
         # test unexpected argument in `call_hook`
         cfg = copy.deepcopy(self.epoch_based_cfg)
-        cfg.experiment_name = 'test_call_hook'
+        cfg.experiment_name = 'test_call_hook1'
         runner = Runner.from_cfg(cfg)
+        runner._hooks = []
         custom_hooks = [dict(type='ToyHook3')]
         runner.register_custom_hooks(custom_hooks)
         with self.assertRaisesRegex(
                 TypeError,
                 r"got an unexpected keyword argument 'batch_idx' in "
                 r'<test_runner.ToyHook3 object at \w+>'):
-            runner.train()
+            runner.call_hook('before_train_iter', batch_idx=0, data_batch=None)
+
+        # test call hook with expected arguments
+        cfg = copy.deepcopy(self.epoch_based_cfg)
+        cfg.experiment_name = 'test_call_hook2'
+        runner = Runner.from_cfg(cfg)
+        runner._hooks = []
+        custom_hooks = [dict(type='ToyHook3')]
+        runner.register_custom_hooks(custom_hooks)
+        runner.call_hook('before_train_iter', data_batch=None)
 
     def test_register_hooks(self):
         cfg = copy.deepcopy(self.epoch_based_cfg)


### PR DESCRIPTION
## Motivation

When there is a custom hook parameter error, it will only prompt the reason for the error, but it does not tell the user which hook is wrong.

## Modification

`runner.py` and `test_runner.py`

## Use cases (Optional)

Before this PR:
![image-20220522225437737](https://user-images.githubusercontent.com/47851024/169726462-5aa61a55-79e4-48d0-8ede-6b7a2ef501b1.png)
After this PR:
![image-20220522225246331](https://user-images.githubusercontent.com/47851024/169726530-09484704-8dc7-422d-8188-951e3f2cebb3.png)


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
