### PR TITLE
add non_blocking feature to BaseDataPreprocessor

### DIFF
--- a/mmengine/model/base_model/data_preprocessor.py
+++ b/mmengine/model/base_model/data_preprocessor.py
@@ -25,6 +25,7 @@ class BaseDataPreprocessor(nn.Module):
     Args:
         non_blocking (bool): Whether block current process
             when transferring data to device.
+            New in version 0.3.0.
 
     Note:
         Data dictionary returned by dataloader must be a dict and at least

--- a/mmengine/model/base_model/data_preprocessor.py
+++ b/mmengine/model/base_model/data_preprocessor.py
@@ -24,7 +24,7 @@ class BaseDataPreprocessor(nn.Module):
 
     Args:
         non_blocking (bool): Whether block current process
-         when transfer tensor to device.
+            when transferring data to device.
 
     Note:
         Data dictionary returned by dataloader must be a dict and at least

--- a/mmengine/model/base_model/data_preprocessor.py
+++ b/mmengine/model/base_model/data_preprocessor.py
@@ -158,6 +158,7 @@ class ImgDataPreprocessor(BaseDataPreprocessor):
             Defaults to False.
         non_blocking (bool): Whether block current process
             when transferring data to device.
+            New in version v0.3.0.
 
     Note:
         if images do not need to be normalized, `std` and `mean` should be

--- a/mmengine/model/base_model/data_preprocessor.py
+++ b/mmengine/model/base_model/data_preprocessor.py
@@ -22,13 +22,18 @@ class BaseDataPreprocessor(nn.Module):
     forward method to implement custom data pre-processing, such as
     batch-resize, MixUp, or CutMix.
 
+    Args:
+        non_blocking (bool): Whether block current process
+         when transfer tensor to device.
+
     Note:
         Data dictionary returned by dataloader must be a dict and at least
         contain the ``inputs`` key.
     """
 
-    def __init__(self):
+    def __init__(self, non_blocking: Optional[bool] = False):
         super().__init__()
+        self._non_blocking = non_blocking
         self._device = torch.device('cpu')
 
     def cast_data(self, data: CastData) -> CastData:
@@ -48,9 +53,9 @@ class BaseDataPreprocessor(nn.Module):
         elif isinstance(data, Sequence):
             return [self.cast_data(sample) for sample in data]
         elif isinstance(data, torch.Tensor):
-            return data.to(self.device)
+            return data.to(self.device, non_blocking=self._non_blocking)
         elif isinstance(data, BaseDataElement):
-            return data.to(self.device)
+            return data.to(self.device, non_blocking=self._non_blocking)
         else:
             return data
 
@@ -158,13 +163,14 @@ class ImgDataPreprocessor(BaseDataPreprocessor):
     """
 
     def __init__(self,
+                 non_blocking: Optional[bool] = False,
                  mean: Optional[Sequence[Union[float, int]]] = None,
                  std: Optional[Sequence[Union[float, int]]] = None,
                  pad_size_divisor: int = 1,
                  pad_value: Union[float, int] = 0,
                  bgr_to_rgb: bool = False,
                  rgb_to_bgr: bool = False):
-        super().__init__()
+        super().__init__(non_blocking)
         assert not (bgr_to_rgb and rgb_to_bgr), (
             '`bgr2rgb` and `rgb2bgr` cannot be set to True at the same time')
         assert (mean is None) == (std is None), (

--- a/mmengine/model/base_model/data_preprocessor.py
+++ b/mmengine/model/base_model/data_preprocessor.py
@@ -155,6 +155,8 @@ class ImgDataPreprocessor(BaseDataPreprocessor):
             Defaults to False.
         rgb_to_bgr (bool): whether to convert image from RGB to RGB.
             Defaults to False.
+        non_blocking (bool): Whether block current process
+            when transferring data to device.
 
     Note:
         if images do not need to be normalized, `std` and `mean` should be
@@ -163,13 +165,13 @@ class ImgDataPreprocessor(BaseDataPreprocessor):
     """
 
     def __init__(self,
-                 non_blocking: Optional[bool] = False,
                  mean: Optional[Sequence[Union[float, int]]] = None,
                  std: Optional[Sequence[Union[float, int]]] = None,
                  pad_size_divisor: int = 1,
                  pad_value: Union[float, int] = 0,
                  bgr_to_rgb: bool = False,
-                 rgb_to_bgr: bool = False):
+                 rgb_to_bgr: bool = False,
+                 non_blocking: Optional[bool] = False):
         super().__init__(non_blocking)
         assert not (bgr_to_rgb and rgb_to_bgr), (
             '`bgr2rgb` and `rgb2bgr` cannot be set to True at the same time')

--- a/tests/test_model/test_base_model/test_data_preprocessor.py
+++ b/tests/test_model/test_base_model/test_data_preprocessor.py
@@ -14,6 +14,11 @@ class TestBaseDataPreprocessor(TestCase):
     def test_init(self):
         base_data_preprocessor = BaseDataPreprocessor()
         self.assertEqual(base_data_preprocessor._device.type, 'cpu')
+        self.assertEqual(base_data_preprocessor._non_blocking, False)
+
+        base_data_preprocessor = BaseDataPreprocessor(True)
+        self.assertEqual(base_data_preprocessor._device.type, 'cpu')
+        self.assertEqual(base_data_preprocessor._non_blocking, True)
 
     def test_forward(self):
         # Test cpu forward with list of data samples.


### PR DESCRIPTION
## Motivation

add non_blocking param to BaseDataPreprocessor, which transfer tensor to device asynchronously. See https://pytorch.org/docs/stable/generated/torch.Tensor.to.html#torch.Tensor.to for detail.

## Modification

add non_blocking param to BaseDataPreprocessor.

## BC-breaking (Optional)

Every DataPreprocessor should add non_blocking param.

## Use cases (Optional)

User can set pin_memory and non_blocking to True to transfer tensor from cpu to gpu asynchronously, instead of blocking the process when transfer data.

## Checklist

3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
