### PR TITLE
support set omp and mkl num threads in set_multi_processing func

### DIFF
--- a/mmengine/utils/dl_utils/setup_env.py
+++ b/mmengine/utils/dl_utils/setup_env.py
@@ -2,12 +2,15 @@
 import os
 import platform
 import warnings
+from typing import Optional
 
 import torch.multiprocessing as mp
 
 
 def set_multi_processing(mp_start_method: str = 'fork',
                          opencv_num_threads: int = 0,
+                         omp_num_threads: Optional[int] = None,
+                         mkl_num_threads: Optional[int] = None,
                          distributed: bool = False) -> None:
     """Set multi-processing related environment.
 
@@ -16,6 +19,10 @@ def set_multi_processing(mp_start_method: str = 'fork',
             child processes. Defaults to 'fork'.
         opencv_num_threads (int): Number of threads for opencv.
             Defaults to 0.
+        omp_num_threads (int, optional): Number of threads for OMP.
+            Defaults to 1 when distributed is True, otherwise no change.
+        mkl_num_threads (int, optional): Number of threads for MKL.
+            Defaults to 1 when distributed is True, otherwise no change.
         distributed (bool): True if distributed environment.
             Defaults to False.
     """
@@ -39,23 +46,26 @@ def set_multi_processing(mp_start_method: str = 'fork',
     except ImportError:
         pass
 
-    # setup OMP threads
-    # This code is referred from https://github.com/pytorch/pytorch/blob/master/torch/distributed/run.py  # noqa
-    if 'OMP_NUM_THREADS' not in os.environ and distributed:
-        omp_num_threads = 1
-        warnings.warn(
-            'Setting OMP_NUM_THREADS environment variable for each process'
-            f' to be {omp_num_threads} in default, to avoid your system '
-            'being overloaded, please further tune the variable for '
-            'optimal performance in your application as needed.')
-        os.environ['OMP_NUM_THREADS'] = str(omp_num_threads)
+    if distributed:
+        # setup OMP threads
+        # This code is referred from https://github.com/pytorch/pytorch/blob/master/torch/distributed/run.py  # noqa
+        if omp_num_threads is None and 'OMP_NUM_THREADS' not in os.environ:
+            omp_num_threads = 1
+            warnings.warn(
+                'Setting OMP_NUM_THREADS environment variable for each process'
+                f' to be {omp_num_threads} in default, to avoid your system '
+                'being overloaded, please further tune the variable for '
+                'optimal performance in your application as needed.')
+        if omp_num_threads is not None:
+            os.environ['OMP_NUM_THREADS'] = str(omp_num_threads)
 
-    # setup MKL threads
-    if 'MKL_NUM_THREADS' not in os.environ and distributed:
-        mkl_num_threads = 1
-        warnings.warn(
-            'Setting MKL_NUM_THREADS environment variable for each process'
-            f' to be {mkl_num_threads} in default, to avoid your system '
-            'being overloaded, please further tune the variable for '
-            'optimal performance in your application as needed.')
-        os.environ['MKL_NUM_THREADS'] = str(mkl_num_threads)
+        # setup MKL threads
+        if mkl_num_threads is None and 'MKL_NUM_THREADS' not in os.environ:
+            mkl_num_threads = 1
+            warnings.warn(
+                'Setting MKL_NUM_THREADS environment variable for each process'
+                f' to be {mkl_num_threads} in default, to avoid your system '
+                'being overloaded, please further tune the variable for '
+                'optimal performance in your application as needed.')
+        if mkl_num_threads is not None:
+            os.environ['MKL_NUM_THREADS'] = str(mkl_num_threads)

--- a/mmengine/utils/dl_utils/setup_env.py
+++ b/mmengine/utils/dl_utils/setup_env.py
@@ -46,26 +46,27 @@ def set_multi_processing(mp_start_method: str = 'fork',
     except ImportError:
         pass
 
-    if distributed:
-        # setup OMP threads
-        # This code is referred from https://github.com/pytorch/pytorch/blob/master/torch/distributed/run.py  # noqa
-        if omp_num_threads is None and 'OMP_NUM_THREADS' not in os.environ:
-            omp_num_threads = 1
+    # setup OMP threads
+    # This code is referred from https://github.com/pytorch/pytorch/blob/master/torch/distributed/run.py  # noqa
+    if omp_num_threads is None:
+        if 'OMP_NUM_THREADS' not in os.environ and distributed:
+            os.environ['OMP_NUM_THREADS'] = '1'
             warnings.warn(
                 'Setting OMP_NUM_THREADS environment variable for each process'
-                f' to be {omp_num_threads} in default, to avoid your system '
-                'being overloaded, please further tune the variable for '
-                'optimal performance in your application as needed.')
-        if omp_num_threads is not None:
-            os.environ['OMP_NUM_THREADS'] = str(omp_num_threads)
+                ' to be 1 in default, to avoid your system being overloaded, '
+                'please further tune the variable for optimal performance in '
+                'your application as needed.')
+    else:
+        os.environ['OMP_NUM_THREADS'] = str(omp_num_threads)
 
-        # setup MKL threads
-        if mkl_num_threads is None and 'MKL_NUM_THREADS' not in os.environ:
-            mkl_num_threads = 1
+    # setup MKL threads
+    if mkl_num_threads is None:
+        if 'MKL_NUM_THREADS' not in os.environ and distributed:
+            os.environ['MKL_NUM_THREADS'] = '1'
             warnings.warn(
                 'Setting MKL_NUM_THREADS environment variable for each process'
-                f' to be {mkl_num_threads} in default, to avoid your system '
-                'being overloaded, please further tune the variable for '
-                'optimal performance in your application as needed.')
-        if mkl_num_threads is not None:
-            os.environ['MKL_NUM_THREADS'] = str(mkl_num_threads)
+                ' to be 1 in default, to avoid your system being overloaded, '
+                'please further tune the variable for optimal performance in '
+                'your application as needed.')
+    else:
+        os.environ['MKL_NUM_THREADS'] = str(mkl_num_threads)

--- a/mmengine/utils/dl_utils/setup_env.py
+++ b/mmengine/utils/dl_utils/setup_env.py
@@ -9,9 +9,9 @@ import torch.multiprocessing as mp
 
 def set_multi_processing(mp_start_method: str = 'fork',
                          opencv_num_threads: int = 0,
+                         distributed: bool = False,
                          omp_num_threads: Optional[int] = None,
-                         mkl_num_threads: Optional[int] = None,
-                         distributed: bool = False) -> None:
+                         mkl_num_threads: Optional[int] = None) -> None:
     """Set multi-processing related environment.
 
     Args:
@@ -19,12 +19,12 @@ def set_multi_processing(mp_start_method: str = 'fork',
             child processes. Defaults to 'fork'.
         opencv_num_threads (int): Number of threads for opencv.
             Defaults to 0.
+        distributed (bool): True if distributed environment.
+            Defaults to False.
         omp_num_threads (int, optional): Number of threads for OMP.
             Defaults to 1 when distributed is True, otherwise no change.
         mkl_num_threads (int, optional): Number of threads for MKL.
             Defaults to 1 when distributed is True, otherwise no change.
-        distributed (bool): True if distributed environment.
-            Defaults to False.
     """
     # set multi-process start method as `fork` to speed up the training
     if platform.system() != 'Windows':

--- a/tests/test_utils/test_dl_utils/test_setup_env.py
+++ b/tests/test_utils/test_dl_utils/test_setup_env.py
@@ -39,10 +39,16 @@ def test_setup_multi_processes():
 
     # test manually set opencv threads and mp start method
     config = dict(
-        mp_start_method='spawn', opencv_num_threads=4, distributed=True)
+        mp_start_method='spawn',
+        opencv_num_threads=4,
+        omp_num_threads=5,
+        mkl_num_threads=6,
+        distributed=True)
     set_multi_processing(**config)
     assert cv2.getNumThreads() == 4
     assert mp.get_start_method() == 'spawn'
+    assert os.getenv('OMP_NUM_THREADS') == '5'
+    assert os.getenv('MKL_NUM_THREADS') == '6'
 
     # revert setting to avoid affecting other programs
     if sys_start_mehod:


### PR DESCRIPTION
## Motivation

Support set omp and mkl num threads in set_multi_processing func. Therefore, users can set them in mp_cfg.

## Modification

Add omp_num_threads and mkl_num_threads params to set_multi_processing func.

## Use cases (Optional)

Now, we can set omp and mkl num threads like:
```python
    mp_cfg = dict(
        mp_start_method='spawn',
        opencv_num_threads=4,
        omp_num_threads=5,
        mkl_num_threads=6,
        distributed=True)
```

## Checklist

3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
