### PR TITLE
[Fix] Fix potential OOM error when loading checkpoint with `map_location="cuda:0"`

### DIFF
--- a/mmengine/model/weight_init.py
+++ b/mmengine/model/weight_init.py
@@ -472,7 +472,7 @@ class PretrainedInit:
         map_location (str): map tensors into proper locations.
     """
 
-    def __init__(self, checkpoint, prefix=None, map_location=None):
+    def __init__(self, checkpoint, prefix=None, map_location='cpu'):
         self.checkpoint = checkpoint
         self.prefix = prefix
         self.map_location = map_location

--- a/mmengine/model/weight_init.py
+++ b/mmengine/model/weight_init.py
@@ -469,7 +469,7 @@ class PretrainedInit:
             initialize. For example, if we would like to only load the
             backbone of a detector model, we can set ``prefix='backbone.'``.
             Defaults to None.
-        map_location (str): map tensors into proper locations.
+        map_location (str): map tensors into proper locations. Defaults to cpu.
     """
 
     def __init__(self, checkpoint, prefix=None, map_location='cpu'):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

If a checkpoint is saved with `map_location='cuda:0'`, `PretrainedInit` will first load the checkpoint to "cuda:0", and then copy the parameters to the model. During ddp-training, all ranks will first load the checkpoint to "cuda:0", which could cause an OOM error.

A workaround could be that let `PretrainedInit` load the checkpoint to "cpu" by default.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
