### PR TITLE
[Fix] Change order of BaseModel arguments

### DIFF
--- a/mmengine/model/base_model/base_model.py
+++ b/mmengine/model/base_model/base_model.py
@@ -57,21 +57,21 @@ class BaseModel(BaseModule):
         >>>             return dict(loss=loss)
 
     Args:
-        init_cfg (dict, optional): The weight initialized config for
-            :class:`BaseModule`.
         data_preprocessor (dict, optional): The pre-process config of
             :class:`BaseDataPreprocessor`.
+        init_cfg (dict, optional): The weight initialized config for
+            :class:`BaseModule`.
 
     Attributes:
-        init_cfg (dict, optional): Initialization config dict.
         data_preprocessor (:obj:`BaseDataPreprocessor`): Used for
             pre-processing data sampled by dataloader to the format accepted by
             :meth:`forward`.
+        init_cfg (dict, optional): Initialization config dict.
     """
 
     def __init__(self,
-                 init_cfg: Optional[dict] = None,
-                 data_preprocessor: Optional[Union[dict, nn.Module]] = None):
+                 data_preprocessor: Optional[Union[dict, nn.Module]] = None,
+                 init_cfg: Optional[dict] = None):
         super().__init__(init_cfg)
         if data_preprocessor is None:
             data_preprocessor = dict(type='BaseDataPreprocessor')

--- a/tests/test_model/test_base_model/test_base_model.py
+++ b/tests/test_model/test_base_model/test_base_model.py
@@ -25,7 +25,7 @@ class CustomDataPreprocessor(BaseDataPreprocessor):
 class ToyModel(BaseModel):
 
     def __init__(self, data_preprocessor=None):
-        super().__init__(None, data_preprocessor=data_preprocessor)
+        super().__init__(data_preprocessor=data_preprocessor, init_cfg=None)
         self.conv = nn.Conv2d(3, 1, 1)
 
     def forward(self, batch_inputs, data_samples=None, mode='tensor'):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

It would be more proper to make `init_cfg` as the second arguments of `BaseModel`

## Modification

Change the order of `data_preprocessor` and `init_cfg` in `BaseModel.__init__`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
