### PR TITLE
[Fix] Use `get` instead of `pop` to dump `runner_type`

### DIFF
--- a/mmengine/registry/build_functions.py
+++ b/mmengine/registry/build_functions.py
@@ -176,7 +176,7 @@ def build_runner_from_cfg(cfg: Union[dict, ConfigDict, Config],
     # temporarily.
     scope = args.pop('_scope_', None)
     with registry.switch_scope_and_registry(scope) as registry:
-        obj_type = args.pop('runner_type', 'mmengine.Runner')
+        obj_type = args.get('runner_type', 'mmengine.Runner')
         if isinstance(obj_type, str):
             runner_cls = registry.get(obj_type)
             if runner_cls is None:


### PR DESCRIPTION
## Motivation
When using a custom runner, `runner_type` is not dumped appropriately, since `build_runner_from_cfg` function **pops** the `runner_type`.
To reproduce the experiment, it seems better to dump `runner_type` too.
https://github.com/open-mmlab/mmengine/blob/8d14eb65465785f8ec45bd8125a39c918f601b1f/mmengine/registry/build_functions.py#L179
