### PR TITLE
[Enhance] Put the total loss in the log before all losses

### DIFF
--- a/mmengine/model/base_model/base_model.py
+++ b/mmengine/model/base_model/base_model.py
@@ -162,20 +162,23 @@ class BaseModel(BaseModule):
             all losses, and the second is log_vars which will be sent to the
             logger.
         """
-        log_vars = OrderedDict()
+        log_vars = []
         for loss_name, loss_value in losses.items():
             if isinstance(loss_value, torch.Tensor):
-                log_vars[loss_name] = loss_value.mean()
+                log_vars.append([loss_name, loss_value.mean()])
             elif is_list_of(loss_value, torch.Tensor):
-                log_vars[loss_name] = sum(_loss.mean() for _loss in loss_value)
+                log_vars.append(
+                    [loss_name,
+                     sum(_loss.mean() for _loss in loss_value)])
             else:
                 raise TypeError(
                     f'{loss_name} is not a tensor or list of tensors')
 
-        loss = sum(value for key, value in log_vars.items() if 'loss' in key)
-        log_vars['loss'] = loss
+        loss = sum(value for key, value in log_vars if 'loss' in key)
+        log_vars.insert(0, ['loss', loss])
+        log_vars = OrderedDict(log_vars)  # type: ignore
 
-        return loss, log_vars
+        return loss, log_vars  # type: ignore
 
     def to(self, device: Optional[Union[int, torch.device]], *args,
            **kwargs) -> nn.Module:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Put the total loss in the log before all losses. total `loss` should be next to `grad_norm` 


Original log：

```bash
07/15 15:08:01 - mmengine - INFO - Epoch(train) [1][10/4]  lr: 1.0000e-02  eta: 0:00:00  time: 0.4341  data_time: 0.4319  memory: 0  grad_norm: 30.3858  loss_bbox: 9.6376  loss_cls: 9.6376  loss: 19.2753
```

Enhanced log：

```bash
07/15 15:06:04 - mmengine - INFO - Epoch(train) [1][10/4]  lr: 1.0000e-02  eta: 0:00:00  time: 0.0325  data_time: 0.0313  memory: 0  grad_norm: 23.0277  loss: 12.9813  loss_bbox: 6.4906  loss_cls: 6.4906
```

## Modification

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
