### PR TITLE
[Fix] Exception while building registered function

### DIFF
--- a/mmengine/registry/build_functions.py
+++ b/mmengine/registry/build_functions.py
@@ -114,7 +114,8 @@ def build_from_cfg(
             # If `obj_cls` inherits from `ManagerMixin`, it should be
             # instantiated by `ManagerMixin.get_instance` to ensure that it
             # can be accessed globally.
-            if issubclass(obj_cls, ManagerMixin):  # type: ignore
+            if inspect.isclass(obj_cls) and \
+                    issubclass(obj_cls, ManagerMixin):  # type: ignore
                 obj = obj_cls.get_instance(**args)  # type: ignore
             else:
                 obj = obj_cls(**args)  # type: ignore

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -340,6 +340,13 @@ class TestRegistry:
         DOGS, HOUNDS, LITTLE_HOUNDS, MID_HOUNDS, SAMOYEDS = registries[:5]
 
         @DOGS.register_module()
+        def bark(times=1):
+            return ' '.join(['woof'] * times)
+
+        bark_cfg = cfg_type(dict(type='bark', times=3))
+        assert DOGS.build(bark_cfg) == 'woof woof woof'
+
+        @DOGS.register_module()
         class GoldenRetriever:
             pass
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Unexpected exception occurs while building a registered function from Registry. Example code as below

```python
from mmengine.registry import Registry

FUNCTION = Registry('function', scope='mmengine')

@FUNCTION.register_module()
def print_args(**kwargs):
    print(kwargs)

func_cfg = dict(type='print_args', a=1, b=2)
func_res = FUNCTION.build(func_cfg)
```

Error messages:

```
Traceback (most recent call last):
  File "registry_test_root.py", line 12, in <module>
    func_res = FUNCTION.build(func_cfg)
  File "/mmengine/mmengine/registry/registry.py", line 421, in build
    return self.build_func(cfg, *args, **kwargs, registry=self)
  File "/mmengine/mmengine/registry/build_functions.py", line 135, in build_from_cfg
    f'class `{obj_cls.__name__}` in '  # type: ignore
TypeError: class `print_args` in __main__.py: issubclass() arg 1 must be a class
```

## Modification

1. Check if `obj_cls` is a Class before `issubclass` function call.
2. Add unit test case in `test_registry.py`.

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
5. The documentation has been modified accordingly, like docstring or example tutorials.
