### PR TITLE
[Fix] make `autocast` compatible with  GTX1660 and make it more robust.

### DIFF
--- a/mmengine/runner/amp.py
+++ b/mmengine/runner/amp.py
@@ -5,9 +5,9 @@ from typing import Optional
 
 import torch
 
-from mmengine import print_log
-from mmengine.device import get_device
-from mmengine.utils import TORCH_VERSION, digit_version
+from ..device import get_device
+from ..logging import print_log
+from ..utils import TORCH_VERSION, digit_version
 
 
 @contextmanager


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`autocast` cannot not work with GTX1660 since the device does not support `torch.bfloat16` autocast. Besides, to make `autocast` more compatible with different pytorch version, I copy the core logic from `torch.autocast` to `autocast`. 

## Modification

Copy some code from `torch.autocast` to `autocast`, and make the dtype argument  must be `torch.bfloat16` in CPU mode( pytorch 1.12 still only support `torch.bfloat16` autocast in cpu mode).   

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
