### PR TITLE
[Enhance] support to add custom settings to param_group

### DIFF
--- a/mmengine/optim/optimizer/default_constructor.py
+++ b/mmengine/optim/optimizer/default_constructor.py
@@ -216,6 +216,9 @@ class DefaultOptimWrapperConstructor:
                     if self.base_wd is not None:
                         decay_mult = custom_keys[key].get('decay_mult', 1.)
                         param_group['weight_decay'] = self.base_wd * decay_mult
+                    # add custom settings to param_group
+                    for k, v in custom_keys[key].items():
+                        param_group[k] = v
                     break
 
             if not is_custom:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

As in some self supervised training, we need some special key-value pair in custom key to control some layers. 
For example, {fix_lr: True} or {lars_exclude: True}.

## Modification

Revise default constructor, it support to save special key-value pair to param_group.

The example log:
06/08 12:03:35 - mmengine - INFO - paramwise_options -- linear.bias:lr=0.05
06/08 12:03:35 - mmengine - INFO - paramwise_options -- predictor.weight:lr=0.05
06/08 12:03:35 - mmengine - INFO - paramwise_options -- predictor.weight:fix_lr=True
06/08 12:03:35 - mmengine - INFO - paramwise_options -- predictor.bias:lr=0.05
06/08 12:03:35 - mmengine - INFO - paramwise_options -- predictor.bias:fix_lr=True

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
