### PR TITLE
[Fix] Fix compatibility of persistent_workers.

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1382,6 +1382,13 @@ class Runner:
         else:
             init_fn = None
 
+        # `persistent_workers` requires pytorch version >= 1.7
+        if ('persistent_workers' in dataloader_cfg
+                and digit_version(TORCH_VERSION) < digit_version('1.7.0')):
+            warnings.warn('`persistent_workers` is only available when '
+                          'pytorch version >= 1.7')
+            dataloader_cfg.pop('persistent_workers')
+
         # The default behavior of `collat_fn` in dataloader is to
         # merge a list of samples to form a mini-batch of Tensor(s).
         # However, to make this more flexible, collate_fn in MMengine does


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`persistent_workers` is only available when PyTorch version >= 1.7, auto remove the `persistent_workers` argument.

## Modification

modify the `build_dataloader` in runner.py
