### PR TITLE
[bugfix] EMAHook load state dict

### DIFF
--- a/mmengine/hooks/ema_hook.py
+++ b/mmengine/hooks/ema_hook.py
@@ -176,9 +176,10 @@ class EMAHook(Hook):
             # The original model parameters are actually saved in ema
             # field swap the weights back to resume ema state.
             self._swap_ema_state_dict(checkpoint)
-            load_state_dict(self.ema_model.module,
-                            checkpoint['ema_state_dict'],
-                            strict=self.strict_load)
+            load_state_dict(
+                self.ema_model.module,
+                checkpoint['ema_state_dict'],
+                strict=self.strict_load)
 
         # Support load checkpoint without ema state dict.
         else:
@@ -186,9 +187,10 @@ class EMAHook(Hook):
                 'There is no `ema_state_dict` in checkpoint. '
                 '`EMAHook` will make a copy of `state_dict` as the '
                 'initial `ema_state_dict`', 'current', logging.WARNING)
-            load_state_dict(self.ema_model.module,
-                            copy.deepcopy(checkpoint['state_dict']),
-                            strict=self.strict_load)
+            load_state_dict(
+                self.ema_model.module,
+                copy.deepcopy(checkpoint['state_dict']),
+                strict=self.strict_load)
 
     def _swap_ema_parameters(self) -> None:
         """Swap the parameter of model with ema_model."""

--- a/mmengine/hooks/ema_hook.py
+++ b/mmengine/hooks/ema_hook.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional
 from mmengine.logging import print_log
 from mmengine.model import is_model_wrapper
 from mmengine.registry import HOOKS, MODELS
+from mmengine.runner import load_state_dict
 from .hook import DATA_BATCH, Hook
 
 
@@ -175,8 +176,9 @@ class EMAHook(Hook):
             # The original model parameters are actually saved in ema
             # field swap the weights back to resume ema state.
             self._swap_ema_state_dict(checkpoint)
-            self.ema_model.load_state_dict(
-                checkpoint['ema_state_dict'], strict=self.strict_load)
+            load_state_dict(self.ema_model.module,
+                            checkpoint['ema_state_dict'],
+                            strict=self.strict_load)
 
         # Support load checkpoint without ema state dict.
         else:
@@ -184,9 +186,9 @@ class EMAHook(Hook):
                 'There is no `ema_state_dict` in checkpoint. '
                 '`EMAHook` will make a copy of `state_dict` as the '
                 'initial `ema_state_dict`', 'current', logging.WARNING)
-            self.ema_model.module.load_state_dict(
-                copy.deepcopy(checkpoint['state_dict']),
-                strict=self.strict_load)
+            load_state_dict(self.ema_model.module,
+                            copy.deepcopy(checkpoint['state_dict']),
+                            strict=self.strict_load)
 
     def _swap_ema_parameters(self) -> None:
         """Swap the parameter of model with ema_model."""

--- a/mmengine/hooks/ema_hook.py
+++ b/mmengine/hooks/ema_hook.py
@@ -33,13 +33,6 @@ class EMAHook(Hook):
             Defaults to 0.
         begin_epoch (int): The number of epoch to enable ``EMAHook``. Defaults
             to 0.
-        revise_keys (list): A list of customized keywords to modify the
-                state_dict in checkpoint. Each item is a (pattern, replacement)
-                pair of the regular expression operations. Default: strip
-                the prefix 'module.' by [(r'^module\\.', '')].
-        resume (bool): Whether to resume ema model. If ``resume`` is True and
-            ``ema_state_dict`` is not found in checkpoint, resuming does
-            nothing. Defaults to True.
         **kwargs: Keyword arguments passed to subclasses of
             :obj:`BaseAveragedModel`
     """
@@ -51,8 +44,6 @@ class EMAHook(Hook):
                  strict_load: bool = True,
                  begin_iter: int = 0,
                  begin_epoch: int = 0,
-                 revise_keys: list = [(r'^module.', '')],
-                 resume: bool = True,
                  **kwargs):
         self.strict_load = strict_load
         self.ema_cfg = dict(type=ema_type, **kwargs)
@@ -67,9 +58,6 @@ class EMAHook(Hook):
         # If `begin_epoch` and `begin_iter` are not set, `EMAHook` will be
         # enabled at 0 iteration.
         self.enabled_by_epoch = self.begin_epoch > 0
-
-        self.revise_keys = revise_keys
-        self.resume = resume
 
     def before_run(self, runner) -> None:
         """Create an ema copy of the model.
@@ -184,7 +172,7 @@ class EMAHook(Hook):
         Args:
             runner (Runner): The runner of the testing process.
         """
-        if 'ema_state_dict' in checkpoint and self.resume:
+        if 'ema_state_dict' in checkpoint and runner._resume:
             # The original model parameters are actually saved in ema
             # field swap the weights back to resume ema state.
             self._swap_ema_state_dict(checkpoint)
@@ -193,7 +181,7 @@ class EMAHook(Hook):
 
         # Support load checkpoint without ema state dict.
         else:
-            if self.resume:
+            if runner._resume:
                 print_log(
                     'There is no `ema_state_dict` in checkpoint. '
                     '`EMAHook` will make a copy of `state_dict` as the '
@@ -201,8 +189,7 @@ class EMAHook(Hook):
             _load_checkpoint_to_model(
                 self.ema_model.module,
                 copy.deepcopy(checkpoint['state_dict']),
-                strict=self.strict_load,
-                revise_keys=self.revise_keys)
+                strict=self.strict_load)
 
     def _swap_ema_parameters(self) -> None:
         """Swap the parameter of model with ema_model."""

--- a/tests/test_hooks/test_ema_hook.py
+++ b/tests/test_hooks/test_ema_hook.py
@@ -56,6 +56,16 @@ class ToyModel2(BaseModel, ToyModel):
         return super(BaseModel, self).forward(*args, **kwargs)
 
 
+class ToyModel3(BaseModel, ToyModel):
+
+    def __init__(self):
+        super().__init__()
+        self.linear1 = nn.Linear(2, 2)
+
+    def forward(self, *args, **kwargs):
+        return super(BaseModel, self).forward(*args, **kwargs)
+
+
 @DATASETS.register_module()
 class DummyDataset(Dataset):
     METAINFO = dict()  # type: ignore
@@ -189,6 +199,25 @@ class TestEMAHook(TestCase):
         # Test load checkpoint without ema_state_dict
         runner = Runner(
             model=ToyModel2(),
+            test_dataloader=dict(
+                dataset=dict(type='DummyDataset'),
+                sampler=dict(type='DefaultSampler', shuffle=True),
+                batch_size=3,
+                num_workers=0),
+            test_evaluator=evaluator,
+            test_cfg=dict(),
+            work_dir=self.temp_dir.name,
+            load_from=osp.join(self.temp_dir.name, 'epoch_2.pth'),
+            default_hooks=dict(logger=None),
+            custom_hooks=[dict(type='EMAHook', strict_load=False)],
+            experiment_name='test5')
+        runner.test()
+
+        # Test does not load ckpt strict_loadly.
+        # Test load checkpoint without ema_state_dict
+        # Test with different size head.
+        runner = Runner(
+            model=ToyModel3(),
             test_dataloader=dict(
                 dataset=dict(type='DummyDataset'),
                 sampler=dict(type='DefaultSampler', shuffle=True),


### PR DESCRIPTION
## Motivation

When using yolox, it raised an error because of fixed num_classes in head.

```
  File "/opt/site-packages/mmdet/.mim/tools/train.py", line 120, in <module>
    main()
  File "/opt/site-packages/mmdet/.mim/tools/train.py", line 116, in main
    runner.train()
  File "/opt/conda/lib/python3.8/site-packages/mmengine/runner/runner.py", line 1623, in train
    self.load_or_resume()
  File "/opt/conda/lib/python3.8/site-packages/mmengine/runner/runner.py", line 1585, in load_or_resume
    self.load_checkpoint(self._load_from)
  File "/opt/conda/lib/python3.8/site-packages/mmengine/runner/runner.py", line 1977, in load_checkpoint
    self.call_hook('after_load_checkpoint', checkpoint=checkpoint)
  File "/opt/conda/lib/python3.8/site-packages/mmengine/runner/runner.py", line 1693, in call_hook
    getattr(hook, fn_name)(self, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/mmengine/hooks/ema_hook.py", line 187, in after_load_checkpoint
    self.ema_model.module.load_state_dict(
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1605, in load_state_dict
    raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for YOLOX:
        size mismatch for bbox_head.multi_level_conv_cls.0.weight: copying a param with shape torch.Size([80, 128, 1, 1]) from checkpoint, the shape in current model is torch.Size([3, 128, 1, 1]).
        size mismatch for bbox_head.multi_level_conv_cls.0.bias: copying a param with shape torch.Size([80]) from checkpoint, the shape in current model is torch.Size([3]).
        size mismatch for bbox_head.multi_level_conv_cls.1.weight: copying a param with shape torch.Size([80, 128, 1, 1]) from checkpoint, the shape in current model is torch.Size([3, 128, 1, 1]).
        size mismatch for bbox_head.multi_level_conv_cls.1.bias: copying a param with shape torch.Size([80]) from checkpoint, the shape in current model is torch.Size([3]).
        size mismatch for bbox_head.multi_level_conv_cls.2.weight: copying a param with shape torch.Size([80, 128, 1, 1]) from checkpoint, the shape in current model is torch.Size([3, 128, 1, 1]).
        size mismatch for bbox_head.multi_level_conv_cls.2.bias: copying a param with shape torch.Size([80]) from checkpoint, the shape in current model is torch.Size([3]).
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
