### PR TITLE
[Fix] Fix `LogProcessor._get_iter`

### DIFF
--- a/mmengine/logging/log_processor.py
+++ b/mmengine/logging/log_processor.py
@@ -369,7 +369,7 @@ class LogProcessor:
         Returns:
             int: The current global iter or inner iter.
         """
-        if self.by_epoch and batch_idx:
+        if self.by_epoch and batch_idx is not None:
             current_iter = batch_idx + 1
         else:
             current_iter = runner.iter + 1


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
If `batch_size==1`, The training log: `Epoch(train) [3][7/3]` is wrong(current iteration is larger than the length of dataloader). 
```bash
07/14 18:39:02 - mmengine - INFO - Epoch(train) [3][7/3]  lr: 6.9895e-03  memory: 1779  data_time: 0.3146  loss_prob: 13.1695  loss_thr: 2.2237  loss_db: 0.9783  loss: 16.3716  time: 1.3600
```

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
