### PR TITLE
[Feature] Support torch ZeroRedundancyOptimizer

### DIFF
--- a/docs/en/api/optim.rst
+++ b/docs/en/api/optim.rst
@@ -23,6 +23,7 @@ Optimizer
     OptimWrapper
     OptimWrapperDict
     DefaultOptimWrapperConstructor
+    ZeroRedundancyOptimizer
 
 .. autosummary::
    :toctree: generated

--- a/docs/zh_cn/api/optim.rst
+++ b/docs/zh_cn/api/optim.rst
@@ -23,6 +23,7 @@ Optimizer
     OptimWrapper
     OptimWrapperDict
     DefaultOptimWrapperConstructor
+    ZeroRedundancyOptimizer
 
 .. autosummary::
    :toctree: generated

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -6,7 +6,6 @@ from math import inf
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Union
 
-from mmengine.dist import master_only
 from mmengine.fileio import FileClient, get_file_backend
 from mmengine.registry import HOOKS
 from mmengine.utils import is_list_of, is_seq_of
@@ -309,7 +308,6 @@ class CheckpointHook(Hook):
 
         return eval_res[key_indicator]
 
-    @master_only
     def _save_checkpoint(self, runner) -> None:
         """Save the current checkpoint and delete outdated checkpoint.
 
@@ -357,7 +355,6 @@ class CheckpointHook(Hook):
         with open(save_file, 'w') as f:
             f.write(filepath)
 
-    @master_only
     def _save_best_checkpoint(self, runner, metrics) -> None:
         """Save the current checkpoint and delete outdated checkpoint.
 

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -6,6 +6,7 @@ from math import inf
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Union
 
+from mmengine.dist import is_main_process
 from mmengine.fileio import FileClient, get_file_backend
 from mmengine.registry import HOOKS
 from mmengine.utils import is_list_of, is_seq_of
@@ -328,6 +329,11 @@ class CheckpointHook(Hook):
             by_epoch=self.by_epoch,
             backend_args=self.backend_args,
             **self.args)
+
+        # Model parallel-like training should involve pulling sharded states
+        # from all ranks, but skip the following procedure.
+        if not is_main_process():
+            return
 
         runner.message_hub.update_info(
             'last_ckpt',

--- a/mmengine/optim/optimizer/__init__.py
+++ b/mmengine/optim/optimizer/__init__.py
@@ -5,9 +5,10 @@ from .builder import (OPTIM_WRAPPER_CONSTRUCTORS, OPTIMIZERS,
 from .default_constructor import DefaultOptimWrapperConstructor
 from .optimizer_wrapper import OptimWrapper
 from .optimizer_wrapper_dict import OptimWrapperDict
+from .zero_optimizer import ZeroRedundancyOptimizer
 
 __all__ = [
     'OPTIM_WRAPPER_CONSTRUCTORS', 'OPTIMIZERS',
     'DefaultOptimWrapperConstructor', 'build_optim_wrapper', 'OptimWrapper',
-    'AmpOptimWrapper', 'OptimWrapperDict'
+    'AmpOptimWrapper', 'OptimWrapperDict', 'ZeroRedundancyOptimizer'
 ]

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -57,8 +57,7 @@ class ZeroRedundancyOptimizer(_ZeroRedundancyOptimizer):
         # TODO: Register a DDP communication hook for `overlap_with_ddp=True`.
         # Currently only `overlap_with_ddp=False` is supported. For more
         # details, please refer to the pytorch's official documentation.
-        super().__init__(
-            params, optimizer_class, overlap_with_ddp=False, **kwargs)
+        super().__init__(params, optimizer_class, **kwargs)
 
     def state_dict(self):
         """Consolidate `state_dict`s from ranks to save the `state_dict`."""

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -24,12 +24,12 @@ class ZeroRedundancyOptimizer(_ZeroRedundancyOptimizer):
     This class wraps an arbitrary :class:`torch.optim.Optimizer` and shards its
     states across ranks in the group as described by ZeRO_. The local optimizer
     instance in each rank is only responsible for updating approximately
-    ``1 / world_size`` parameters and hence only needs to keep ``1 / world_size``
-    optimizer states. After parameters are updated locally, each rank will
-    broadcast its parameters to all other peers to keep all model replicas
-    in the same state. ``ZeroRedundancyOptimizer`` can be used in conjunction
-    with :class:`torch.nn.parallel.DistributedDataParallel` to reduce per-rank peak
-    memory consumption.
+    ``1 / world_size`` parameters and hence only needs to keep
+    ``1 / world_size`` optimizer states. After parameters are updated locally,
+    each rank will broadcast its parameters to all other peers to keep all
+    model replicas in the same state. ``ZeroRedundancyOptimizer`` can be used
+    in conjunction with :class:`torch.nn.parallel.DistributedDataParallel` to
+    reduce per-rank peak memory consumption.
 
     ``ZeroRedundancyOptimizer`` uses a sorted-greedy algorithm to pack a number
     of parameters at each rank. Each parameter belongs to a single rank and is

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -19,29 +19,33 @@ from .builder import OPTIMIZERS
 @OPTIMIZERS.register_module()
 class ZeroRedundancyOptimizer(_ZeroRedundancyOptimizer):
     """A wrapper class of :class:`ZeroRedundancyOptimizer` that gets a
-    optimizer type as string. This class wraps an arbitrary
-    :class:`optim.Optimizer.
-
-    <torch.optim.Optimizer>` and shards its states across ranks in the group as
-    described by ZeRO_. The local optimizer instance in each rank is only
-    responsible for updating approximately ``1 / world_size`` parameters and
-    hence only needs to keep ``1 / world_size`` optimizer states. After
-    parameters are updated locally, each rank will broadcast its parameters to
-    all other peers to keep all model replicas in the same state.
-    ``ZeroRedundancyOptimizer`` can be used in conjunction with
-    :class:`torch.nn.parallel.DistributedDataParallel` to reduce per-rank peak
+    optimizer type as string. 
+    
+    This class wraps an arbitrary :class:`torch.optim.Optimizer` and shards its
+    states across ranks in the group as described by ZeRO_. The local optimizer
+    instance in each rank is only responsible for updating approximately
+    ``1 / world_size`` parameters and hence only needs to keep ``1 / world_size``
+    optimizer states. After parameters are updated locally, each rank will
+    broadcast its parameters to all other peers to keep all model replicas
+    in the same state. ``ZeroRedundancyOptimizer`` can be used in conjunction
+    with :class:`torch.nn.parallel.DistributedDataParallel` to reduce per-rank peak
     memory consumption.
+
     ``ZeroRedundancyOptimizer`` uses a sorted-greedy algorithm to pack a number
     of parameters at each rank. Each parameter belongs to a single rank and is
     not divided among ranks. The partition is arbitrary and might not match the
     the parameter registration or usage order.
+
     Warnings:
         ``ZeroRedundancyOptimizer`` requires PyTorch >= 1.8.
+
     Args:
         params (``Iterable``): an ``Iterable`` of :class:`torch.Tensor` s
             or :class:`dict` s giving all parameters, which will be sharded
             across ranks.
         optimizer_type (str): the string of the local optimizer class.
+        
+    .. _ZeRO: https://arxiv.org/abs/1910.02054
     """
 
     def __init__(self, params, optimizer_type: str, **kwargs):

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -59,5 +59,5 @@ class ZeroRedundancyOptimizer(_ZeroRedundancyOptimizer):
     def state_dict(self):
         """Consolidate `state_dict`s from ranks to save the `state_dict`."""
         self.consolidate_state_dict()
-        if is_main_process():
-            return super().state_dict()
+        state_dict = super().state_dict() if is_main_process() else dict()
+        return state_dict

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -11,7 +11,7 @@ try:
     from torch.distributed.optim import \
         ZeroRedundancyOptimizer as _ZeroRedundancyOptimizer
 except ImportError:
-    _ZeroReundancyOptimizer = object
+    _ZeroRedundancyOptimizer = object
 
 from .builder import OPTIMIZERS
 

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -9,7 +9,7 @@ from mmengine.utils.dl_utils import TORCH_VERSION
 
 try:
     from torch.distributed.optim import \
-        ZeroRedundancyOptimizer as _ZeroReundancyOptimizer
+        ZeroRedundancyOptimizer as _ZeroRedundancyOptimizer
 except ImportError:
     _ZeroReundancyOptimizer = object
 
@@ -17,7 +17,7 @@ from .builder import OPTIMIZERS
 
 
 @OPTIMIZERS.register_module()
-class ZeroRedundancyOptimizer(_ZeroReundancyOptimizer):
+class ZeroRedundancyOptimizer(_ZeroRedundancyOptimizer):
     """A wrapper class of :class:`ZeroRedundancyOptimizer` that gets a
     optimizer type as string. This class wraps an arbitrary
     :class:`optim.Optimizer.

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -5,12 +5,13 @@ import torch
 from mmengine.dist import is_main_process
 from mmengine.utils import digit_version
 from mmengine.utils.dl_utils import TORCH_VERSION
+import warnings
 
 try:
     from torch.distributed.optim import \
         ZeroRedundancyOptimizer as _ZeroReundancyOptimizer
 except ImportError as e:
-    print(e)
+    warnings.warn(e)
     _ZeroReundancyOptimizer = object
 
 from .builder import OPTIMIZERS

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -2,13 +2,15 @@
 
 import torch
 
+from mmengine.dist import is_main_process
 from mmengine.utils import digit_version
 from mmengine.utils.dl_utils import TORCH_VERSION
 
 try:
     from torch.distributed.optim import \
         ZeroRedundancyOptimizer as _ZeroReundancyOptimizer
-except ImportError:
+except ImportError as e:
+    print(e)
     _ZeroReundancyOptimizer = object
 
 from .builder import OPTIMIZERS
@@ -52,4 +54,5 @@ class ZeroRedundancyOptimizer(_ZeroReundancyOptimizer):
     def state_dict(self):
         """Consolidate `state_dict`s from ranks to save the `state_dict`"""
         self.consolidate_state_dict()
-        return super().state_dict()
+        if is_main_process():
+            return super().state_dict()

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -9,7 +9,7 @@ try:
     from torch.distributed.optim import \
         ZeroRedundancyOptimizer as _ZeroReundancyOptimizer
 except ImportError:
-    _ZeroReundancyOptimizer = None
+    _ZeroReundancyOptimizer = object
 
 from .builder import OPTIMIZERS
 

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -1,0 +1,48 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import torch
+from mmengine.utils import digit_version
+from mmengine.utils.dl_utils import TORCH_VERSION
+
+try:
+    from torch.distributed.optim import \
+        ZeroRedundancyOptimizer as _ZeroReundancyOptimizer
+except ImportError:
+    _ZeroReundancyOptimizer = None
+
+from .builder import OPTIMIZERS
+
+
+@OPTIMIZERS.register_module()
+class ZeroRedundancyOptimizer(_ZeroReundancyOptimizer):
+    """A wrapper class of :class:`ZeroRedundancyOptimizer` that gets a
+    optimizer type as string.
+    This class wraps an arbitrary :class:`optim.Optimizer
+    <torch.optim.Optimizer>` and shards its states across ranks in the group as
+    described by ZeRO_. The local optimizer instance in each rank is only
+    responsible for updating approximately ``1 / world_size`` parameters and
+    hence only needs to keep ``1 / world_size`` optimizer states. After
+    parameters are updated locally, each rank will broadcast its parameters to
+    all other peers to keep all model replicas in the same state.
+    ``ZeroRedundancyOptimizer`` can be used in conjunction with
+    :class:`torch.nn.parallel.DistributedDataParallel` to reduce per-rank peak
+    memory consumption.
+    ``ZeroRedundancyOptimizer`` uses a sorted-greedy algorithm to pack a number
+    of parameters at each rank. Each parameter belongs to a single rank and is
+    not divided among ranks. The partition is arbitrary and might not match the
+    the parameter registration or usage order.
+    Warnings:
+        ``ZeroRedundancyOptimizer`` requires PyTorch >= 1.8.
+    Args:
+        params (``Iterable``): an ``Iterable`` of :class:`torch.Tensor` s
+            or :class:`dict` s giving all parameters, which will be sharded
+            across ranks.
+        optimizer_type (str): the string of the local optimizer class.
+    """
+
+    def __init__(self, params, optimizer_type: str, **kwargs):
+        assert digit_version(TORCH_VERSION) >= digit_version('1.8.0'), (
+            '`torch.distributed.optim.ZeroReundancyOptimizer` is only '
+            'available when pytorch version >= 1.8')
+        optimizer_class = getattr(torch.optim, optimizer_type)
+        super().__init__(params, optimizer_class, **kwargs)

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
 import torch
+
 from mmengine.utils import digit_version
 from mmengine.utils.dl_utils import TORCH_VERSION
 
@@ -16,8 +17,9 @@ from .builder import OPTIMIZERS
 @OPTIMIZERS.register_module()
 class ZeroRedundancyOptimizer(_ZeroReundancyOptimizer):
     """A wrapper class of :class:`ZeroRedundancyOptimizer` that gets a
-    optimizer type as string.
-    This class wraps an arbitrary :class:`optim.Optimizer
+    optimizer type as string. This class wraps an arbitrary
+    :class:`optim.Optimizer.
+
     <torch.optim.Optimizer>` and shards its states across ranks in the group as
     described by ZeRO_. The local optimizer instance in each rank is only
     responsible for updating approximately ``1 / world_size`` parameters and

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -48,3 +48,8 @@ class ZeroRedundancyOptimizer(_ZeroReundancyOptimizer):
             'available when pytorch version >= 1.8')
         optimizer_class = getattr(torch.optim, optimizer_type)
         super().__init__(params, optimizer_class, **kwargs)
+
+    def state_dict(self):
+        """Consolidate `state_dict`s from ranks to save the `state_dict`"""
+        self.consolidate_state_dict()
+        return super().state_dict()

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -1,17 +1,16 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
 import torch
+from torch.distributed.rpc import is_available
 
 from mmengine.dist import is_main_process
 from mmengine.utils import digit_version
 from mmengine.utils.dl_utils import TORCH_VERSION
-import warnings
 
 try:
     from torch.distributed.optim import \
         ZeroRedundancyOptimizer as _ZeroReundancyOptimizer
-except ImportError as e:
-    warnings.warn(e)
+except ImportError:
     _ZeroReundancyOptimizer = object
 
 from .builder import OPTIMIZERS
@@ -49,6 +48,7 @@ class ZeroRedundancyOptimizer(_ZeroReundancyOptimizer):
         assert digit_version(TORCH_VERSION) >= digit_version('1.8.0'), (
             '`torch.distributed.optim.ZeroReundancyOptimizer` is only '
             'available when pytorch version >= 1.8')
+        assert is_available(), 'torch.distributed.rpc is not available'
         optimizer_class = getattr(torch.optim, optimizer_type)
         super().__init__(params, optimizer_class, **kwargs)
 

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -19,8 +19,8 @@ from .builder import OPTIMIZERS
 @OPTIMIZERS.register_module()
 class ZeroRedundancyOptimizer(_ZeroRedundancyOptimizer):
     """A wrapper class of :class:`ZeroRedundancyOptimizer` that gets a
-    optimizer type as string. 
-    
+    optimizer type as string.
+
     This class wraps an arbitrary :class:`torch.optim.Optimizer` and shards its
     states across ranks in the group as described by ZeRO_. The local optimizer
     instance in each rank is only responsible for updating approximately
@@ -44,7 +44,7 @@ class ZeroRedundancyOptimizer(_ZeroRedundancyOptimizer):
             or :class:`dict` s giving all parameters, which will be sharded
             across ranks.
         optimizer_type (str): the string of the local optimizer class.
-        
+
     .. _ZeRO: https://arxiv.org/abs/1910.02054
     """
 

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -47,13 +47,13 @@ class ZeroRedundancyOptimizer(_ZeroReundancyOptimizer):
     def __init__(self, params, optimizer_type: str, **kwargs):
         assert digit_version(TORCH_VERSION) >= digit_version('1.8.0'), (
             '`torch.distributed.optim.ZeroReundancyOptimizer` is only '
-            'available when pytorch version >= 1.8')
-        assert is_available(), 'torch.distributed.rpc is not available'
+            'available when pytorch version >= 1.8.')
+        assert is_available(), 'torch.distributed.rpc is not available.'
         optimizer_class = getattr(torch.optim, optimizer_type)
         super().__init__(params, optimizer_class, **kwargs)
 
     def state_dict(self):
-        """Consolidate `state_dict`s from ranks to save the `state_dict`"""
+        """Consolidate `state_dict`s from ranks to save the `state_dict`."""
         self.consolidate_state_dict()
         if is_main_process():
             return super().state_dict()

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -54,7 +54,11 @@ class ZeroRedundancyOptimizer(_ZeroRedundancyOptimizer):
             'available when pytorch version >= 1.8.')
         assert is_available(), 'torch.distributed.rpc is not available.'
         optimizer_class = getattr(torch.optim, optimizer_type)
-        super().__init__(params, optimizer_class, **kwargs)
+        # TODO: Register a DDP communication hook for `overlap_with_ddp=True`.
+        # Currently only `overlap_with_ddp=False` is supported. For more
+        # details, please refer to the pytorch's official documentation.
+        super().__init__(
+            params, optimizer_class, overlap_with_ddp=False, **kwargs)
 
     def state_dict(self):
         """Consolidate `state_dict`s from ranks to save the `state_dict`."""

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -22,8 +22,10 @@ if not MMCV_FULL_AVAILABLE:
     sys.modules['mmcv.ops'] = MagicMock(
         DeformConv2d=dict, ModulatedDeformConv2d=dict)
 
-if digit_version(TORCH_VERSION) >= digit_version('1.8.0'):
-    from mmengine.optim.optimizer import ZeroRedundancyOptimizer  # noqa: F401
+try:
+    from torch.distributed.optim import ZeroRedundancyOptimizer
+except ImportError:
+    ZeroRedundancyOptimizer = None
 
 
 class ExampleModel(nn.Module):
@@ -728,6 +730,9 @@ class TestBuilder(TestCase):
 class TestZeroOptimizer(MultiProcessTestCase):
 
     def setUp(self) -> None:
+        if ZeroRedundancyOptimizer is None:
+            self.skipTest('ZeroRedundancyOptimizer is not available.')
+
         super().setUp()
         self._spawn_processes()
 

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock
 import torch
 import torch.nn as nn
 
-from mmengine.model import MMDistributedDataParallel
 from mmengine.optim import (OPTIM_WRAPPER_CONSTRUCTORS, OPTIMIZERS,
                             DefaultOptimWrapperConstructor, OptimWrapper,
                             build_optim_wrapper)
@@ -760,7 +759,6 @@ class TestZeroOptimizer(MultiProcessTestCase):
     def test_build_zero_redundancy_optimizer(self):
         self._init_dist_env(self.rank, self.world_size)
         model = ExampleModel()
-        model = MMDistributedDataParallel(module=model)
         self.base_lr = 0.01
         self.momentum = 0.0001
         self.base_wd = 0.9
@@ -775,8 +773,17 @@ class TestZeroOptimizer(MultiProcessTestCase):
                 momentum=self.momentum))
         optim_wrapper = build_optim_wrapper(model, optim_wrapper_cfg)
         self.assertIsInstance(optim_wrapper.optimizer, ZeroRedundancyOptimizer)
-        self._check_default_optimizer(
-            optim_wrapper.optimizer, model, prefix='module.')
+        self._check_default_optimizer(optim_wrapper.optimizer, model)
+
+        # test build optimizer without ``optimizer_type``
+        with self.assertRaises(TypeError):
+            optim_wrapper_cfg = dict(
+                optimizer=dict(
+                    type='ZeroRedundancyOptimizer',
+                    lr=self.base_lr,
+                    weight_decay=self.base_wd,
+                    momentum=self.momentum))
+            optim_wrapper = build_optim_wrapper(model, optim_wrapper_cfg)
 
     def _init_dist_env(self, rank, world_size):
         """Initialize the distributed environment."""

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -721,7 +721,8 @@ class TestBuilder(TestCase):
 
 
 @unittest.skipIf(
-    (digit_version(TORCH_VERSION) < digit_version('1.8.0')) and is_available(),
+    (digit_version(TORCH_VERSION) < digit_version('1.8.0'))
+    or not is_available(),
     reason='ZeRO requires pytorch>=1.8 with torch.distributed.rpc available.')
 class TestZeroOptimizer(MultiProcessTestCase):
 

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock
 import torch
 import torch.nn as nn
 
-from mmengine.dist import is_main_process
 from mmengine.optim import (OPTIM_WRAPPER_CONSTRUCTORS, OPTIMIZERS,
                             DefaultOptimWrapperConstructor, OptimWrapper,
                             build_optim_wrapper)


### PR DESCRIPTION
- Device: V100 32GB (32510MiB) x4
- Input Size: 512
- Total Batch Size: 16

### upernet_r50_4xb4-80k_ade20k-512x512

|  Method  |      Time       |  Memory  |
| :------: | :-------------: | :------: |
| w/o zero | 0.611 | 7053|
| w/  zero | 0.552 | 6868 |

Time may be dependent to the environment.


Co-authored-by: Junhwa Song <ethan9867@gmail.com> @KKIEEK
Signed-off-by: Junhwa Song <ethan9867@gmail.com>
Signed-off-by: Hakjin Lee <nijkah@gmail.com>

- [x] Check reduced memory
- [x] Reproduce Performance
- [x] Check saving optimizer's state
- [x] Check loading optimizer's state
