### PR TITLE
Update distributed_training.py

### DIFF
--- a/examples/distributed_training.py
+++ b/examples/distributed_training.py
@@ -1,11 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
 
+import torch
 import torch.nn.functional as F
 import torchvision
 import torchvision.transforms as transforms
 from torch.optim import SGD
-from torch.utils.data import DataLoader
 
 from mmengine.evaluator import BaseMetric
 from mmengine.model import BaseModel
@@ -39,6 +39,14 @@ class Accuracy(BaseMetric):
         total_correct = sum(item['correct'] for item in results)
         total_size = sum(item['batch_size'] for item in results)
         return dict(accuracy=100 * total_correct / total_size)
+    
+    
+class IntToTensor:
+    def __call__(self, data):
+        return torch.tensor(data)
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
 
 
 def parse_args():
@@ -57,29 +65,37 @@ def parse_args():
 def main():
     args = parse_args()
     norm_cfg = dict(mean=[0.491, 0.482, 0.447], std=[0.202, 0.199, 0.201])
-    train_dataloader = DataLoader(
-        batch_size=32,
-        shuffle=True,
-        dataset=torchvision.datasets.CIFAR10(
-            'data/cifar10',
-            train=True,
-            download=True,
-            transform=transforms.Compose([
-                transforms.RandomCrop(32, padding=4),
-                transforms.RandomHorizontalFlip(),
-                transforms.ToTensor(),
-                transforms.Normalize(**norm_cfg)
-            ])))
-    val_dataloader = DataLoader(
+    train_set = torchvision.datasets.CIFAR10(
+        'data/cifar10',
+        train=True,
+        download=True,
+        transform=transforms.Compose([
+            transforms.RandomCrop(32, padding=4),
+            transforms.RandomHorizontalFlip(),
+            transforms.ToTensor(),
+            transforms.Normalize(**norm_cfg)
+        ]),
+        target_transform=IntToTensor())
+    valid_set = torchvision.datasets.CIFAR10(
+        'data/cifar10',
+        train=False,
+        download=True,
+        transform=transforms.Compose(
+            [transforms.ToTensor(),
+             transforms.Normalize(**norm_cfg)]),
+        target_transform=IntToTensor())
+    train_dataloader = dict(
         batch_size=32,
         shuffle=False,
-        dataset=torchvision.datasets.CIFAR10(
-            'data/cifar10',
-            train=False,
-            download=True,
-            transform=transforms.Compose(
-                [transforms.ToTensor(),
-                 transforms.Normalize(**norm_cfg)])))
+        dataset=train_set,
+        sampler=dict(type='DefaultSampler', shuffle=True),
+        collate_fn=dict(type='default_collate'))
+    val_dataloader = dict(
+        batch_size=32,
+        shuffle=False,
+        dataset=valid_set,
+        sampler=dict(type='DefaultSampler', shuffle=True),
+        collate_fn=dict(type='default_collate'))
     runner = Runner(
         model=MMResNet50(),
         work_dir='./work_dir',

--- a/examples/distributed_training.py
+++ b/examples/distributed_training.py
@@ -41,14 +41,6 @@ class Accuracy(BaseMetric):
         return dict(accuracy=100 * total_correct / total_size)
 
 
-class IntToTensor:
-    def __call__(self, data):
-        return torch.tensor(data)
-
-    def __repr__(self):
-        return self.__class__.__name__ + '()'
-
-
 def parse_args():
     parser = argparse.ArgumentParser(description='Distributed Training')
     parser.add_argument(
@@ -74,27 +66,23 @@ def main():
             transforms.RandomHorizontalFlip(),
             transforms.ToTensor(),
             transforms.Normalize(**norm_cfg)
-        ]),
-        target_transform=IntToTensor())
+        ]))
     valid_set = torchvision.datasets.CIFAR10(
         'data/cifar10',
         train=False,
         download=True,
         transform=transforms.Compose(
             [transforms.ToTensor(),
-             transforms.Normalize(**norm_cfg)]),
-        target_transform=IntToTensor())
+             transforms.Normalize(**norm_cfg)]))
     train_dataloader = dict(
         batch_size=32,
-        shuffle=False,
         dataset=train_set,
         sampler=dict(type='DefaultSampler', shuffle=True),
         collate_fn=dict(type='default_collate'))
     val_dataloader = dict(
         batch_size=32,
-        shuffle=False,
         dataset=valid_set,
-        sampler=dict(type='DefaultSampler', shuffle=True),
+        sampler=dict(type='DefaultSampler', shuffle=False),
         collate_fn=dict(type='default_collate'))
     runner = Runner(
         model=MMResNet50(),

--- a/examples/distributed_training.py
+++ b/examples/distributed_training.py
@@ -1,11 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
 
-import torch
 import torch.nn.functional as F
 import torchvision
 import torchvision.transforms as transforms
 from torch.optim import SGD
+from torch.utils.data import DataLoader
 
 from mmengine.evaluator import BaseMetric
 from mmengine.model import BaseModel
@@ -57,33 +57,29 @@ def parse_args():
 def main():
     args = parse_args()
     norm_cfg = dict(mean=[0.491, 0.482, 0.447], std=[0.202, 0.199, 0.201])
-    train_set = torchvision.datasets.CIFAR10(
-        'data/cifar10',
-        train=True,
-        download=True,
-        transform=transforms.Compose([
-            transforms.RandomCrop(32, padding=4),
-            transforms.RandomHorizontalFlip(),
-            transforms.ToTensor(),
-            transforms.Normalize(**norm_cfg)
-        ]))
-    valid_set = torchvision.datasets.CIFAR10(
-        'data/cifar10',
-        train=False,
-        download=True,
-        transform=transforms.Compose(
-            [transforms.ToTensor(),
-             transforms.Normalize(**norm_cfg)]))
-    train_dataloader = dict(
+    train_dataloader = DataLoader(
         batch_size=32,
-        dataset=train_set,
-        sampler=dict(type='DefaultSampler', shuffle=True),
-        collate_fn=dict(type='default_collate'))
-    val_dataloader = dict(
+        shuffle=True,
+        dataset=torchvision.datasets.CIFAR10(
+            'data/cifar10',
+            train=True,
+            download=True,
+            transform=transforms.Compose([
+                transforms.RandomCrop(32, padding=4),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize(**norm_cfg)
+            ])))
+    val_dataloader = DataLoader(
         batch_size=32,
-        dataset=valid_set,
-        sampler=dict(type='DefaultSampler', shuffle=False),
-        collate_fn=dict(type='default_collate'))
+        shuffle=False,
+        dataset=torchvision.datasets.CIFAR10(
+            'data/cifar10',
+            train=False,
+            download=True,
+            transform=transforms.Compose(
+                [transforms.ToTensor(),
+                 transforms.Normalize(**norm_cfg)])))
     runner = Runner(
         model=MMResNet50(),
         work_dir='./work_dir',

--- a/examples/distributed_training.py
+++ b/examples/distributed_training.py
@@ -39,8 +39,8 @@ class Accuracy(BaseMetric):
         total_correct = sum(item['correct'] for item in results)
         total_size = sum(item['batch_size'] for item in results)
         return dict(accuracy=100 * total_correct / total_size)
-    
-    
+
+
 class IntToTensor:
     def __call__(self, data):
         return torch.tensor(data)


### PR DESCRIPTION
Better example for DDP training

## Motivation

The previous version of `example/distributed_training.py` can not run DDP training correctly. After the discussion in #688，we provide a better example.

## Modification

Only `example/distributed_training.py` is modified, mainly  the dataloader. And I have done sufficient test.

## BC-breaking (Optional)

Nope

## Use cases (Optional)

Nope

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
