### PR TITLE
[Fix] `_save_to_state_dict`

### DIFF
--- a/mmengine/runner/checkpoint.py
+++ b/mmengine/runner/checkpoint.py
@@ -610,8 +610,7 @@ def _save_to_state_dict(module, destination, prefix, keep_vars):
         if param is not None:
             destination[prefix + name] = param if keep_vars else param.detach()
     for name, buf in module._buffers.items():
-        # remove check of _non_persistent_buffers_set to allow nn.BatchNorm2d
-        if buf is not None:
+        if buf is not None and name not in module._non_persistent_buffers_set:
             destination[prefix + name] = buf if keep_vars else buf.detach()
 
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In OpenMMLab 1.0, mmcv should be compatible with Pytorch1.5. Since `nn.Module` of Pytorch1.5  does not have `_non_persistent_buffers_set` attribute, therefore `_save_to_state_dict` will save registered buffer regardless of whether `persistent=True` or `persistent=False`.  

Pytorch 1.6:

```python
    def _save_to_state_dict(self, destination, prefix, keep_vars):
        for name, param in self._parameters.items():
            if param is not None:
                destination[prefix + name] = param if keep_vars else param.detach()
        for name, buf in self._buffers.items():
            if buf is not None and name not in self._non_persistent_buffers_set:
                destination[prefix + name] = buf if keep_vars else buf.detach()
       ...
```

MMCV :

```python
    def _save_to_state_dict(module, destination, prefix, keep_vars):
        for name, param in module._parameters.items():
            if param is not None:
                destination[prefix + name] = param if keep_vars else param.detach()
        for name, buf in module._buffers.items():
            if buf is not None:  # Does not check `_non_persistent_buffers_set` for compatible with pytorch1.5
                destination[prefix + name] = buf if keep_vars else buf.detach()
```

This leads to the runner saving unexpected buffers like `data_preprocessor.std` and `data_preprocessor.mean`. 

Since the lowest supported PyTorch version of MMEngine is Pytorch1.6, we should consistent with the PyTorch implementation

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
