### PR TITLE
fix swa in pytorch 1.6

### DIFF
--- a/mmengine/model/averaged_model.py
+++ b/mmengine/model/averaged_model.py
@@ -129,7 +129,7 @@ class StochasticWeightAverage(BaseAveragedModel):
         """
         averaged_param.add_(
             source_param - averaged_param,
-            alpha=1 / (steps // self.interval + 1))
+            alpha=1 / float(steps // self.interval + 1))
 
 
 @MODELS.register_module()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In pytorch 1.6 or lower version, 1 / torch.tensor(2, dtype=torch.long) = 0
In pytorch >= 1.7 , 1 / torch.tensor(2, dtype=torch.long) = 0.5

## Modification

set the swa function to float.
