### PR TITLE
[Fix] Calls `OptimWrapper.initialize_count_status` after resume.

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1592,15 +1592,16 @@ class Runner:
                 self._val_loop)  # type: ignore
 
         self.call_hook('before_run')
+
+        # TODO: add a contextmanager to avoid calling `before_run` many times
+        # make sure checkpoint-related hooks are triggered after `before_run`
+        self.load_or_resume()
+
         # Initiate inner count of `optim_wrapper`.
         self.optim_wrapper.initialize_count_status(
             self.model,
             self._train_loop.iter,  # type: ignore
             self._train_loop.max_iters)  # type: ignore
-
-        # TODO: add a contextmanager to avoid calling `before_run` many times
-        # make sure checkpoint-related hooks are triggered after `before_run`
-        self.load_or_resume()
 
         self.train_loop.run()  # type: ignore
         self.call_hook('after_run')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`OptimWrapper.initialize_count_status` should be called after `Runner.load_or_resume`, Otherwise `OptimWrapper._innter_iter` will not be consistent with  `Runner.train_loop.iter` after resuming.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
