### PR TITLE
[Enhancement] wandb define_metric

### DIFF
--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -342,7 +342,9 @@ class WandbVisBackend(BaseVisBackend):
             input parameters. Default to None.
         define_metric_cfg (dict, optional):
             A dict of metrics and summary for wandb.define_metric.
-            Example. {'coco/bbox_mAP': 'max'}
+            The key is metric and the value is summary.
+            When ``define_metric_cfg={'coco/bbox_mAP': 'max'}``,
+            The maximum value of``coco/bbox_mAP`` is logged on wandb UI.
             Default: None
         commit: (bool, optional) Save the metrics dict to the wandb server
                 and increment the step.  If false `wandb.log` just

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -345,6 +345,9 @@ class WandbVisBackend(BaseVisBackend):
             The key is metric and the value is summary.
             When ``define_metric_cfg={'coco/bbox_mAP': 'max'}``,
             The maximum value of``coco/bbox_mAP`` is logged on wandb UI.
+            See
+            `wandb docs <https://docs.wandb.ai/ref/python/run#define_metric>`_
+            for details.
             Default: None
         commit: (bool, optional) Save the metrics dict to the wandb server
                 and increment the step.  If false `wandb.log` just

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -340,6 +340,10 @@ class WandbVisBackend(BaseVisBackend):
             produced by the visualizer.
         init_kwargs (dict, optional): wandb initialization
             input parameters. Default to None.
+        define_metric_cfg (dict, optional):
+            A dict of metrics and summary for wandb.define_metric.
+            Example. {'coco/bbox_mAP': 'max'}
+            Default: None
         commit: (bool, optional) Save the metrics dict to the wandb server
                 and increment the step.  If false `wandb.log` just
                 updates the current metrics dict with the row argument
@@ -350,9 +354,11 @@ class WandbVisBackend(BaseVisBackend):
     def __init__(self,
                  save_dir: str,
                  init_kwargs: Optional[dict] = None,
+                 define_metric_cfg: Optional[dict] = None,
                  commit: Optional[bool] = True):
         super().__init__(save_dir)
         self._init_kwargs = init_kwargs
+        self._define_metric_cfg = define_metric_cfg
         self._commit = commit
 
     def _init_env(self):
@@ -370,6 +376,9 @@ class WandbVisBackend(BaseVisBackend):
                 'Please run "pip install wandb" to install wandb')
 
         wandb.init(**self._init_kwargs)
+        if self._define_metric_cfg is not None:
+            for metric, summary in self._define_metric_cfg.items():
+                wandb.define_metric(metric, summary=summary)
         self._wandb = wandb
 
     @property  # type: ignore


### PR DESCRIPTION
## Motivation

Related to https://github.com/open-mmlab/mmcv/pull/2237

## Use cases (Optional)

```
vis_backends = [
    dict(type='LocalVisBackend'),
    dict(
        type='WandbVisBackend',
        init_kwargs=dict(
            project='project', name='expname'),
        define_metric_cfg={'coco/bbox_mAP': 'max'})
]
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
