### PR TITLE
[Enhance] Support multiple `--cfg-options`.

### DIFF
--- a/docs/en/advanced_tutorials/config.md
+++ b/docs/en/advanced_tutorials/config.md
@@ -477,6 +477,19 @@ Config (path: ./example.py): {'model': {'type': 'CustomModel', 'in_channels': [1
 The standard procedure only supports modifying String, Integer, Floating Point, Boolean, None, List, and Tuple fields from the command line. For the elements of list and tuple instance, each of them must be one of the above seven types.
 ```
 
+:::{note}
+The behavior of `DictAction` is similar with `"extend"`. It stores a list, and extends each argument value to the list, like:
+
+```bash
+python demo_train.py ./example.py --cfg-options optimizer.type="Adam" --cfg-options model.in_channels="[1, 1, 1]"
+```
+
+```
+Config (path: ./example.py): {'model': {'type': 'CustomModel', 'in_channels': [1, 1, 1]}, 'optimizer': {'type': 'Adam', 'lr': 0.01}}
+```
+
+:::
+
 ### import the custom module
 
 If we customize a module and register it into the corresponding registry, could we directly build it from the configuration file as the previous [section](#how-to-use-config) does? The answer is "I don't know" since I'm not sure the registration process has been triggered. To solve this "unknown" case, `Config` provides the `custom_imports` function, to make sure your module could be registered as expected.

--- a/docs/zh_cn/advanced_tutorials/config.md
+++ b/docs/zh_cn/advanced_tutorials/config.md
@@ -477,6 +477,19 @@ Config (path: ./example.py): {'model': {'type': 'CustomModel', 'in_channels': [1
 上述流程只支持在命令行里修改字符串、整型、浮点型、布尔型、None、列表、元组类型的配置项。对于列表、元组类型的配置，里面每个元素的类型也必须为上述七种类型之一。
 ```
 
+:::{note}
+`DictAction` 的行为与 `"extend"` 相似，支持多次传递，并保存在同一个列表中。如
+
+```bash
+python demo_train.py ./example.py --cfg-options optimizer.type="Adam" --cfg-options model.in_channels="[1, 1, 1]"
+```
+
+```
+Config (path: ./example.py): {'model': {'type': 'CustomModel', 'in_channels': [1, 1, 1]}, 'optimizer': {'type': 'Adam', 'lr': 0.01}}
+```
+
+:::
+
 ### 导入自定义 Python 模块
 
 将配置与注册器结合起来使用时，如果我们往注册器中注册了一些自定义的类，就可能会遇到一些问题。因为读取配置文件的时候，这部分代码可能还没有被执行到，所以并未完成注册过程，从而导致构建自定义类的时候报错。

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -1029,7 +1029,8 @@ class DictAction(Action):
             option_string (list[str], optional): Option string.
                 Defaults to None.
         """
-        options = {}
+        # Copied behavior from `argparse._ExtendAction`.
+        options = copy.copy(getattr(namespace, self.dest, None) or {})
         if values is not None:
             for kv in values:
                 key, val = kv.split('=', maxsplit=1)

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -322,6 +322,14 @@ class TestConfig:
         assert cfg.item2 == dict(a=1, b=0.1, c='x')
         assert cfg.item3 is False
 
+        # test multiple options
+        args = parser.parse_args([
+            '--options', 'item1.a=1', 'item2.a=2', '--options', 'item2.a=1',
+            'item3=false'
+        ])
+        out_dict = {'item1.a': 1, 'item2.a': 1, 'item3': False}
+        assert args.options == out_dict
+
     def test_validate_py_syntax(self, tmp_path):
         tmp_cfg = tmp_path / 'tmp_config.py'
         with open(tmp_cfg, 'w') as f:


### PR DESCRIPTION
## Motivation

Sometimes, we want to create a bash script with some default `--cfg-options`, like
```bash
python tools/train.py $1 --cfg-options default_hooks.checkpoint.save_best=True ${@:2}
```
but when we use the script, and pass another `--cfg-options` to it, the last one will overwrite the previous completely.

## Modification

According to the [`extend` action](https://docs.python.org/3/library/argparse.html#action) of Python, I modified the `DictAction` in MMEngine, and now it supports multiple `--cfg-options` and will concat these options.

## BC-breaking (Optional)

Almost not, unless users exactly use multiple options and want the last one to overwrite the previous one.

## Use cases (Optional)

```bash
python tools/train.py $1 --cfg-options default_hooks.checkpoint.save_best=True --cfg-options train_cfg.max_epochs=300
```

And we will get both options.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
