### PR TITLE
[Fix] fix loss smooth when loss name doesn't start with `loss`

### DIFF
--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -265,7 +265,7 @@ class LogProcessor:
                 mode_history_scalars[key] = log_buffer
         for key in mode_history_scalars:
             # Update the latest learning rate and smoothed time logs.
-            if ('loss' in key) or key in ('time', 'data_time', 'grad_norm'):
+            if 'loss' in key or key in ('time', 'data_time', 'grad_norm'):
                 tag[key] = mode_history_scalars[key].mean(self.window_size)
             else:
                 # Default statistic method is current.

--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -152,7 +152,7 @@ class LogProcessor:
                 log_str = (f'Iter({mode}) '
                            f'[{cur_iter}/{runner.max_iters}]  ')
             else:
-                log_str = (f'Iter({mode}) [{batch_idx+1}'
+                log_str = (f'Iter({mode}) [{batch_idx + 1}'
                            f'/{len(current_loop.dataloader)}]  ')
         # Concatenate lr, momentum string with log header.
         log_str += f'{lr_str}  '
@@ -265,8 +265,7 @@ class LogProcessor:
                 mode_history_scalars[key] = log_buffer
         for key in mode_history_scalars:
             # Update the latest learning rate and smoothed time logs.
-            if key.startswith('loss') or key in ('time', 'data_time',
-                                                 'grad_norm'):
+            if ('loss' in key) or key in ('time', 'data_time', 'grad_norm'):
                 tag[key] = mode_history_scalars[key].mean(self.window_size)
             else:
                 # Default statistic method is current.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

fix loss smooth when loss name doesn't start with `loss`, such as `Cascade RCNN` in mmdet and `RefineSingleStageDetector` in mmrotate. 

For example, loss may have prefix 's0.loss_xxx'.

cascade rcnn loss before:
```
09/19 11:31:38 - mmengine - INFO - Epoch(train) [1][500/6400]  lr: 2.5000e-03  eta: 6:32:10  time: 0.3258  data_time: 0.0035  memory: 4946  grad_norm: 6.8527  loss_rpn_cls: 0.1451  loss_rpn_bbox: 0.0861  s0.loss_cls: 0.2497  s0.acc: 94.9219  s0.loss_bbox: 0.0781  s1.loss_cls: 0.1206  s1.acc: 95.5078  s1.loss_bbox: 0.0738  s2.loss_cls: 0.0415  s2.acc: 97.5586  s2.loss_bbox: 0.0226  loss: 1.2572
```
total loss sum = 0.8175, total loss in log = 1.2572

after:
```
09/19 11:25:44 - mmengine - INFO - Epoch(train) [1][500/6400]  lr: 2.5000e-03  eta: 6:28:44  time: 0.3342  data_time: 0.0035  memory: 4042  grad_norm: 6.7206  loss_rpn_cls: 0.1482  loss_rpn_bbox: 0.0601  s0.loss_cls: 0.3946  s0.acc: 89.4531  s0.loss_bbox: 0.1871  s1.loss_cls: 0.1690  s1.acc: 92.3828  s1.loss_bbox: 0.1161  s2.loss_cls: 0.0619  s2.acc: 96.5820  s2.loss_bbox: 0.0268  loss: 1.1638
```
total loss sum = 1.1638, total loss in log = 1.1638

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
