### PR TITLE
[Enhance] add param to customized Formatter

### DIFF
--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -136,11 +136,11 @@ class MMLogger(Logger, ManagerMixin):
             ``FileHandler`` will be added to the logger. Defaults to None.
         log_level (str): The log level of the handler and logger. Defaults to
             "NOTSET".
-        log_datefmt (str): The log date formatter. If `log_datefmt` is not
-            defined, defaults to '%m/%d %H:%M:%S'.
         file_mode (str): The file mode used to open log file. Defaults to 'w'.
         distributed (bool): Whether to save distributed logs, Defaults to
             false.
+        log_datefmt (str): The log date formatter. If `log_datefmt` is not
+            defined, defaults to '%m/%d %H:%M:%S'.
     """
 
     def __init__(self,
@@ -148,9 +148,9 @@ class MMLogger(Logger, ManagerMixin):
                  logger_name='mmengine',
                  log_file: Optional[str] = None,
                  log_level: str = 'INFO',
-                 log_datefmt: str = '%m/%d %H:%M:%S',
                  file_mode: str = 'w',
-                 distributed=False):
+                 distributed=False,
+                 log_datefmt: str = '%m/%d %H:%M:%S'):
         Logger.__init__(self, logger_name)
         ManagerMixin.__init__(self, name)
         # Get rank in DDP mode.

--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -136,6 +136,8 @@ class MMLogger(Logger, ManagerMixin):
             ``FileHandler`` will be added to the logger. Defaults to None.
         log_level (str): The log level of the handler and logger. Defaults to
             "NOTSET".
+        log_datefmt (str): The log date formatter. If `log_datefmt` is not
+            defined, defaults to '%m/%d %H:%M:%S'.
         file_mode (str): The file mode used to open log file. Defaults to 'w'.
         distributed (bool): Whether to save distributed logs, Defaults to
             false.
@@ -146,6 +148,7 @@ class MMLogger(Logger, ManagerMixin):
                  logger_name='mmengine',
                  log_file: Optional[str] = None,
                  log_level: str = 'INFO',
+                 log_datefmt: str = '%m/%d %H:%M:%S',
                  file_mode: str = 'w',
                  distributed=False):
         Logger.__init__(self, logger_name)
@@ -160,7 +163,7 @@ class MMLogger(Logger, ManagerMixin):
         # `StreamHandler` record month, day, hour, minute, and second
         # timestamp.
         stream_handler.setFormatter(
-            MMFormatter(color=True, datefmt='%m/%d %H:%M:%S'))
+            MMFormatter(color=True, datefmt=log_datefmt))
         # Only rank0 `StreamHandler` will log messages below error level.
         stream_handler.setLevel(log_level) if rank == 0 else \
             stream_handler.setLevel(logging.ERROR)

--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -139,7 +139,7 @@ class MMLogger(Logger, ManagerMixin):
         file_mode (str): The file mode used to open log file. Defaults to 'w'.
         distributed (bool): Whether to save distributed logs, Defaults to
             false.
-        log_datefmt (str): The log date formatter. If `log_datefmt` is not
+        datefmt (str): The log date formatter. If `datefmt` is not
             defined, defaults to '%m/%d %H:%M:%S'.
     """
 
@@ -150,7 +150,7 @@ class MMLogger(Logger, ManagerMixin):
                  log_level: str = 'INFO',
                  file_mode: str = 'w',
                  distributed=False,
-                 log_datefmt: str = '%m/%d %H:%M:%S'):
+                 datefmt: str = '%m/%d %H:%M:%S'):
         Logger.__init__(self, logger_name)
         ManagerMixin.__init__(self, name)
         # Get rank in DDP mode.
@@ -162,8 +162,7 @@ class MMLogger(Logger, ManagerMixin):
         stream_handler = logging.StreamHandler(stream=sys.stdout)
         # `StreamHandler` record month, day, hour, minute, and second
         # timestamp.
-        stream_handler.setFormatter(
-            MMFormatter(color=True, datefmt=log_datefmt))
+        stream_handler.setFormatter(MMFormatter(color=True, datefmt=datefmt))
         # Only rank0 `StreamHandler` will log messages below error level.
         stream_handler.setLevel(log_level) if rank == 0 else \
             stream_handler.setLevel(logging.ERROR)


### PR DESCRIPTION

## Motivation

If the output information is too long, the output information will occupy two lines, which seems to be very uncomfortable to user, so can we add a parameter to allow users to customize logging.Formatter

## Modification

 add param in `mmengine/logging/logger.py` for class `MMLogger`

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
