### PR TITLE
[Enhance] Add param to control save checkpoint

### DIFF
--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -84,7 +84,7 @@ class CheckpointHook(Hook):
         backend_args (dict, optional): Arguments to instantiate the
             preifx of uri corresponding backend. Defaults to None.
             New in v0.2.0.
-        save_start (int): Start saving the number of epochs or
+        save_begin (int): Start saving the number of epochs or
             epochs or iterations of model weights. Defaults to 0.
             New in v0.3.0.
 
@@ -131,7 +131,7 @@ class CheckpointHook(Hook):
                  file_client_args: Optional[dict] = None,
                  filename_tmpl: Optional[str] = None,
                  backend_args: Optional[dict] = None,
-                 save_start: int = 0,
+                 save_begin: int = 0,
                  **kwargs) -> None:
         self.interval = interval
         self.by_epoch = by_epoch
@@ -140,7 +140,7 @@ class CheckpointHook(Hook):
         self.out_dir = out_dir  # type: ignore
         self.max_keep_ckpts = max_keep_ckpts
         self.save_last = save_last
-        self.save_start = save_start
+        self.save_begin = save_begin
         self.args = kwargs
 
         if file_client_args is not None:
@@ -282,7 +282,7 @@ class CheckpointHook(Hook):
         if not self.by_epoch:
             return
 
-        if runner.epoch + 1 < self.save_start:
+        if runner.epoch + 1 < self.save_begin:
             return
 
         # save checkpoint for following cases:
@@ -311,7 +311,7 @@ class CheckpointHook(Hook):
         if self.by_epoch:
             return
 
-        if runner.iter < self.save_start:
+        if runner.iter + 1 < self.save_begin:
             return
 
         # save checkpoint for following cases:
@@ -545,7 +545,7 @@ class CheckpointHook(Hook):
             bool: Return True if the current iteration can be evenly divided
             by n, otherwise False.
         """
-        return (runner.iter + 1 - self.save_start) % n == 0 if n > 0 else False
+        return (runner.iter + 1 - self.save_begin) % n == 0 if n > 0 else False
 
     def every_n_epochs(self, runner, n: int) -> bool:
         """Test whether current epoch can be evenly divided by n.
@@ -559,4 +559,4 @@ class CheckpointHook(Hook):
             bool: Whether current epoch can be evenly divided by n.
         """
         return (runner.epoch + 1 -
-                self.save_start) % n == 0 if n > 0 else False
+                self.save_begin) % n == 0 if n > 0 else False

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -55,6 +55,8 @@ class CheckpointHook(Hook):
             detection and instance segmentation. ``AR@100`` for proposal
             recall. If ``save_best`` is ``auto``, the first key of the returned
             ``OrderedDict`` result will be used. Defaults to None.
+        save_start (int): Start saving the number of epochs or
+            iterations of model weights. Defaults to 0.
         rule (str, List[str], optional): Comparison rule for best score. If
             set to None, it will infer a reasonable rule. Keys such as 'acc',
             'top' .etc will be inferred by 'greater' rule. Keys contain 'loss'
@@ -122,6 +124,7 @@ class CheckpointHook(Hook):
                  max_keep_ckpts: int = -1,
                  save_last: bool = True,
                  save_best: Union[str, List[str], None] = None,
+                 save_start: int = 0,
                  rule: Union[str, List[str], None] = None,
                  greater_keys: Optional[Sequence[str]] = None,
                  less_keys: Optional[Sequence[str]] = None,
@@ -136,6 +139,7 @@ class CheckpointHook(Hook):
         self.out_dir = out_dir  # type: ignore
         self.max_keep_ckpts = max_keep_ckpts
         self.save_last = save_last
+        self.save_start = save_start
         self.args = kwargs
 
         if file_client_args is not None:
@@ -316,6 +320,10 @@ class CheckpointHook(Hook):
         Args:
             runner (Runner): The runner of the training process.
         """
+        if (self.by_epoch and runner.epoch < self.save_start) or (
+                not self.by_epoch and runner.iter < self.save_start):
+            return
+
         if self.by_epoch:
             ckpt_filename = self.filename_tmpl.format(runner.epoch + 1)
         else:

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -85,7 +85,7 @@ class CheckpointHook(Hook):
             preifx of uri corresponding backend. Defaults to None.
             New in v0.2.0.
         save_begin (int): Start saving the number of epochs or
-            epochs or iterations of model weights. Defaults to 0.
+            epochs or iterations of model weights. Defaults to 1.
             New in v0.3.0.
 
     Examples:
@@ -131,7 +131,7 @@ class CheckpointHook(Hook):
                  file_client_args: Optional[dict] = None,
                  filename_tmpl: Optional[str] = None,
                  backend_args: Optional[dict] = None,
-                 save_begin: int = 0,
+                 save_begin: int = 1,
                  **kwargs) -> None:
         self.interval = interval
         self.by_epoch = by_epoch

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -532,31 +532,3 @@ class CheckpointHook(Hook):
             self.rules.append(rule)
 
         self.key_indicators = key_indicators
-
-    def every_n_train_iters(self, runner, n: int) -> bool:
-        """Test whether current training iteration can be evenly divided by n.
-
-        Args:
-            runner (Runner): The runner of the training, validation or testing
-                process.
-            n (int): Whether current iteration can be evenly divided by n.
-
-        Returns:
-            bool: Return True if the current iteration can be evenly divided
-            by n, otherwise False.
-        """
-        return (runner.iter + 1 - self.save_begin) % n == 0 if n > 0 else False
-
-    def every_n_epochs(self, runner, n: int) -> bool:
-        """Test whether current epoch can be evenly divided by n.
-
-        Args:
-            runner (Runner): The runner of the training, validation or testing
-                process.
-            n (int): Whether current epoch can be evenly divided by n.
-
-        Returns:
-            bool: Whether current epoch can be evenly divided by n.
-        """
-        return (runner.epoch + 1 -
-                self.save_begin) % n == 0 if n > 0 else False

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -323,9 +323,6 @@ class CheckpointHook(Hook):
         Args:
             runner (Runner): The runner of the training process.
         """
-        if (self.by_epoch and runner.epoch < self.save_start) or (
-                not self.by_epoch and runner.iter < self.save_start):
-            return
 
         if self.by_epoch:
             ckpt_filename = self.filename_tmpl.format(runner.epoch + 1)

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -357,7 +357,7 @@ class TestCheckpointHook:
         runner = Mock()
         work_dir = str(tmp_path)
         runner.work_dir = tmp_path
-        runner.epoch = 9
+        runner.epoch = 10
         runner.model = Mock()
         runner.message_hub = MessageHub.get_instance('test_after_train_epoch')
 
@@ -365,21 +365,21 @@ class TestCheckpointHook:
         checkpoint_hook = CheckpointHook(interval=2, by_epoch=True)
         checkpoint_hook.before_train(runner)
         checkpoint_hook.after_train_epoch(runner)
-        assert (runner.epoch + 1) % 2 == 0
+        assert (runner.epoch + 1 - checkpoint_hook.save_begin) % 2 == 0
         assert 'last_ckpt' in runner.message_hub.runtime_info and \
             runner.message_hub.get_info('last_ckpt') == \
-               osp.join(work_dir, 'epoch_10.pth')
+               osp.join(work_dir, 'epoch_11.pth')
         last_ckpt_path = osp.join(work_dir, 'last_checkpoint')
         assert osp.isfile(last_ckpt_path)
         with open(last_ckpt_path) as f:
             filepath = f.read()
-            assert filepath == osp.join(work_dir, 'epoch_10.pth')
+            assert filepath == osp.join(work_dir, 'epoch_11.pth')
 
         # epoch can not be evenly divided by 2
-        runner.epoch = 10
+        runner.epoch = 9
         checkpoint_hook.after_train_epoch(runner)
         assert 'last_ckpt' in runner.message_hub.runtime_info and \
-            runner.message_hub.get_info('last_ckpt') == \
+            runner.message_hub.get_info('last_ckpt') != \
                osp.join(work_dir, 'epoch_10.pth')
 
         # by epoch is False
@@ -391,20 +391,21 @@ class TestCheckpointHook:
         assert 'last_ckpt' not in runner.message_hub.runtime_info
 
         # # max_keep_ckpts > 0
+        runner.epoch = 10
         runner.work_dir = work_dir
-        os.system(f'touch {work_dir}/epoch_8.pth')
+        os.system(f'touch {work_dir}/epoch_9.pth')
         checkpoint_hook = CheckpointHook(
             interval=2, by_epoch=True, max_keep_ckpts=1)
         checkpoint_hook.before_train(runner)
         checkpoint_hook.after_train_epoch(runner)
-        assert (runner.epoch + 1) % 2 == 0
-        assert not os.path.exists(f'{work_dir}/epoch_8.pth')
+        assert (runner.epoch + 1 - checkpoint_hook.save_begin) % 2 == 0
+        assert not os.path.exists(f'{work_dir}/epoch_9.pth')
 
         # save_checkpoint of runner should be called with expected arguments
         runner = Mock()
         work_dir = str(tmp_path)
         runner.work_dir = tmp_path
-        runner.epoch = 1
+        runner.epoch = 0
         runner.message_hub = MessageHub.get_instance('test_after_train_epoch2')
 
         checkpoint_hook = CheckpointHook(interval=2, by_epoch=True)
@@ -413,7 +414,7 @@ class TestCheckpointHook:
 
         runner.save_checkpoint.assert_called_once_with(
             runner.work_dir,
-            'epoch_2.pth',
+            'epoch_1.pth',
             None,
             backend_args=None,
             by_epoch=True,
@@ -424,8 +425,8 @@ class TestCheckpointHook:
         work_dir = str(tmp_path)
         runner = Mock()
         runner.work_dir = str(work_dir)
-        runner.iter = 9
-        batch_idx = 9
+        runner.iter = 10
+        batch_idx = 10
         runner.model = Mock()
         runner.message_hub = MessageHub.get_instance('test_after_train_iter')
 
@@ -439,37 +440,38 @@ class TestCheckpointHook:
         checkpoint_hook = CheckpointHook(interval=2, by_epoch=False)
         checkpoint_hook.before_train(runner)
         checkpoint_hook.after_train_iter(runner, batch_idx=batch_idx)
-        assert (runner.iter + 1) % 2 == 0
+        assert (runner.iter + 1 - checkpoint_hook.save_last) % 2 == 0
         assert 'last_ckpt' in runner.message_hub.runtime_info and \
             runner.message_hub.get_info('last_ckpt') == \
-               osp.join(work_dir, 'iter_10.pth')
+               osp.join(work_dir, 'iter_11.pth')
 
         # epoch can not be evenly divided by 2
-        runner.iter = 10
-        checkpoint_hook.after_train_epoch(runner)
+        runner.iter = 9
+        checkpoint_hook.after_train_iter(runner, batch_idx=runner.iter)
         assert 'last_ckpt' in runner.message_hub.runtime_info and \
-            runner.message_hub.get_info('last_ckpt') == \
+            runner.message_hub.get_info('last_ckpt') != \
                osp.join(work_dir, 'iter_10.pth')
 
         # max_keep_ckpts > 0
-        runner.iter = 9
+        runner.iter = 10
         runner.work_dir = work_dir
-        os.system(f'touch {osp.join(work_dir, "iter_8.pth")}')
+        os.system(f'touch {osp.join(work_dir, "iter_9.pth")}')
         checkpoint_hook = CheckpointHook(
             interval=2, by_epoch=False, max_keep_ckpts=1)
         checkpoint_hook.before_train(runner)
-        checkpoint_hook.after_train_iter(runner, batch_idx=batch_idx)
-        assert not os.path.exists(f'{work_dir}/iter_8.pth')
+        checkpoint_hook.after_train_iter(runner, batch_idx=runner.iter)
+        assert not os.path.exists(f'{work_dir}/iter_9.pth')
 
     def test_with_runner(self, tmp_path):
         max_epoch = 10
         work_dir = osp.join(str(tmp_path), 'runner_test')
         tmpl = '{}.pth'
         save_interval = 2
+        save_begin = 5
         checkpoint_cfg = dict(
             type='CheckpointHook',
             interval=save_interval,
-            save_begin=5,
+            save_begin=save_begin,
             filename_tmpl=tmpl,
             by_epoch=True)
         runner = Runner(
@@ -497,8 +499,8 @@ class TestCheckpointHook:
             path = osp.join(work_dir, tmpl.format(epoch))
             # save ckpt every 2 epoch since from epoch 5. Also save the
             # last ckpt
-            if epoch >= 5 and ((epoch - 5) % save_interval == 0
-                               or epoch == max_epoch):
+            if epoch >= save_begin and ((epoch - save_begin) % save_interval
+                                        == 0 or epoch == max_epoch):
                 assert osp.exists(path)
             else:
                 assert not osp.isfile(path=path)

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -469,7 +469,7 @@ class TestCheckpointHook:
         checkpoint_cfg = dict(
             type='CheckpointHook',
             interval=save_interval,
-            save_start=5,
+            save_begin=5,
             filename_tmpl=tmpl,
             by_epoch=True)
         runner = Runner(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Model training, sometimes do not need to save the previous weight, just need a later epoch to start saving some weights, and `max_keep_ckpts` still need to save the previous weight, but save_start will not save the previous weight

## Modification

add param `save_start` in `mmengine/hooks/checkpoint_hook.py`  `Class CheckpointHook`

## BC-breaking (Optional)

## Use cases (Optional)

## Checklist

