### PR TITLE
[Fix] Make logger compatible with python3.6

### DIFF
--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -237,15 +237,13 @@ class MMLogger(Logger, ManagerMixin):
         """
         # Compatible with python3.6. `logging.Logger` does not have
         # `_cache` attribute in python3.6.
+        self.level = logging._checkLevel(level)
         if hasattr(self, '_cache'):
-            self.level = logging._checkLevel(level)
             _accquire_lock()
             # The same logic as `logging.Manager._clear_cache`.
             for logger in MMLogger._instance_dict.values():
                 logger._cache.clear()
             _release_lock()
-        else:
-            self.level = logging._checkLevel(level)
 
 
 def print_log(msg,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`logging.Logger` does not have `_cache` attribute in python3.6

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
