### PR TITLE
[Fix] Revise UT of OneCycle scheduler

### DIFF
--- a/tests/test_optim/test_scheduler/test_lr_scheduler.py
+++ b/tests/test_optim/test_scheduler/test_lr_scheduler.py
@@ -596,7 +596,7 @@ class TestLRScheduler(TestCase):
 
     def test_onecycle_lr(self):
         # test linear annealing
-        target = [1, 13, 25, 21.5, 18, 14.5, 11, 7.5, 4, 0.5]
+        target = [1., 13., 25., 21.5, 18., 14.5, 11., 7.5, 4., 0.5]
         scheduler = OneCycleLR(
             self.optimizer,
             eta_max=25,
@@ -605,7 +605,7 @@ class TestLRScheduler(TestCase):
             anneal_strategy='linear')
         self._test_scheduler_value(scheduler, [target], 10)
         # test linear annealing three phase
-        target = [1, 9, 17, 25, 17, 9, 1, 0.75, 0.5, 0.25]
+        target = [1., 9., 17., 25., 17., 9., 1., 0.75, 0.5, 0.25]
         scheduler = OneCycleLR(
             self.optimizer,
             eta_max=25,
@@ -623,7 +623,7 @@ class TestLRScheduler(TestCase):
             return end + (start - end) / 2.0 * cos_out
 
         target = [
-            1, 13, 25,
+            1., 13., 25.,
             annealing_cos(25, 0.5, 1 / 7.0),
             annealing_cos(25, 0.5, 2 / 7.0),
             annealing_cos(25, 0.5, 3 / 7.0),


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Current Pytorch with Python 3.10 cannot create integer tensor from floating point values, but might fix it in the next version. ref: https://github.com/pytorch/pytorch/pull/81372

To avoid `TypeError: 'float' object cannot be interpreted as an integer` with Python 3.10. this pr change data type of the target lr from integer to float in OneCycle ut.


related pr 

## Modification

1. tests/test_optim/test_scheduler/test_lr_scheduler.py
