### PR TITLE
Fix `experiment_name` settings in runner.py

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -356,7 +356,7 @@ class Runner:
             self._experiment_name = f'{filename_no_ext}_{self._timestamp}'
         else:
             self._experiment_name = self.timestamp
-        self._log_dir = osp.join(self.work_dir, self.timestamp)
+        self._log_dir = osp.join(self.work_dir, self.experiment_name)
         mmengine.mkdir_or_exist(self._log_dir)
         # Used to reset registries location. See :meth:`Registry.build` for
         # more details.


### PR DESCRIPTION
Fix `experiment_name` settings in runner.py.

## Motivation

The `experiment_name` param in `Runner()` construction makes no scence, bucause a small mistake.
I correct this mistake here.

## Modification

I just change line 359 in runner.py from:
```python
self._log_dir = osp.join(self.work_dir, self.timestamp)
```
to
```python
self._log_dir = osp.join(self.work_dir, self.experiment_name)
```

## BC-breaking (Optional)

Nope

## Use cases (Optional)

Nope

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
