### PR TITLE
[Fix] fix `is_abs` criterion error

### DIFF
--- a/mmengine/utils/path.py
+++ b/mmengine/utils/path.py
@@ -110,7 +110,7 @@ def is_abs(path: str) -> bool:
     Returns:
         bool: whether path is an absolute path.
     """
-    if osp.isabs(path) or path.startswith(('http', 'https', 's3:')):
+    if osp.isabs(path) or path.startswith(('http://', 'https://', 's3://')):
         return True
     else:
         return False


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In mmdet3d, we have `ann_file= 's3dis_infos_train.pkl' `,  and it will be regarded as `absolute path` in code.

## Modification

change `is_abs` code in mmengine.utils.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
