### PR TITLE
[Docs] fix docstring and documentation used for hub.get_model

### DIFF
--- a/docs/zh_cn/tutorials/config.md
+++ b/docs/zh_cn/tutorials/config.md
@@ -533,7 +533,7 @@ print(custom_optim)
 configs/_base_/schedules/schedule_1x.py
 configs/_base_/datasets.coco_instance.py
 configs/_base_/default_runtime.py
-configs/_base_/models/faster_rcnn_r50_fpn.py
+configs/_base_/models/faster-rcnn_r50_fpn.py
 ```
 
 如果没有配置文件跨项目继承的功能，我们就需要把 MMDetection 的配置文件拷贝到当前项目，而我们现在只需要安装 MMDetection
@@ -546,7 +546,7 @@ _base_ = [
     'mmdet::_base_/schedules/schedule_1x.py',
     'mmdet::_base_/datasets/coco_instance.py',
     'mmdet::_base_/default_runtime.py',
-    'mmdet::_base_/models/faster_rcnn_r50_fpn.py',
+    'mmdet::_base_/models/faster-rcnn_r50_fpn.py',
 ]
 ```
 
@@ -575,7 +575,7 @@ MMEngine 还提供了 `get_config` 和 `get_model` 两个接口，支持对符�
 from mmengine.hub import get_model
 
 model = get_model(
-    'mmdet::faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py', pretrained=True)
+    'mmdet::faster_rcnn/faster-rcnn_r50_fpn_1x_coco.py', pretrained=True)
 print(type(model))
 ```
 
@@ -592,7 +592,7 @@ http loads checkpoint from path: https://download.openmmlab.com/mmdetection/v2.0
 from mmengine.hub import get_config
 
 cfg = get_config(
-    'mmdet::faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py', pretrained=True)
+    'mmdet::faster_rcnn/faster-rcnn_r50_fpn_1x_coco.py', pretrained=True)
 print(cfg.model_path)
 
 ```

--- a/mmengine/config/utils.py
+++ b/mmengine/config/utils.py
@@ -106,7 +106,7 @@ def _get_package_and_cfg_path(cfg_path: str) -> Tuple[str, str]:
         raise ValueError(
             '`_get_package_and_cfg_path` is used for get external package, '
             'please specify the package name and relative config path, just '
-            'like `mmdet::faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py`')
+            'like `mmdet::faster_rcnn/faster-rcnn_r50_fpn_1x_coco.py`')
     package_cfg = cfg_path.split('::')
     if len(package_cfg) > 2:
         raise ValueError('`::` should only be used to separate package and '

--- a/mmengine/hub/hub.py
+++ b/mmengine/hub/hub.py
@@ -21,9 +21,9 @@ def get_config(cfg_path: str, pretrained: bool = False) -> Config:
             by ``cfg.model_path``. Defaults to False.
 
     Examples:
-        >>> cfg = get_config('mmdet::faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py', pretrained=True)
+        >>> cfg = get_config('mmdet::faster_rcnn/faster-rcnn_r50_fpn_1x_coco.py', pretrained=True)
         >>> # Equivalent to
-        >>> # cfg = Config.fromfile('/path/to/faster_rcnn_r50_fpn_1x_coco.py')
+        >>> # cfg = Config.fromfile('/path/to/faster-rcnn_r50_fpn_1x_coco.py')
         >>> cfg.model_path
         https://download.openmmlab.com/mmdetection/v2.0/faster_rcnn/faster_rcnn_r50_fpn_1x_coco/faster_rcnn_r50_fpn_1x_coco_20200130-047c8118.pth
 

--- a/tests/test_hub/test_hub.py
+++ b/tests/test_hub/test_hub.py
@@ -17,23 +17,23 @@ data_path = osp.join(osp.dirname(osp.dirname(__file__)), 'data/')
     reason='mmdet and mmpose should be installed')
 def test_get_config():
     # Test load base config.
-    base_cfg = get_config('mmdet::_base_/models/faster_rcnn_r50_fpn.py')
+    base_cfg = get_config('mmdet::_base_/models/faster-rcnn_r50_fpn.py')
     package_path = get_installed_path('mmdet')
     test_base_cfg = Config.fromfile(
         osp.join(package_path, '.mim',
-                 'configs/_base_/models/faster_rcnn_r50_fpn.py'))
+                 'configs/_base_/models/faster-rcnn_r50_fpn.py'))
     assert test_base_cfg._cfg_dict == base_cfg._cfg_dict
 
     # Test load faster_rcnn config
-    cfg = get_config('mmdet::faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py')
+    cfg = get_config('mmdet::faster_rcnn/faster-rcnn_r50_fpn_1x_coco.py')
     test_cfg = Config.fromfile(
         osp.join(package_path, '.mim',
-                 'configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py'))
+                 'configs/faster_rcnn/faster-rcnn_r50_fpn_1x_coco.py'))
     assert cfg._cfg_dict == test_cfg._cfg_dict
 
     # Test pretrained
     cfg = get_config(
-        'mmdet::faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py', pretrained=True)
+        'mmdet::faster_rcnn/faster-rcnn_r50_fpn_1x_coco.py', pretrained=True)
     assert cfg.model_path == 'https://download.openmmlab.com/mmdetection/v2.0/faster_rcnn/faster_rcnn_r50_fpn_1x_coco/faster_rcnn_r50_fpn_1x_coco_20200130-047c8118.pth'  # noqa E301
 
     # Test load mmpose


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

MMdetection has renamed some configs https://github.com/open-mmlab/mmdetection/tree/3.x/configs
The docstring and documentation used in mmengine.hub.get_model should be updated. 

## Modification

'faster_rcnn' -> 'faster-rcnn'

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
