### PR TITLE
[Fix] Fix offline eval dataset index error.

### DIFF
--- a/mmengine/evaluator/evaluator.py
+++ b/mmengine/evaluator/evaluator.py
@@ -104,12 +104,6 @@ class Evaluator:
         """
 
         # support chunking iterable objects
-        if data is not None:
-            assert len(data_samples) == len(data), (
-                'outputs and data should have the same length, but got '
-                f'outputs length: {len(data_samples)} '
-                f'data length: {len(data)}')
-
         def get_chunks(seq: Iterator, chunk_size=1):
             stop = False
             while not stop:
@@ -123,10 +117,17 @@ class Evaluator:
                 if chunk:
                     yield chunk
 
+        if data is not None:
+            assert len(data_samples) == len(data), (
+                'outputs and data should have the same length, but got '
+                f'outputs length: {len(data_samples)} '
+                f'data length: {len(data)}')
+            data = get_chunks(iter(data), chunk_size)
+
         size = 0
         for output_chunk in get_chunks(iter(data_samples), chunk_size):
             if data is not None:
-                data_chunk = pseudo_collate(data[size:size + chunk_size])
+                data_chunk = pseudo_collate(next(data))  # type: ignore
             else:
                 data_chunk = None
             size += len(output_chunk)

--- a/mmengine/evaluator/evaluator.py
+++ b/mmengine/evaluator/evaluator.py
@@ -119,8 +119,8 @@ class Evaluator:
 
         if data is not None:
             assert len(data_samples) == len(data), (
-                'outputs and data should have the same length, but got '
-                f'outputs length: {len(data_samples)} '
+                'data_samples and data should have the same length, but got '
+                f'data_samples length: {len(data_samples)} '
                 f'data length: {len(data)}')
             data = get_chunks(iter(data), chunk_size)
 

--- a/tests/test_evaluator/test_evaluator.py
+++ b/tests/test_evaluator/test_evaluator.py
@@ -247,7 +247,7 @@ class TestEvaluator(TestCase):
         all_data = [dict() for _ in range(9)]
         with self.assertRaisesRegex(
                 AssertionError,
-                'outputs and data should have the same length'):
+                'data_samples and data should have the same length'):
             evaluator.offline_evaluate(all_predictions, all_data)
 
     @unittest.skipUnless(torch.cuda.is_available(), 'can only run with gpu')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

BaseDataset does not support slice index which is used in `offline_evaluate`.

## Modification

Replace slice index with `get_chunks` to get a batch of data.

## BC-breaking (Optional)

None.
