### PR TITLE
[FIx] Fix tensorboard visbackend will modify `scalar_dict`, and cannot log `np.int64` message.

### DIFF
--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import copy
 import functools
 import os
 import os.path as osp
@@ -291,6 +292,7 @@ class LocalVisBackend(BaseVisBackend):
                 Default to None.
         """
         assert isinstance(scalar_dict, dict)
+        scalar_dict = copy.deepcopy(scalar_dict)
         scalar_dict.setdefault('step', step)
 
         if file_path is not None:
@@ -542,7 +544,8 @@ class TensorboardVisBackend(BaseVisBackend):
             value (int, float, torch.Tensor, np.ndarray): Value to save.
             step (int): Global step value to record. Default to 0.
         """
-        if isinstance(value, (int, float, torch.Tensor, np.ndarray)):
+        if isinstance(value,
+                      (int, float, torch.Tensor, np.ndarray, np.number)):
             self._tensorboard.add_scalar(name, value, step)
         else:
             warnings.warn(f'Got {type(value)}, but numpy array, torch tensor, '

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -86,6 +86,7 @@ class TestLocalVisBackend:
         input_dict = {'map': 0.7, 'acc': 0.9}
         local_vis_backend = LocalVisBackend('temp_dir')
         local_vis_backend.add_scalars(input_dict)
+        assert input_dict == {'map': 0.7, 'acc': 0.9}
         out_dict = load(local_vis_backend._scalar_save_file, 'json')
         assert out_dict == {'map': 0.7, 'acc': 0.9, 'step': 0}
 
@@ -143,7 +144,19 @@ class TestTensorboardVisBackend:
         # test append mode
         tensorboard_vis_backend.add_scalar('map', 0.9, step=0)
         tensorboard_vis_backend.add_scalar('map', 0.95, step=1)
-
+        # test with numpy
+        with pytest.warns(None) as record:
+            tensorboard_vis_backend.add_scalar('map', np.array(0.9), step=0)
+            tensorboard_vis_backend.add_scalar('map', np.array(0.95), step=1)
+            tensorboard_vis_backend.add_scalar('map', np.array(9), step=0)
+            tensorboard_vis_backend.add_scalar('map', np.array(95), step=1)
+            tensorboard_vis_backend.add_scalar('map', np.array([9])[0], step=0)
+            tensorboard_vis_backend.add_scalar(
+                'map', np.array([95])[0], step=1)
+        assert len(record) == 0
+        # test with tensor
+        tensorboard_vis_backend.add_scalar('map', torch.tensor(0.9), step=0)
+        tensorboard_vis_backend.add_scalar('map', torch.tensor(0.95), step=1)
         # Unprocessable data will output a warning message
         with pytest.warns(Warning):
             tensorboard_vis_backend.add_scalar('map', [0.95])


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

- `LocalVisBackend.add_scalars` will change the modify the `scalar_dict`. If `LocalVisBackend` and `TensorboardVisBackend`
are both defined in config, `scalar_dict` will contain the key `step` after `LocalVisBackend`, and `TensorboardVisBackend` will raise an error.
https://github.com/open-mmlab/mmengine/blob/5b648c119fc0f8789b6cb285d00e8c7fe8cba2ba/mmengine/visualization/vis_backend.py#L294
- `TensorboardVisBackend` cannot log `np.int64` instance. 

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
