### PR TITLE
[Fix] Update metainfo check in ConcatDataset

### DIFF
--- a/mmengine/dataset/dataset_wrapper.py
+++ b/mmengine/dataset/dataset_wrapper.py
@@ -48,7 +48,7 @@ class ConcatDataset(_ConcatDataset):
         # Only use metainfo of first dataset.
         self._metainfo = self.datasets[0].metainfo
         for i, dataset in enumerate(self.datasets, 1):
-            if self._metainfo != dataset.metainfo:
+            if self._metainfo.get('CLASSES') != dataset.metainfo.get('CLASSES'):
                 raise ValueError(
                     f'The meta information of the {i}-th dataset does not '
                     'match meta information of the first dataset')


### PR DESCRIPTION
We changed the metainfo checking parts in concatdataset wrapper: from "`dataset._metainfo` must be equal" to "`dataset._metainfo['CLASSES']` must be equal".  
You see, when some one defined a dataset and set dataset._metainfo['PALETTE'] to random generation, in which case he can't concat two of this datasets just for they don't have a same 'PALETTE', we think it's really inconvenient.