### PR TITLE
[FIx] Logging `time` in `LoggerHook.after_val_epoch` has no effect.

### DIFF
--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -214,10 +214,7 @@ class LoggerHook(Hook):
             # by iter. At the same time, scalars related to time should
             # still be logged by iter to avoid messy visualized result.
             # see details in PR #278.
-            time_tags = {k: v for k, v in tag.items() if 'time' in k}
             metric_tags = {k: v for k, v in tag.items() if 'time' not in k}
-            runner.visualizer.add_scalars(
-                time_tags, step=runner.iter, file_path=self.json_log_path)
             runner.visualizer.add_scalars(
                 metric_tags, step=runner.epoch, file_path=self.json_log_path)
         else:

--- a/tests/test_hook/test_logger_hook.py
+++ b/tests/test_hook/test_logger_hook.py
@@ -128,12 +128,7 @@ class TestLoggerHook:
         logger_hook.after_val_epoch(runner)
         args = {'step': ANY, 'file_path': ANY}
         # expect visualizer log `time` and `metric` respectively
-        runner.visualizer.add_scalars.assert_any_call(
-            {
-                'time': 1,
-                'datatime': 1
-            }, **args)
-        runner.visualizer.add_scalars.assert_any_call({'acc': 0.8}, **args)
+        runner.visualizer.add_scalars.assert_called_with({'acc': 0.8}, **args)
 
         # Test when `log_metric_by_epoch` is False
         logger_hook = LoggerHook(log_metric_by_epoch=False)
@@ -145,7 +140,7 @@ class TestLoggerHook:
             }, 'string'))
         logger_hook.after_val_epoch(runner)
         # expect visualizer log `time` and `metric` jointly
-        runner.visualizer.add_scalars.assert_any_call(
+        runner.visualizer.add_scalars.assert_called_with(
             {
                 'time': 5,
                 'datatime': 5,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The tag returned by `LogProcessor.get_log_after_epoch` will not contain `time` and `data_time`, and it should not be passed to visualizer to log time.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
