### PR TITLE
[Fix] Fix optimizer wrapper UT failed in pytorch1.6

### DIFF
--- a/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
+++ b/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
@@ -79,9 +79,9 @@ class TestOptimWrapper(MultiProcessTestCase):
         # Test update params every iteration.
         optim_wrapper = OptimWrapper(self.optimizer, accumulative_counts=1)
         self._mock_method(optim_wrapper)
-        loss = torch.tensor(1)
+        loss = torch.tensor(1.)
         optim_wrapper.update_params(loss)
-        self.assertEqual(optim_wrapper.scaled_loss, torch.tensor(1))
+        self.assertEqual(optim_wrapper.scaled_loss, torch.tensor(1.))
         optim_wrapper.step.assert_called_with()
         optim_wrapper.zero_grad.assert_called_with()
 
@@ -89,15 +89,15 @@ class TestOptimWrapper(MultiProcessTestCase):
         optim_wrapper = OptimWrapper(self.optimizer, accumulative_counts=3)
         self._mock_method(optim_wrapper)
         # `iter=0`, accumulate gradient and do not update params.
-        loss = torch.tensor(1)
+        loss = torch.tensor(1.)
         optim_wrapper.update_params(loss)
-        self.assertEqual(optim_wrapper.scaled_loss, torch.tensor(1) / 3)
+        self.assertEqual(optim_wrapper.scaled_loss, torch.tensor(1.) / 3.)
         optim_wrapper.step.assert_not_called()
         optim_wrapper.zero_grad.assert_not_called()
 
         # gradient accumulate
         optim_wrapper.update_params(loss)
-        self.assertEqual(optim_wrapper._inner_count, 2)
+        self.assertEqual(optim_wrapper._inner_count, 2.)
 
         # `iter=2`, update params.
         optim_wrapper.update_params(loss)
@@ -110,7 +110,7 @@ class TestOptimWrapper(MultiProcessTestCase):
         optim_wrapper.update_params(loss)
         optim_wrapper.step.assert_not_called()
         optim_wrapper.zero_grad.assert_not_called()
-        self.assertEqual(optim_wrapper.scaled_loss, torch.tensor(1) / 3)
+        self.assertEqual(optim_wrapper.scaled_loss, torch.tensor(1.) / 3.)
         self._mock_method(optim_wrapper)
 
         # After calling `initialize_iter_status`, params will be updated at the


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The int tensor cannot be divided by the float tensor in PyTorch 1.6. The unit test of `OptimWrapper`  will fail in pytorch 1.6.

## Modification

Fix `TestOptimWrapper`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
