### PR TITLE
[Feature] Add `RewriteCheckPointHook` to rewrite key of `state_dict` in `checkpoint`  

### DIFF
--- a/mmengine/hooks/__init__.py
+++ b/mmengine/hooks/__init__.py
@@ -7,7 +7,7 @@ from .iter_timer_hook import IterTimerHook
 from .logger_hook import LoggerHook
 from .naive_visualization_hook import NaiveVisualizationHook
 from .param_scheduler_hook import ParamSchedulerHook
-from .rewrite_checkpoint_hook import RewriteCheckPointHook
+from .rewrite_checkpoint_hook import MigrateCheckPointHook
 from .runtime_info_hook import RuntimeInfoHook
 from .sampler_seed_hook import DistSamplerSeedHook
 from .sync_buffer_hook import SyncBuffersHook
@@ -16,5 +16,5 @@ __all__ = [
     'Hook', 'IterTimerHook', 'DistSamplerSeedHook', 'ParamSchedulerHook',
     'SyncBuffersHook', 'EmptyCacheHook', 'CheckpointHook', 'LoggerHook',
     'NaiveVisualizationHook', 'EMAHook', 'RuntimeInfoHook',
-    'RewriteCheckPointHook'
+    'MigrateCheckPointHook'
 ]

--- a/mmengine/hooks/rewrite_checkpoint_hook.py
+++ b/mmengine/hooks/rewrite_checkpoint_hook.py
@@ -8,13 +8,13 @@ from .hook import Hook
 
 
 @HOOKS.register_module()
-class RewriteCheckPointHook(Hook):
+class MigrateCheckPointHook(Hook):
     """A hook to rewrite key in checkpoint.
 
     You can set ``applied_key`` to rewrite dictionary like instance saved in
     checkpoint.
 
-    ``RewriteCheckPointHook`` has three mode to rewrite original checkpoint:
+    ``MigrateCheckPointHook`` has three mode to rewrite original checkpoint:
 
     - remove: Removes specified keys in target dictionary saved in checkpoint.
     - name_mapping: Maps the original key to the target one by the
@@ -42,21 +42,21 @@ class RewriteCheckPointHook(Hook):
     Examples:
         >>> # Config example:
         >>> # remove key starts with `module`
-        >>> cfg = dict(type='RewriteCheckPointHook', removed_prefix='module')
+        >>> cfg = dict(type='MigrateCheckPointHook', removed_prefix='module')
         >>>
         >>> # remapping prefix `submodule` to `module`
-        >>> cfg = dict(type='RewriteCheckPointHook',
+        >>> cfg = dict(type='MigrateCheckPointHook',
                        prefix_mapping=dict(src='submodule', dst='module'))
         >>>
         >>> merge keys from checkpoint.
-        >>> cfg = dict(type='RewriteCheckPointHook',
+        >>> cfg = dict(type='MigrateCheckPointHook',
         >>>            prefix_mapping=dict(src='submodule', dst='module'))
         >>>
         >>> # Example of specific changes to the `state_dict`
         >>> import torch
         >>> import torch.nn as nn
         >>>
-        >>> from mmengine.hooks import RewriteCheckPointHook
+        >>> from mmengine.hooks import MigrateCheckPointHook
         >>>
         >>> class SubModule(nn.Module):
         >>>     def __init__(self) -> None:
@@ -80,7 +80,7 @@ class RewriteCheckPointHook(Hook):
         >>>
         >>> # remove `layer1` in `state_dict`.
         >>> checkpoint = dict(state_dict=model.state_dict())
-        >>> hook = RewriteCheckPointHook(removed_prefix='layer1')
+        >>> hook = MigrateCheckPointHook(removed_prefix='layer1')
         >>> hook.after_load_checkpoint(None, checkpoint)
         >>> checkpoint['state_dict'].keys()
         >>> # ['layer2.weight', 'layer2.bias', 'submodule.layer1.weight',
@@ -89,14 +89,14 @@ class RewriteCheckPointHook(Hook):
         >>>
         >>> # remove key with prefix `submodule`.
         >>> checkpoint = dict(state_dict=model.state_dict())
-        >>> hook = RewriteCheckPointHook(removed_prefix='submodule')
+        >>> hook = MigrateCheckPointHook(removed_prefix='submodule')
         >>> hook.after_load_checkpoint(None, checkpoint)
         >>> checkpoint['state_dict'].keys()
         >>> # ['layer1.weight', 'layer1.bias', 'layer2.weight', 'layer2.bias']
         >>>
         >>> # remapping prefix `module` to `submodule`.
         >>> checkpoint = dict(state_dict=model.state_dict())
-        >>> hook = RewriteCheckPointHook(prefix_mapping=[dict(src='submodule', dst='module')])  # noqa: E501
+        >>> hook = MigrateCheckPointHook(prefix_mapping=[dict(src='submodule', dst='module')])  # noqa: E501
         >>> hook.after_load_checkpoint(None, checkpoint)
         >>> checkpoint['state_dict'].keys()
         >>> # ['layer1.weight', 'layer1.bias', 'layer2.weight', 'layer2.bias',
@@ -105,7 +105,7 @@ class RewriteCheckPointHook(Hook):
         >>>
         >>> # remapping prefix `module` to `submodule`, `layer1` to `linear1`.
         >>> checkpoint = dict(state_dict=model.state_dict())
-        >>> hook = RewriteCheckPointHook(
+        >>> hook = MigrateCheckPointHook(
         >>>     prefix_mapping=[dict(src='submodule', dst='module'),
         >>>                 dict(src='layer1', dst='linear1')])
         >>> hook.after_load_checkpoint(None, checkpoint)
@@ -118,7 +118,7 @@ class RewriteCheckPointHook(Hook):
         >>> checkpoint = dict(state_dict=model.state_dict())
         >>> merged_ckpt = dict(state_dict=nn.Conv2d(1, 1, 1).state_dict())
         >>> torch.save(merged_ckpt, 'docs_demo.pth')
-        >>> hook = RewriteCheckPointHook(
+        >>> hook = MigrateCheckPointHook(
         >>>     merged_state_dicts=['docs_demo.pth'])
         >>> hook.after_load_checkpoint(None, checkpoint)
         >>> checkpoint['state_dict'].keys()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Add `MigrateCheckPointHook` to the rewriting key in the loaded checkpoint. 

The `state_dict`(or any other keys, such as ema_state_dict) in `checkpoint ` may not match the model strictly. `MigrateCheckPointHook` can rewrite these keys to the matched ones.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

```python
import torch
import torch.nn as nn

from mmengine.hooks import MigrateCheckPointHook


class SubModule(nn.Module):
    def __init__(self) -> None:
        super().__init__()
        self.layer1 = nn.Linear(1, 1)
        self.layer2 = nn.Linear(1, 1)
class Model(nn.Module):
    def __init__(self) -> None:
        super().__init__()
        self.layer1 = nn.Linear(1, 1)
        self.layer2 = nn.Linear(1, 1)
        self.submodule = SubModule()

# original `state_dict`.
model = Model()
model.state_dict().keys()
# ['layer1.weight', 'layer1.bias', 'layer2.weight', 'layer2.bias',
#  'submodule.layer1.weight', 'submodule.layer1.bias',
#  'submodule.layer2.weight', 'submodule.layer2.bias']

# remove `layer1` in `state_dict`.
checkpoint = dict(state_dict=model.state_dict())
hook = MigrateCheckPointHook(removed_prefix='layer1')
hook.after_load_checkpoint(None, checkpoint)
checkpoint['state_dict'].keys()
# ['layer2.weight', 'layer2.bias', 'submodule.layer1.weight',
#  'submodule.layer1.bias', 'submodule.layer2.weight',
#  'submodule.layer2.bias']

# remove key with prefix `submodule`.
checkpoint = dict(state_dict=model.state_dict())
hook = MigrateCheckPointHook(removed_prefix='submodule')
hook.after_load_checkpoint(None, checkpoint)
checkpoint['state_dict'].keys()
# ['layer1.weight', 'layer1.bias', 'layer2.weight', 'layer2.bias']

# remapping prefix `module` to `submodule`.
checkpoint = dict(state_dict=model.state_dict())
hook = MigrateCheckPointHook(prefix_mapping=[dict(src='submodule', dst='module')])  # noqa: E501
hook.after_load_checkpoint(None, checkpoint)
checkpoint['state_dict'].keys()
# ['layer1.weight', 'layer1.bias', 'layer2.weight', 'layer2.bias',
#  'module.layer1.weight', 'module.layer1.bias',
#  'module.layer2.weight', 'module.layer2.bias']

# remapping prefix `module` to `submodule`, `layer1` to `linear1`.
checkpoint = dict(state_dict=model.state_dict())
hook = MigrateCheckPointHook(
    prefix_mapping=[dict(src='submodule', dst='module'),
                dict(src='layer1', dst='linear1')])
hook.after_load_checkpoint(None, checkpoint)
checkpoint['state_dict'].keys()
# ['linear1.weight', 'linear1.bias', 'layer2.weight',
#  'layer2.bias', 'module.layer1.weight', 'module.layer1.bias',
#  'module.layer2.weight', 'module.layer2.bias']

# merge other `state_dict`.
checkpoint = dict(state_dict=model.state_dict())
merged_ckpt = dict(state_dict=nn.Conv2d(1, 1, 1).state_dict())
torch.save(merged_ckpt, 'docs_demo.pth')
hook = MigrateCheckPointHook(
    merged_state_dicts=['docs_demo.pth'])
hook.after_load_checkpoint(None, checkpoint)
checkpoint['state_dict'].keys()
# ['layer1.weight', 'layer1.bias', 'layer2.weight', 'layer2.bias',
#  'submodule.layer1.weight', 'submodule.layer1.bias',
#  'submodule.layer2.weight', 'submodule.layer2.bias',
#  'weight', 'bias'
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
