### PR TITLE
[Fix] fix torch 1.10 amp error

### DIFF
--- a/mmengine/runner/amp.py
+++ b/mmengine/runner/amp.py
@@ -77,7 +77,20 @@ def autocast(enabled: bool = True, **kwargs):
                     'If pytorch versions is between 1.5.0 and 1.10, '
                     '`autocast` is only available in gpu mode')
 
-    elif digit_version(TORCH_VERSION) >= digit_version('1.10.0'):
+    elif (digit_version('1.11.0') > digit_version(TORCH_VERSION) >=
+          digit_version('1.10.0')):
+        if torch.cuda.is_available():
+            kwargs.setdefault('device_type', 'cuda')
+        else:
+            kwargs.setdefault('device_type', 'cpu')
+            # torch.autocast only support `dtype=torch.bfloat16` in
+            # pytorch 1.10
+            kwargs.setdefault('dtype', torch.bfloat16)
+
+        with torch.autocast(enabled=enabled, **kwargs):
+            yield
+
+    elif digit_version(TORCH_VERSION) >= digit_version('1.11.0'):
         if torch.cuda.is_available():
             kwargs.setdefault('device_type', 'cuda')
         else:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

If `cuda` is not available and pytorch version is 1.10, the `dtype` arguments of `torch.autocast` must accept `torch.bfloat16` :
```python
with torch.autocast(device_type='cpu', dtype=`torch.bfloat16`)
    linear = nn.Linear(1, 1)
    t = torch.Tensor(1, 1)
    print(linear(t).dtype)
    # torch.bfloat16
```  
OtherWise, `autocast` context manager will not work, and throw a warning:
```bash
UserWarning: In CPU autocast, but the target dtype is not supported. Disabling autocast.
CPU Autocast only supports dtype of torch.bfloat16 currently.
  warnings.warn(error_message)
``` 

If `cuda` is not available and PyTorch version is larger than 1.11,  `autocast` does not need accept any arguments:
```python
with torch.autocast(device_type='cpu', enabled=True):
    linear = nn.Linear(1, 1)
    t = torch.Tensor(1, 1)
    print(linear(t).dtype)
    # torch.bfloat16
```

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
