### PR TITLE
[fix]:use messge_hub instead of log_buffer to store `grad_norm`

### DIFF
--- a/mmengine/hooks/optimizer_hook.py
+++ b/mmengine/hooks/optimizer_hook.py
@@ -94,9 +94,9 @@ class OptimizerHook(Hook):
         if self.grad_clip is not None:
             grad_norm = self.clip_grads(runner.model.parameters())
             if grad_norm is not None:
-                # Add grad norm to the logger
-                runner.log_buffer.update({'grad_norm': float(grad_norm)},
-                                         runner.outputs['num_samples'])
+                # Add grad norm to the message_hub
+                runner.message_hub.update_scalar(
+                        'grad_norm', float(grad_norm),runner.outputs['num_samples'])
         runner.optimizer.step()
 
     def detect_anomalous_parameters(self, loss: torch.Tensor, runner) -> None:


### PR DESCRIPTION
## Motivation

In issue #245, there is a misuse of `log_buffer`.In mmengine,should use `message_hub` to store information instead.

## Modification

This PR fix the problem described above.


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
