### PR TITLE
[Fix] Fix `ImportError` when import `mmsegmentation.utils` in registry

### DIFF
--- a/mmengine/registry/registry.py
+++ b/mmengine/registry/registry.py
@@ -243,8 +243,7 @@ class Registry:
                 scope_name = default_scope.scope_name
                 if scope_name in PKG2PROJECT:
                     try:
-                        module = import_module(
-                            f'{PKG2PROJECT[scope_name]}.utils')
+                        module = import_module(f'{scope_name}.utils')
                         module.register_all_modules()  # type: ignore
                     except ImportError as e:
                         raise e


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix `ImportError` when import `mmsegmentation.utils` in registry.

Error format:
```python
import mmsegmentation.utils
```

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
