### PR TITLE
[Fix] Avoid creating an instance with the same name

### DIFF
--- a/mmengine/registry/default_scope.py
+++ b/mmengine/registry/default_scope.py
@@ -86,6 +86,8 @@ class DefaultScope(ManagerMixin):
             yield
         else:
             tmp = copy.deepcopy(cls._instance_dict)
+            # To avoid create an instance with the same name.
+            time.sleep(1e-6)
             cls.get_instance(f'overwrite-{time.time()}', scope_name=scope_name)
             try:
                 yield

--- a/tests/test_registry/test_default_scope.py
+++ b/tests/test_registry/test_default_scope.py
@@ -33,3 +33,16 @@ class TestDefaultScope:
             ).scope_name == 'test_overwrite'
         assert DefaultScope.get_current_instance(
         ).scope_name == origin_scope.scope_name == 'origin_scope'
+
+        # Test overwrite default scope immediately.
+        # Test sequentially overwrite.
+        with DefaultScope.overwrite_default_scope(scope_name='test_overwrite'):
+            pass
+        with DefaultScope.overwrite_default_scope(scope_name='test_overwrite'):
+            pass
+
+        # Test nested overwrite.
+        with DefaultScope.overwrite_default_scope(scope_name='test_overwrite'):
+            with DefaultScope.overwrite_default_scope(
+                    scope_name='test_overwrite'):
+                pass


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`Registry.build` will call `overwrite_default_scope` multiple times nestedly, for example:

```python
# ResNet defined in mmrazor
class Archtecture(nn.Module):
    def __init__(self, cfg):
        # scope of student is mmrazor
        self.teacher = MODELS.build(cfg.student)
        # scope of teacher is mmcls
        self.student = MODELS.build(cfg.teacher)
```

When `Archtecture` is built, the MODELS will switch to `mmrazor` and `mmcls` immediately, which results in `overwrite_default_scope` building the `DefaultScope` instance with the same name if CPU has a very high performance(`time.time()` will not return a unique name). Here we simply `sleep(1e-6)` to avoid build   instance with the same name.

BTW, `time.time_ns` still cannot create a unique name with the powerful CPU.
## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
