### PR TITLE
[Enhance] Substitute the environment variable in config file.

### DIFF
--- a/docs/en/advanced_tutorials/config.md
+++ b/docs/en/advanced_tutorials/config.md
@@ -528,13 +528,35 @@ Config (path: replace_data_root.py): {'dataset_type': 'CocoDataset', 'data_root'
 
 The value of `data_root` has been substituted with the value of `DATASET` as `/new/dataset/path`.
 
-```note
-Environment variable substitution occurs before the configuration parsing. If the replaced field is also involved in other fields assignment, the environment variable substitution will also affect the other fields. In the above example, dataset.ann_file = data_root + 'train.json', so when data_root is replaced, dataset.ann_file will also be changed. Meanwhile, --cfg-options replace a field after the configuration file is parsed. --cfg-options data_root='/new/dataset/path/' does not affect dataset.ann_file
+It is noteworthy that both `--cfg-options` and `{{$ENV_VAR:DEF_VAL}}` allow users modified fields in command line. But there is a small difference between those two methods. Environment variable substitution occurs before the configuration parsing. If the replaced field is also involved in other fields assignment, the environment variable substitution will also affect the other fields.
+
+We take `demo_train.py` and `replace_data_root.py` for example. If we replace `data_root` by setting `--cfg-options data_root='/new/dataset/path'`:
+
+```bash
+python demo_train.py replace_data_root.py --cfg-options data_root='/new/dataset/path/'
 ```
+
+```
+Config (path: replace_data_root.py): {'dataset_type': 'CocoDataset', 'data_root': '/new/dataset/path/', 'dataset': {'ann_file': '/data/coco/train.json'}}
+```
+
+As we can see, only `data_root` has been modified. `dataset.ann_file` is still the default value.
+
+In contrast, if we replace `data_root` by setting `DATASET=/new/dataset/path`:
+
+```bash
+DATASET=/new/dataset/path/ python demo_train.py replace_data_root.py
+```
+
+```
+Config (path: replace_data_root.py): {'dataset_type': 'CocoDataset', 'data_root': '/new/dataset/path/', 'dataset': {'ann_file': '/new/dataset/path/train.json'}}
+```
+
+Both `data_root` and `dataset.ann_file` have been modified.
 
 Environment variables can also be used to replace other types of fields. We can use `{{'$ENV_VAR:DEF_VAL'}}` or `{{"$ENV_VAR:DEF_VAL"}}` format to ensure the configuration file conforms to python syntax.
 
-We can task `replace_num_classes.py` as an example:
+We can take `replace_num_classes.py` as an example:
 
 ```
 model=dict(

--- a/docs/en/advanced_tutorials/config.md
+++ b/docs/en/advanced_tutorials/config.md
@@ -528,7 +528,7 @@ Config (path: replace_data_root.py): {'dataset_type': 'CocoDataset', 'data_root'
 
 The value of `data_root` has been substituted with the value of `DATASET` as `/new/dataset/path`.
 
-It is noteworthy that both `--cfg-options` and `{{$ENV_VAR:DEF_VAL}}` allow users modified fields in command line. But there is a small difference between those two methods. Environment variable substitution occurs before the configuration parsing. If the replaced field is also involved in other fields assignment, the environment variable substitution will also affect the other fields.
+It is noteworthy that both `--cfg-options` and `{{$ENV_VAR:DEF_VAL}}` allow users to modify fields in command line. But there is a small difference between those two methods. Environment variable substitution occurs before the configuration parsing. If the replaced field is also involved in other fields assignment, the environment variable substitution will also affect the other fields.
 
 We take `demo_train.py` and `replace_data_root.py` for example. If we replace `data_root` by setting `--cfg-options data_root='/new/dataset/path'`:
 

--- a/docs/resources/config/replace_data_root.py
+++ b/docs/resources/config/replace_data_root.py
@@ -1,0 +1,3 @@
+dataset_type = 'CocoDataset'
+data_root = '{{$DATASET:/data/coco/}}'
+dataset = dict(ann_file=data_root + 'train.json')

--- a/docs/resources/config/replace_num_classes.py
+++ b/docs/resources/config/replace_num_classes.py
@@ -1,0 +1,1 @@
+model = dict(bbox_head=dict(num_classes={{'$NUM_CLASSES:80'}}))

--- a/docs/zh_cn/advanced_tutorials/config.md
+++ b/docs/zh_cn/advanced_tutorials/config.md
@@ -528,9 +528,31 @@ Config (path: replace_data_root.py): {'dataset_type': 'CocoDataset', 'data_root'
 
 `data_root` 被替换成了环境变量 `DATASET` 的值 `/new/dataset/path/`。
 
-```note
-环境变量的替换发生在配置文件解析之前。如果该配置还参与到其他配置的定义时，环境变量替换也会影响到其他配置。在上例中 dataset.ann_file 等于 data_root + 'train.json', 因此当 data_root 被替换时，dataset.ann_file 也会发生变化。而 --cfg-options 是在配置文件解析后去替换特定配置。--cfg-options data_root='/new/dataset/path/' 不会影响到 dataset.ann_file
+值得注意的是，`--cfg-options` 与 `{{$ENV_VAR:DEF_VAL}}` 都可以在命令行改变配置文件的值，但他们还有一些区别。环境变量的替换发生在配置文件解析之前。如果该配置还参与到其他配置的定义时，环境变量替换也会影响到其他配置，而 `--cfg-options` 只会改变要修改的配置文件的值。
+
+我们以 `demo_train.py` 与 `replace_data_root.py` 为例。 如果我们通过配置 `--cfg-options data_root='/new/dataset/path'` 来修改 `data_root`：
+
+```bash
+python demo_train.py replace_data_root.py --cfg-options data_root='/new/dataset/path/'
 ```
+
+```
+Config (path: replace_data_root.py): {'dataset_type': 'CocoDataset', 'data_root': '/new/dataset/path/', 'dataset': {'ann_file': '/data/coco/train.json'}}
+```
+
+从输出结果上看，只有 `data_root` 被修改为新的值。`dataset.ann_file` 依然保持原始值。
+
+作为对比，如果我们通过配置 `DATASET=/new/dataset/path` 来修改 `data_root`:
+
+```bash
+DATASET=/new/dataset/path/ python demo_train.py replace_data_root.py
+```
+
+```
+Config (path: replace_data_root.py): {'dataset_type': 'CocoDataset', 'data_root': '/new/dataset/path/', 'dataset': {'ann_file': '/new/dataset/path/train.json'}}
+```
+
+`data_root` 与 `dataset.ann_file` 同时被修改了。
 
 环境变量也可以用来替换字符串以外的配置，这时可以使用 `{{'$ENV_VAR:DEF_VAL'}}` 或者 `{{"$ENV_VAR:DEF_VAL"}}` 格式。`''` 与 `""` 用来保证配置文件合乎 python 语法。
 

--- a/docs/zh_cn/advanced_tutorials/config.md
+++ b/docs/zh_cn/advanced_tutorials/config.md
@@ -492,13 +492,13 @@ Config (path: ./example.py): {'model': {'type': 'CustomModel', 'in_channels': [1
 
 :::
 
-### 替换环境变量
+### 使用环境变量替换配置
 
-当要修改的变量嵌套很深时，我们在命令行中也需要加上很长的前缀来表示这个变量的位置。为了更方便地在命令行中修改配置文件，MMEngine 提供了一套通过环境变量来替换固定片段的方法。
+当要修改的配置嵌套很深时，我们在命令行中需要加上很长的前缀来进行定位。为了更方便地在命令行中修改配置，MMEngine 提供了一套通过环境变量来替换配置的方法。
 
-在解析配置文件之前，MMEngine 会搜索所有的 `{{$ENV_VAR:DEF_VAL}}` 字段，并使用字段指定的环境变量来替换这一部分。这里 `ENV_VAR` 为这一字段指定的环境变量，`DEF_VAL` 表示没有设置环境变量时的默认值。
+在解析配置文件之前，MMEngine 会搜索所有的 `{{$ENV_VAR:DEF_VAL}}` 字段，并使用特定的环境变量来替换这一部分。这里 `ENV_VAR` 为替换这一部分所用的环境变量，`DEF_VAL` 为没有设置环境变量时的默认值。
 
-例如，当我们想在命令行中修改数据集的路径时，我们可以在配置文件 `replace_data_root.py` 中这样写：
+例如，当我们想在命令行中修改数据集路径时，我们可以在配置文件 `replace_data_root.py` 中这样写：
 
 ```python
 dataset_type = 'CocoDataset'
@@ -516,7 +516,7 @@ python demo_train.py replace_data_root.py
 Config (path: replace_data_root.py): {'dataset_type': 'CocoDataset', 'data_root': '/data/coco/', 'dataset': {'ann_file': '/data/coco/train.json'}}
 ```
 
-这里因为没有设置环境变量 `DATASET`, 程序直接使用默认值 `/data/coco/` 作为这一部分的值。如果在命令行前设置设置环境变量则会有如下结果：
+这里没有设置环境变量 `DATASET`, 程序直接使用默认值 `/data/coco/` 来替换 `{{$DATASET:/data/coco/}}`。如果在命令行前设置设置环境变量则会有如下结果：
 
 ```bash
 DATASET=/new/dataset/path/ python demo_train.py replace_data_root.py
@@ -526,15 +526,15 @@ DATASET=/new/dataset/path/ python demo_train.py replace_data_root.py
 Config (path: replace_data_root.py): {'dataset_type': 'CocoDataset', 'data_root': '/new/dataset/path/', 'dataset': {'ann_file': '/new/dataset/path/train.json'}}
 ```
 
-`data_root` 被替换成了新的路径 `/new/dataset/path/`
+`data_root` 被替换成了环境变量 `DATASET` 的值 `/new/dataset/path/`。
 
 ```note
-环境变量的替换发生在配置文件解析之前。如果该变量还参与到其他变量的定义时，环境变量替换也会影响到其他变量。在上例中 dataset.ann_file 等于 data_root + 'train.json', 因此当 data_root 被替换时，dataset.ann_file 也会发生变化。而 --cfg-options 是在配置文件解析后去替换特定变量。--cfg-options data_root='/new/dataset/path/' 不会影响到 dataset.ann_file
+环境变量的替换发生在配置文件解析之前。如果该配置还参与到其他配置的定义时，环境变量替换也会影响到其他配置。在上例中 dataset.ann_file 等于 data_root + 'train.json', 因此当 data_root 被替换时，dataset.ann_file 也会发生变化。而 --cfg-options 是在配置文件解析后去替换特定配置。--cfg-options data_root='/new/dataset/path/' 不会影响到 dataset.ann_file
 ```
 
-环境变量也可以用来替换字符串以外的字段，这时可以使用 `{{'$ENV_VAR:DEF_VAL'}}` 或者 `{{"$ENV_VAR:DEF_VAL"}}`。`''` 与 `""` 保证配置文件合乎 python 语法。
+环境变量也可以用来替换字符串以外的配置，这时可以使用 `{{'$ENV_VAR:DEF_VAL'}}` 或者 `{{"$ENV_VAR:DEF_VAL"}}` 格式。`''` 与 `""` 用来保证配置文件合乎 python 语法。
 
-例如当我们想替换模型预测的类别数时，可以在配置文件 `replace_num_classes.py` 中这样写：
+例如，当我们想替换模型预测的类别数时，可以在配置文件 `replace_num_classes.py` 中这样写：
 
 ```
 model=dict(

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -285,6 +285,12 @@ class Config:
             regexp = r'\{\{\s*' + str(key) + r'\s*\}\}'
             value = value.replace('\\', '/')
             config_file = re.sub(regexp, value, config_file)
+        # substitute environment variables
+        regexp = r'\{\{\s*\$(.+)\s*\:\s*(.*)\s*\}\}'
+        keys = re.findall(regexp, config_file)
+        for var_name, value in keys:
+            value = os.environ.get(var_name, default=value)
+            config_file = re.sub(regexp, value, config_file)
         with open(temp_config_name, 'w', encoding='utf-8') as tmp_config_file:
             tmp_config_file.write(config_file)
 

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -152,7 +152,7 @@ class Config:
         else:
             text = ''
         super().__setattr__('_text', text)
-        if not env_variables:
+        if env_variables is None:
             env_variables = dict()
         super().__setattr__('_env_variables', env_variables)
 

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -298,7 +298,7 @@ class Config:
             tmp_config_file.write(config_file)
 
     @staticmethod
-    def _substitute_environment_vars(filename: str, temp_config_name: str):
+    def _substitute_env_variables(filename: str, temp_config_name: str):
         """Substitute environment variables in config with actual values.
 
         Sometimes, we want to change some items in the config with environment
@@ -466,7 +466,7 @@ class Config:
             # Substitute environment variables
             env_variables = dict()
             if use_environment_variables:
-                env_variables = Config._substitute_environment_vars(
+                env_variables = Config._substitute_env_variables(
                     temp_config_file.name, temp_config_file.name)
             # Substitute base variables from placeholders to strings
             base_var_dict = Config._pre_substitute_base_vars(

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -301,6 +301,33 @@ class Config:
     def _substitute_environment_vars(filename: str, temp_config_name: str):
         """Substitute environment variables in config with actual values.
 
+        Sometimes, we want to change some items in the config with environment
+        variables. For examples, we expect to change dataset root by setting
+        ``DATASET_ROOT=/dataset/root/path`` in the command line. This can be
+        easily achieved by writing lines in the config as follows
+
+        .. code-block:: python
+
+           data_root = '{{$DATASET_ROOT:/default/dataset}}/images'
+
+
+        Here, ``{{$DATASET_ROOT:/default/dataset}}`` indicates using the
+        environment variable ``DATASET_ROOT`` to replace the part between
+        ``{{}}``. If the ``DATASET_ROOT`` is not set, the default value
+        ``/default/dataset`` will be used.
+
+        Environment variables not only can replace items in the string, they
+        can also substitute other types of data in config. In this situation,
+        we can write the config as below
+
+        .. code-block:: python
+
+           model = dict(
+               bbox_head = dict(num_classes={{'$NUM_CLASSES:80'}}))
+
+
+        For details, Please refer to docs/zh_cn/tutorials/config.md .
+
         Args:
             filename (str): Filename of config.
             temp_config_name (str): Temporary filename to save substituted

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -286,7 +286,7 @@ class Config:
             value = value.replace('\\', '/')
             config_file = re.sub(regexp, value, config_file)
         # substitute environment variables
-        regexp = r'\{\{\s*\$(.+)\s*\:\s*(.*)\s*\}\}'
+        regexp = r'\{\{\s*\$(\S+)\s*\:\s*(\S*)\s*\}\}'
         keys = re.findall(regexp, config_file)
         for var_name, value in keys:
             value = os.environ.get(var_name, default=value)

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -335,18 +335,20 @@ class Config:
         """
         with open(filename, encoding='utf-8') as f:
             config_file = f.read()
-        regexp = r'\{\{[\'\"]?\s*\$(\w+)\s*\:?\s*(\S*?)\s*[\'\"]?\}\}'
+        regexp = r'\{\{[\'\"]?\s*\$(\w+)\s*\:\s*(\S*?)\s*[\'\"]?\}\}'
         keys = re.findall(regexp, config_file)
         env_variables = dict()
         for var_name, value in keys:
-            regexp = r'\{\{[\'\"]?\s*\$' + var_name + r'\s*\:?\s*' \
+            regexp = r'\{\{[\'\"]?\s*\$' + var_name + r'\s*\:\s*' \
                 + value + r'\s*[\'\"]?\}\}'
             if var_name in os.environ:
                 value = os.environ[var_name]
                 env_variables[var_name] = value
-                print_log(f'Using env variable `{var_name}` with value of '
-                          f'{value} to replace item in config.')
-            elif not value:
+                print_log(
+                    f'Using env variable `{var_name}` with value of '
+                    f'{value} to replace item in config.',
+                    logger='current')
+            if not value:
                 raise KeyError(f'`{var_name}` cannot be found in `os.environ`.'
                                f' Please set `{var_name}` in environment or '
                                'give a default value.')

--- a/tests/data/config/py_config/test_environment_var.py
+++ b/tests/data/config/py_config/test_environment_var.py
@@ -1,4 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-item1 = '{{ $ITEM1 }}'
+item1 = '{{ $ITEM1: }}'
 item2 = '{{ $ITEM2:default_value }}'
 item3 = {{' $ITEM3:80 '}}

--- a/tests/data/config/py_config/test_environment_var.py
+++ b/tests/data/config/py_config/test_environment_var.py
@@ -1,0 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+item1 = '{{ $ITEM1 }}'
+item2 = '{{ $ITEM2:default_value }}'
+item3 = {{' $ITEM3:80 '}}

--- a/tests/data/config/py_config/test_predefined_var.py
+++ b/tests/data/config/py_config/test_predefined_var.py
@@ -2,3 +2,4 @@
 item1 = '{{fileBasename}}'
 item2 = '{{ fileDirname}}'
 item3 = 'abc_{{ fileBasenameNoExtension }}'
+item4 = '{{ $MMENGINE:/unit/test }}'

--- a/tests/data/config/py_config/test_predefined_var.py
+++ b/tests/data/config/py_config/test_predefined_var.py
@@ -2,4 +2,3 @@
 item1 = '{{fileBasename}}'
 item2 = '{{ fileDirname}}'
 item3 = 'abc_{{ fileBasenameNoExtension }}'
-item4 = '{{ $MMENGINE:/unit/test }}'

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -376,6 +376,42 @@ class TestConfig:
         with open(substituted_cfg) as f:
             assert f.read() == expected_text
 
+    def test_substitute_environment_vars(self, tmp_path):
+        cfg = tmp_path / 'tmp_cfg1.py'
+        substituted_cfg = tmp_path / 'tmp_cfg2.py'
+
+        cfg_text = 'a={{$A}}\n'
+        with open(cfg, 'w') as f:
+            f.write(cfg_text)
+        with pytest.raises(KeyError):
+            Config._substitute_environment_vars(cfg, substituted_cfg)
+
+        os.environ['A'] = 'text_A'
+        Config._substitute_environment_vars(cfg, substituted_cfg)
+        with open(substituted_cfg) as f:
+            assert f.read() == 'a=text_A\n'
+        os.environ.pop('A')
+
+        cfg_text = 'b={{$B:80}}\n'
+        with open(cfg, 'w') as f:
+            f.write(cfg_text)
+        Config._substitute_environment_vars(cfg, substituted_cfg)
+        with open(substituted_cfg) as f:
+            assert f.read() == 'b=80\n'
+
+        os.environ['B'] = '100'
+        Config._substitute_environment_vars(cfg, substituted_cfg)
+        with open(substituted_cfg) as f:
+            assert f.read() == 'b=100\n'
+        os.environ.pop('B')
+
+        cfg_text = 'c={{"$C:80"}}\n'
+        with open(cfg, 'w') as f:
+            f.write(cfg_text)
+        Config._substitute_environment_vars(cfg, substituted_cfg)
+        with open(substituted_cfg) as f:
+            assert f.read() == 'c=80\n'
+
     def test_pre_substitute_base_vars(self, tmp_path):
         cfg_path = osp.join(self.data_path, 'config',
                             'py_config/test_pre_substitute_base_vars.py')
@@ -436,6 +472,7 @@ class TestConfig:
 
         self._simple_load()
         self._predefined_vars()
+        self._environment_vars()
         self._base_variables()
         self._merge_from_base()
         self._code_in_config()
@@ -503,17 +540,11 @@ class TestConfig:
         assert Config._file2dict(cfg_file)[0]['item2'] == cfg_dict_dst['item2']
         assert Config._file2dict(cfg_file)[0]['item3'] == cfg_dict_dst['item3']
 
-        # test environment variable replacing function
-        assert Config._file2dict(cfg_file)[0]['item4'] == '/unit/test'
-        os.environ['MMENGINE'] = '/new/unit/test'
-        assert Config._file2dict(cfg_file)[0]['item4'] == '/new/unit/test'
-
         # test `use_predefined_variable=False`
         cfg_dict_ori = dict(
             item1='{{fileBasename}}',
             item2='{{ fileDirname}}',
-            item3='abc_{{ fileBasenameNoExtension }}',
-            item4='{{ $MMENGINE:/unit/test }}')
+            item3='abc_{{ fileBasenameNoExtension }}')
 
         assert Config._file2dict(cfg_file,
                                  False)[0]['item1'] == cfg_dict_ori['item1']
@@ -521,8 +552,6 @@ class TestConfig:
                                  False)[0]['item2'] == cfg_dict_ori['item2']
         assert Config._file2dict(cfg_file,
                                  False)[0]['item3'] == cfg_dict_ori['item3']
-        assert Config._file2dict(cfg_file,
-                                 False)[0]['item4'] == cfg_dict_ori['item4']
 
         # test test_predefined_var.yaml
         cfg_file = osp.join(self.data_path,
@@ -541,6 +570,31 @@ class TestConfig:
         assert Config.fromfile(cfg_file, False)['item1'] == '{{ fileDirname }}'
         assert Config.fromfile(cfg_file)['item1'] == self._get_file_path(
             osp.dirname(cfg_file))
+
+    def _environment_vars(self):
+        # test parse predefined_var in config
+        cfg_file = osp.join(self.data_path,
+                            'config/py_config/test_environment_var.py')
+
+        with pytest.raises(KeyError):
+            Config._file2dict(cfg_file)
+
+        os.environ['ITEM1'] = '60'
+        cfg_dict_dst = dict(item1='60', item2='default_value', item3=80)
+        assert Config._file2dict(cfg_file)[0]['item1'] == cfg_dict_dst['item1']
+        assert Config._file2dict(cfg_file)[0]['item2'] == cfg_dict_dst['item2']
+        assert Config._file2dict(cfg_file)[0]['item3'] == cfg_dict_dst['item3']
+
+        os.environ['ITEM2'] = 'new_value'
+        os.environ['ITEM3'] = '50'
+        cfg_dict_dst = dict(item1='60', item2='new_value', item3=50)
+        assert Config._file2dict(cfg_file)[0]['item1'] == cfg_dict_dst['item1']
+        assert Config._file2dict(cfg_file)[0]['item2'] == cfg_dict_dst['item2']
+        assert Config._file2dict(cfg_file)[0]['item3'] == cfg_dict_dst['item3']
+
+        os.environ.pop('ITEM1')
+        os.environ.pop('ITEM2')
+        os.environ.pop('ITEM3')
 
     def _merge_from_base(self):
         cfg_file = osp.join(self.data_path,

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -380,7 +380,7 @@ class TestConfig:
         cfg = tmp_path / 'tmp_cfg1.py'
         substituted_cfg = tmp_path / 'tmp_cfg2.py'
 
-        cfg_text = 'a={{$A}}\n'
+        cfg_text = 'a={{$A:}}\n'
         with open(cfg, 'w') as f:
             f.write(cfg_text)
         with pytest.raises(KeyError):

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -503,11 +503,17 @@ class TestConfig:
         assert Config._file2dict(cfg_file)[0]['item2'] == cfg_dict_dst['item2']
         assert Config._file2dict(cfg_file)[0]['item3'] == cfg_dict_dst['item3']
 
+        # test environment variable replacing function
+        assert Config._file2dict(cfg_file)[0]['item4'] == '/unit/test'
+        os.environ['MMENGINE'] = '/new/unit/test'
+        assert Config._file2dict(cfg_file)[0]['item4'] == '/new/unit/test'
+
         # test `use_predefined_variable=False`
         cfg_dict_ori = dict(
             item1='{{fileBasename}}',
             item2='{{ fileDirname}}',
-            item3='abc_{{ fileBasenameNoExtension }}')
+            item3='abc_{{ fileBasenameNoExtension }}',
+            item4='{{ $MMENGINE:/unit/test }}')
 
         assert Config._file2dict(cfg_file,
                                  False)[0]['item1'] == cfg_dict_ori['item1']
@@ -515,6 +521,8 @@ class TestConfig:
                                  False)[0]['item2'] == cfg_dict_ori['item2']
         assert Config._file2dict(cfg_file,
                                  False)[0]['item3'] == cfg_dict_ori['item3']
+        assert Config._file2dict(cfg_file,
+                                 False)[0]['item4'] == cfg_dict_ori['item4']
 
         # test test_predefined_var.yaml
         cfg_file = osp.join(self.data_path,

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -384,10 +384,10 @@ class TestConfig:
         with open(cfg, 'w') as f:
             f.write(cfg_text)
         with pytest.raises(KeyError):
-            Config._substitute_environment_vars(cfg, substituted_cfg)
+            Config._substitute_env_variables(cfg, substituted_cfg)
 
         os.environ['A'] = 'text_A'
-        Config._substitute_environment_vars(cfg, substituted_cfg)
+        Config._substitute_env_variables(cfg, substituted_cfg)
         with open(substituted_cfg) as f:
             assert f.read() == 'a=text_A\n'
         os.environ.pop('A')
@@ -395,12 +395,12 @@ class TestConfig:
         cfg_text = 'b={{$B:80}}\n'
         with open(cfg, 'w') as f:
             f.write(cfg_text)
-        Config._substitute_environment_vars(cfg, substituted_cfg)
+        Config._substitute_env_variables(cfg, substituted_cfg)
         with open(substituted_cfg) as f:
             assert f.read() == 'b=80\n'
 
         os.environ['B'] = '100'
-        Config._substitute_environment_vars(cfg, substituted_cfg)
+        Config._substitute_env_variables(cfg, substituted_cfg)
         with open(substituted_cfg) as f:
             assert f.read() == 'b=100\n'
         os.environ.pop('B')
@@ -408,7 +408,7 @@ class TestConfig:
         cfg_text = 'c={{"$C:80"}}\n'
         with open(cfg, 'w') as f:
             f.write(cfg_text)
-        Config._substitute_environment_vars(cfg, substituted_cfg)
+        Config._substitute_env_variables(cfg, substituted_cfg)
         with open(substituted_cfg) as f:
             assert f.read() == 'c=80\n'
 

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -514,9 +514,10 @@ class TestConfig:
                 filename = f'{file_format}_config/{name}.{file_format}'
 
                 cfg_file = osp.join(self.data_path, 'config', filename)
-                cfg_dict, cfg_text = Config._file2dict(cfg_file)
+                cfg_dict, cfg_text, env_variables = Config._file2dict(cfg_file)
                 assert isinstance(cfg_text, str)
                 assert isinstance(cfg_dict, dict)
+                assert isinstance(env_variables, dict)
 
     def _get_file_path(self, file_path):
         if platform.system() == 'Windows':


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Enable using environment variables in config files. Can make config more flexible.
### Example 1

demo_config.py
```
# dataset settings
dataset_type = 'CocoDataset'
data_root = '{{$MMDET_DATASET:/data/coco/}}'

# file_client_args = dict(
#     backend='petrel',
#     path_mapping=dict({
#         './data/': 's3://openmmlab/datasets/detection/',
#         'data/': 's3://openmmlab/datasets/detection/'
#     }))
file_client_args = dict(backend='disk')
```
test.py
```
from mmengine.config import Config

cfg = Config.fromfile('demo_config.py')
print(cfg)
```
The results of this pr are as below:
```
>> python test.py
Config (path: demo_config.py): {'dataset_type': 'CocoDataset', 'data_root': '/data/coco/', 'file_client_args': {'backend': 'disk'}}
>> MMDET_DATASET=/home/my_dataset/ python test.py
Config (path: demo_config.py): {'dataset_type': 'CocoDataset', 'data_root': '/home/my_dataset/', 'file_client_args': {'backend': 'disk'}}
```

### Example 2

demo_config.py
```
model=dict(
    bbox_head=dict(
        num_classes={{'$NUM_CLASSES:80'}}))
```

The results of this pr are as below:

```
>> python test.py
Config (path: demo_config.py): {'model': {'bbox_head': {'num_classes': 80}}}
>> NUM_CLASSES=20 python test.py
Config (path: demo_config.py): {'model': {'bbox_head': {'num_classes': 20}}}
```


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
