### PR TITLE
[FIx] Fix the total number of iterations in log is a float number.

### DIFF
--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -151,7 +151,7 @@ class LogProcessor:
         else:
             if mode == 'train':
                 log_str = (f'Iter({mode}) '
-                           f'[{cur_iter}/{int(runner.max_iters)}]  ')
+                           f'[{cur_iter}/{runner.max_iters}]  ')
             else:
                 log_str = (f'Iter({mode}) [{batch_idx + 1}'
                            f'/{len(current_loop.dataloader)}]  ')

--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -151,7 +151,7 @@ class LogProcessor:
         else:
             if mode == 'train':
                 log_str = (f'Iter({mode}) '
-                           f'[{cur_iter}/{runner.max_iters}]  ')
+                           f'[{cur_iter}/{int(runner.max_iters)}]  ')
             else:
                 log_str = (f'Iter({mode}) [{batch_idx + 1}'
                            f'/{len(current_loop.dataloader)}]  ')

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -41,8 +41,10 @@ class EpochBasedTrainLoop(BaseLoop):
             val_interval: int = 1,
             dynamic_intervals: Optional[List[Tuple[int, int]]] = None) -> None:
         super().__init__(runner, dataloader)
-        self._max_epochs = max_epochs
-        self._max_iters = max_epochs * len(self.dataloader)
+        self._max_epochs = int(max_epochs)
+        assert self._max_epochs == max_epochs, \
+            f'`max_epochs` should be a integer number, but get {max_epochs}.'
+        self._max_iters = self._max_epochs * len(self.dataloader)
         self._epoch = 0
         self._iter = 0
         self.val_begin = val_begin
@@ -206,7 +208,9 @@ class IterBasedTrainLoop(BaseLoop):
             val_interval: int = 1000,
             dynamic_intervals: Optional[List[Tuple[int, int]]] = None) -> None:
         super().__init__(runner, dataloader)
-        self._max_iters = max_iters
+        self._max_iters = int(max_iters)
+        assert self._max_iters == max_iters, \
+            f'`max_iters` should be a integer number, but get {max_iters}'
         self._max_epochs = 1  # for compatibility with EpochBasedTrainLoop
         self._epoch = 0
         self._iter = 0


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The log information of total iterations is float type when using `IterBasedTrainLoop`.

Related issue: #603 

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
