### PR TITLE
[Fis] Set `_is_init` to True when `pretrained` is True

### DIFF
--- a/mmengine/hub/hub.py
+++ b/mmengine/hub/hub.py
@@ -80,4 +80,6 @@ def get_model(cfg_path: str, pretrained: bool = False, **kwargs):
         model = MODELS.build(cfg.model, default_args=kwargs)
         if pretrained:
             load_checkpoint(model, cfg.model_path)
+            # Hack to use pretrained weights
+            model._is_init = True
         return model

--- a/mmengine/hub/hub.py
+++ b/mmengine/hub/hub.py
@@ -80,6 +80,8 @@ def get_model(cfg_path: str, pretrained: bool = False, **kwargs):
         model = MODELS.build(cfg.model, default_args=kwargs)
         if pretrained:
             load_checkpoint(model, cfg.model_path)
-            # Hack to use pretrained weights
+            # Hack to use pretrained weights.
+            # If we do not set _is_init here, Runner will call
+            # `model.init_weights()` to overwrite the pretrained model.
             model._is_init = True
         return model


### PR DESCRIPTION
In mmengine/hub/hub.py, the attribute `_is_init` of the model is set to True after loading checkpoint when `pretrained` is set to True so that the pretrained weights will not be overwritten.