### PR TITLE
Upgrade pre commit hooks

### DIFF
--- a/.pre-commit-config-zh-cn.yaml
+++ b/.pre-commit-config-zh-cn.yaml
@@ -1,7 +1,7 @@
 exclude: ^tests/data/
 repos:
   - repo: https://gitee.com/openmmlab/mirrors-flake8
-    rev: 3.8.3
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://gitee.com/openmmlab/mirrors-isort
@@ -9,11 +9,11 @@ repos:
     hooks:
       - id: isort
   - repo: https://gitee.com/openmmlab/mirrors-yapf
-    rev: v0.30.0
+    rev: v0.32.0
     hooks:
       - id: yapf
   - repo: https://gitee.com/openmmlab/mirrors-pre-commit-hooks
-    rev: v3.1.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
@@ -35,7 +35,7 @@ repos:
           - mdformat_frontmatter
           - linkify-it-py
   - repo: https://gitee.com/openmmlab/mirrors-codespell
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
       - id: codespell
   - repo: https://gitee.com/openmmlab/mirrors-docformatter
@@ -44,7 +44,7 @@ repos:
       - id: docformatter
         args: ["--in-place", "--wrap-descriptions", "79"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v3.0.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: ^tests/data/
 repos:
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.8.3
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/isort
@@ -9,11 +9,11 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.30.0
+    rev: v0.32.0
     hooks:
       - id: yapf
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
@@ -35,7 +35,7 @@ repos:
           - mdformat_frontmatter
           - linkify-it-py
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
       - id: codespell
   - repo: https://github.com/myint/docformatter
@@ -44,7 +44,7 @@ repos:
       - id: docformatter
         args: ["--in-place", "--wrap-descriptions", "79"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v3.0.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -199,7 +199,7 @@ class Config:
         # `temp_file` is opened first in `tempfile.NamedTemporaryFile` and
         #  second in `Config.from_file`.
         # In addition, a named temporary file will be removed after closed.
-        # As a workround we set `delete=False` and close the temporary file
+        # As a workaround we set `delete=False` and close the temporary file
         # before opening again.
 
         with tempfile.NamedTemporaryFile(

--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -109,7 +109,7 @@ class MMLogger(Logger, ManagerMixin):
           ``MMLogger.get_instance`` but not ``logging.getLogger``. This feature
           ensures ``MMLogger`` will not be incluenced by third-party logging
           config.
-        - Different from ``logging.Logger``, ``MMLogger`` will not log warrning
+        - Different from ``logging.Logger``, ``MMLogger`` will not log warning
           or error message without ``Handler``.
 
     Examples:

--- a/mmengine/optim/scheduler/param_scheduler.py
+++ b/mmengine/optim/scheduler/param_scheduler.py
@@ -563,9 +563,9 @@ class ExponentialParamScheduler(_ParamScheduler):
 
 @PARAM_SCHEDULERS.register_module()
 class CosineAnnealingParamScheduler(_ParamScheduler):
-    r"""Set the parameter value of each parameter group using a cosine annealing
-    schedule, where :math:`\eta_{max}` is set to the initial value and
-    :math:`T_{cur}` is the number of epochs since the last restart in SGDR:
+    r"""Set the parameter value of each parameter group using a cosine
+    annealing schedule, where :math:`\eta_{max}` is set to the initial value
+    and :math:`T_{cur}` is the number of epochs since the last restart in SGDR:
 
     .. math::
         \begin{aligned}

--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -129,7 +129,8 @@ class LogProcessor:
         for key, value in tag.items():
             if key.endswith('lr'):
                 log_tag.pop(key)
-                lr_str_list.append(f'{key}: ' f'{value:.{self.num_digits}e}')
+                lr_str_list.append(f'{key}: '
+                                   f'{value:.{self.num_digits}e}')
         lr_str = ' '.join(lr_str_list)
         # Format log header.
         # by_epoch == True

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,4 +13,4 @@ BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF = true
 SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = true
 
 [codespell]
-ignore-words-list = nd, ba
+ignore-words-list = nd, ba, warmup


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The motivation to upgrade some versions of pre-commit hooks to latest is that `importlib-metadata v5.0.0` which removed deprecated endpoint breaks the flake8. More details at https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean/73932581#73932581.

## Modification

Upgrade some versions of pre-commit hooks.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
