### PR TITLE
[Enhance] Support doing validation on non-ema model.

### DIFF
--- a/mmengine/hooks/ema_hook.py
+++ b/mmengine/hooks/ema_hook.py
@@ -33,6 +33,8 @@ class EMAHook(Hook):
             Defaults to 0.
         begin_epoch (int): The number of epoch to enable ``EMAHook``.
             Defaults to 0.
+        validate_on_ema (bool): Whether to do validation on EMA model.
+            Defaults to True.
         **kwargs: Keyword arguments passed to subclasses of
             :obj:`BaseAveragedModel`
     """
@@ -44,6 +46,7 @@ class EMAHook(Hook):
                  strict_load: bool = False,
                  begin_iter: int = 0,
                  begin_epoch: int = 0,
+                 validate_on_ema: bool = True,
                  **kwargs):
         self.strict_load = strict_load
         self.ema_cfg = dict(type=ema_type, **kwargs)
@@ -58,6 +61,7 @@ class EMAHook(Hook):
         # If `begin_epoch` and `begin_iter` are not set, `EMAHook` will be
         # enabled at 0 iteration.
         self.enabled_by_epoch = self.begin_epoch > 0
+        self.validate_on_ema = validate_on_ema
 
     def before_run(self, runner) -> None:
         """Create an ema copy of the model.
@@ -116,7 +120,8 @@ class EMAHook(Hook):
         Args:
             runner (Runner): The runner of the training process.
         """
-        self._swap_ema_parameters()
+        if self.validate_on_ema:
+            self._swap_ema_parameters()
 
     def after_val_epoch(self,
                         runner,
@@ -129,7 +134,8 @@ class EMAHook(Hook):
                 metrics on validation dataset. The keys are the names of the
                 metrics, and the values are corresponding results.
         """
-        self._swap_ema_parameters()
+        if self.validate_on_ema:
+            self._swap_ema_parameters()
 
     def before_test_epoch(self, runner) -> None:
         """We load parameter values from ema model to source model before test.


### PR DESCRIPTION
## Motivation

Sometimes, we want to do validation on the non-ema model although the EMA is enabled.

## Modification

Add an option to determine whether to do validation on EMA models.

## BC-breaking (Optional)

No

## Use cases (Optional)

```python
custom_hooks = [dict(type='EMAHook', validate_on_ema=False)]
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
