### PR TITLE
[Enhance] Optimize parameter updating speed in AveragedModel.

### DIFF
--- a/mmengine/model/averaged_model.py
+++ b/mmengine/model/averaged_model.py
@@ -19,7 +19,10 @@ class BaseAveragedModel(nn.Module):
     This class creates a copy of the provided module :attr:`model`
     on the device :attr:`device` and allows computing running averages of the
     parameters of the :attr:`model`.
-    The code is referenced from: https://github.com/pytorch/pytorch/blob/master/torch/optim/swa_utils.py
+    The code is referenced from: https://github.com/pytorch/pytorch/blob/master/torch/optim/swa_utils.py.
+    Different from the `AveragedModel` in PyTorch, we use in-place operation
+    to improve the parameter updating speed, which is about 5 times faster
+    than the non-in-place version.
 
     In mmengine, we provide two ways to use the model averaging:
     1. Use the model averaging module in hook:


### PR DESCRIPTION
## Motivation

Optimize the parameter update code to improve the speed.

### Use EMA to update ResNet50
previous version:
```
New EMA [10 /100], fps: 49.6 iter/s, times per iter: 20.2 ms/iter, 
New EMA [15 /100], fps: 50.0 iter/s, times per iter: 20.0 ms/iter, 
New EMA [20 /100], fps: 50.0 iter/s, times per iter: 20.0 ms/iter, 
New EMA [25 /100], fps: 49.9 iter/s, times per iter: 20.1 ms/iter, 
New EMA [30 /100], fps: 50.1 iter/s, times per iter: 20.0 ms/iter, 
New EMA [35 /100], fps: 50.0 iter/s, times per iter: 20.0 ms/iter, 
New EMA [40 /100], fps: 50.1 iter/s, times per iter: 20.0 ms/iter, 
New EMA [45 /100], fps: 50.2 iter/s, times per iter: 19.9 ms/iter, 
New EMA [50 /100], fps: 50.1 iter/s, times per iter: 19.9 ms/iter, 
New EMA [55 /100], fps: 50.3 iter/s, times per iter: 19.9 ms/iter, 
New EMA [60 /100], fps: 50.3 iter/s, times per iter: 19.9 ms/iter, 
New EMA [65 /100], fps: 50.2 iter/s, times per iter: 19.9 ms/iter, 
New EMA [70 /100], fps: 50.3 iter/s, times per iter: 19.9 ms/iter, 
New EMA [75 /100], fps: 50.3 iter/s, times per iter: 19.9 ms/iter, 
New EMA [80 /100], fps: 49.9 iter/s, times per iter: 20.1 ms/iter, 
New EMA [85 /100], fps: 49.9 iter/s, times per iter: 20.0 ms/iter, 
New EMA [90 /100], fps: 50.0 iter/s, times per iter: 20.0 ms/iter, 
New EMA [95 /100], fps: 49.4 iter/s, times per iter: 20.3 ms/iter, 
New EMA [100/100], fps: 49.4 iter/s, times per iter: 20.2 ms/iter, 
```


Now:
```
New EMA [10 /100], fps: 237.3 iter/s, times per iter: 4.2 ms/iter, 
New EMA [15 /100], fps: 237.3 iter/s, times per iter: 4.2 ms/iter, 
New EMA [20 /100], fps: 237.3 iter/s, times per iter: 4.2 ms/iter, 
New EMA [25 /100], fps: 237.4 iter/s, times per iter: 4.2 ms/iter, 
New EMA [30 /100], fps: 237.8 iter/s, times per iter: 4.2 ms/iter, 
New EMA [35 /100], fps: 237.7 iter/s, times per iter: 4.2 ms/iter, 
New EMA [40 /100], fps: 237.8 iter/s, times per iter: 4.2 ms/iter, 
New EMA [45 /100], fps: 238.0 iter/s, times per iter: 4.2 ms/iter, 
New EMA [50 /100], fps: 238.2 iter/s, times per iter: 4.2 ms/iter, 
New EMA [55 /100], fps: 238.4 iter/s, times per iter: 4.2 ms/iter, 
New EMA [60 /100], fps: 238.3 iter/s, times per iter: 4.2 ms/iter, 
New EMA [65 /100], fps: 238.4 iter/s, times per iter: 4.2 ms/iter, 
New EMA [70 /100], fps: 238.3 iter/s, times per iter: 4.2 ms/iter, 
New EMA [75 /100], fps: 238.4 iter/s, times per iter: 4.2 ms/iter, 
New EMA [80 /100], fps: 238.6 iter/s, times per iter: 4.2 ms/iter, 
New EMA [85 /100], fps: 238.6 iter/s, times per iter: 4.2 ms/iter, 
New EMA [90 /100], fps: 238.6 iter/s, times per iter: 4.2 ms/iter, 
New EMA [95 /100], fps: 238.5 iter/s, times per iter: 4.2 ms/iter, 
New EMA [100/100], fps: 238.5 iter/s, times per iter: 4.2 ms/iter, 
```

## Modification

Replace the `avg_func` with in-place oprations.
Disable auto-grad of the averaged model.
Change the way of getting parameters.

## BC-breaking (Optional)

All subclass should change the `avg_func` to an in-place version.


