### PR TITLE
[Fix] Fix gpu tensors in results list are not on the same device.

### DIFF
--- a/mmengine/evaluator/metric.py
+++ b/mmengine/evaluator/metric.py
@@ -3,7 +3,6 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from typing import Any, List, Optional, Sequence, Union
 
-import torch
 from torch import Tensor
 
 from mmengine.data import BaseDataElement
@@ -107,10 +106,8 @@ class BaseMetric(metaclass=ABCMeta):
         results = collect_results(self.results, size, self.collect_device)
 
         if is_main_process():
-            # avoid gpu tensors in the results list have different device ids
-            if torch.cuda.is_available():
-                device_id = torch.cuda.current_device()
-                _align_gpu_tensor_device(results, device_id=device_id)
+            # cast all tensors in results list to cpu
+            results = _to_cpu(results)
             _metrics = self.compute_metrics(results)  # type: ignore
             # Add prefix to metric names
             if self.prefix:
@@ -173,22 +170,5 @@ def _to_cpu(data: Any) -> Any:
         return tuple(_to_cpu(d) for d in data)
     elif isinstance(data, dict):
         return {k: _to_cpu(v) for k, v in data.items()}
-    else:
-        return data
-
-
-def _align_gpu_tensor_device(data: Any, device_id: int) -> Any:
-    """transfer all gpu tensors on different devices to the target device."""
-    if isinstance(data, Tensor) and data.device.type == 'cuda':
-        return data.to(torch.device('cuda', device_id))
-    elif isinstance(data, list):
-        return [_align_gpu_tensor_device(d, device_id) for d in data]
-    elif isinstance(data, tuple):
-        return tuple(_align_gpu_tensor_device(d, device_id) for d in data)
-    elif isinstance(data, dict):
-        return {
-            k: _align_gpu_tensor_device(v, device_id)
-            for k, v in data.items()
-        }
     else:
         return data

--- a/tests/test_evaluator/test_metric.py
+++ b/tests/test_evaluator/test_metric.py
@@ -1,14 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import os.path as osp
 import tempfile
-import unittest
 from unittest import TestCase
 
 import torch
 from torch import Tensor
 
 from mmengine.evaluator import DumpResults
-from mmengine.evaluator.metric import _align_gpu_tensor_device
 from mmengine.fileio import load
 
 
@@ -41,19 +39,3 @@ class TestDumpResults(TestCase):
         self.assertEqual(results[0]['data'][0].device, torch.device('cpu'))
 
         temp_dir.cleanup()
-
-
-class TestAlignGpuTensorDevice(TestCase):
-
-    @unittest.skipUnless(torch.cuda.is_available(), 'must run with gpu')
-    def test_align_gpu_tensor_device(self):
-        data = [{
-            'input': (torch.zeros(
-                (1, 2), device='cuda'), torch.zeros((2, 1), device='cpu'))
-        } for _ in range(5)]
-        _align_gpu_tensor_device(data, device_id=0)
-        for d in data:
-            tenosr_gpu, tensor_cpu = d['input']
-            self.assertEqual(tenosr_gpu.device,
-                             torch.device(type='cuda', index=0))
-            self.assertEqual(tensor_cpu.device, torch.device('cpu'))


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

If users do not move tensors to CPU in `process`, the collected tensors will still be on their origin GPU device.

## Modification

Cast all tensor's device to CPU in rank0 in BaseMetirc's `evaluate` method.

