### PR TITLE
[Enchance] Support Config.fromdict

### DIFF
--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -215,6 +215,28 @@ class Config:
         return cfg
 
     @staticmethod
+    def fromdict(cfg_dict, file_format='.py'):
+        """Build a Config instance from config dict.
+
+        Args:
+            cfg_dict (dict): A config dictionary.
+            file_format (str): Config file format corresponding to the
+               config str. Only py/yml/yaml/json type are supported now!
+
+        Returns:
+            Config: Config object generated from ``cfg_dict``.
+        """
+        if file_format not in ['.py', '.json', '.yaml', '.yml']:
+            raise OSError('Only py/yml/yaml/json type are supported now!')
+
+        cfg = Config(cfg_dict)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpcfg = f'{tmpdir}/tmp{file_format}'
+            cfg.dump(tmpcfg)
+            cfg = Config.fromfile(tmpcfg)
+        return cfg
+
+    @staticmethod
     def _validate_py_syntax(filename: str):
         """Validate syntax of python config.
 


### PR DESCRIPTION
## Motivation

To be able to load config using `_base_` in dict format.

## Use cases (Optional)

```
cfg = dict(_base_=['mmcls::_base_/models/resnet18.py',
                  'mmcls::_base_/datasets/imagenet_bs32.py',
                  'mmcls::_base_/schedules/imagenet_bs256.py',
                  'mmcls::_base_/default_runtime.py'])
cfg = Config.fromdict(cfg)
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
