### PR TITLE
Change strict_load of EMAHook to False by default

### DIFF
--- a/mmengine/hooks/ema_hook.py
+++ b/mmengine/hooks/ema_hook.py
@@ -27,11 +27,12 @@ class EMAHook(Hook):
             Defaults to 'ExponentialMovingAverage'.
         strict_load (bool): Whether to strictly enforce that the keys of
             ``state_dict`` in checkpoint match the keys returned by
-            ``self.module.state_dict``. Defaults to True.
+            ``self.module.state_dict``. Defaults to False.
+            Changed in v0.3.0.
         begin_iter (int): The number of iteration to enable ``EMAHook``.
             Defaults to 0.
-        begin_epoch (int): The number of epoch to enable ``EMAHook``. Defaults
-            to 0.
+        begin_epoch (int): The number of epoch to enable ``EMAHook``.
+            Defaults to 0.
         **kwargs: Keyword arguments passed to subclasses of
             :obj:`BaseAveragedModel`
     """

--- a/mmengine/hooks/ema_hook.py
+++ b/mmengine/hooks/ema_hook.py
@@ -40,7 +40,7 @@ class EMAHook(Hook):
 
     def __init__(self,
                  ema_type: str = 'ExponentialMovingAverage',
-                 strict_load: bool = True,
+                 strict_load: bool = False,
                  begin_iter: int = 0,
                  begin_epoch: int = 0,
                  **kwargs):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Resolve #607.

Since #542 makes `load_state_dict` not save or load non-persistent buffer anymore, resuming the old checkpoint with `std` and `mean` will cause the error described in #607. 

The default resume strategy of `EMAHook` should be consistent with `Runner`. Since `Runner` does not load checkpoint strictly, the default value of `load_strict` in `EMAHook` should be False.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
