### PR TITLE
[Feature] support `requires_grad` key in `paramwise_cfg`

### DIFF
--- a/mmengine/optim/optimizer/default_constructor.py
+++ b/mmengine/optim/optimizer/default_constructor.py
@@ -98,17 +98,20 @@ class DefaultOptimWrapperConstructor:
         >>> optim_wrapper = optim_wrapper_builder(model)
 
     Example 2:
-        >>> # assume model have attribute model.backbone and model.cls_head
+        >>> # assume model have attribute model.backbone, model.backbone.stem
+        >>> # and model.cls_head
         >>> optim_wrapper_cfg = dict(type='OptimWrapper', optimizer=dict(
         >>>     type='SGD', lr=0.01, weight_decay=0.95))
         >>> paramwise_cfg = dict(custom_keys={
-        >>>     'backbone': dict(lr_mult=0.1, decay_mult=0.9)})
+        >>>     'backbone': dict(lr_mult=0.1, decay_mult=0.9),
+        >>>     'backbone.stem': dict(requires_grad=False)})
         >>> optim_wrapper_builder = DefaultOptimWrapperConstructor(
         >>>     optim_wrapper_cfg, paramwise_cfg)
         >>> optim_wrapper = optim_wrapper_builder(model)
         >>> # Then the `lr` and `weight_decay` for model.backbone is
         >>> # (0.01 * 0.1, 0.95 * 0.9). `lr` and `weight_decay` for
-        >>> # model.cls_head is (0.01, 0.95).
+        >>> # model.cls_head is (0.01, 0.95). the `grad` is invalid
+        >>> # for model.backbone.stem.
     """
 
     def __init__(self,

--- a/mmengine/optim/optimizer/default_constructor.py
+++ b/mmengine/optim/optimizer/default_constructor.py
@@ -217,6 +217,9 @@ class DefaultOptimWrapperConstructor:
                     if self.base_wd is not None:
                         decay_mult = custom_keys[key].get('decay_mult', 1.)
                         param_group['weight_decay'] = self.base_wd * decay_mult
+                    requires_grad = custom_keys[key].get('requires_grad', True)
+                    if not requires_grad:
+                        param_group['params'][0].requires_grad = requires_grad
                     # add custom settings to param_group
                     for k, v in custom_keys[key].items():
                         param_group[k] = v

--- a/mmengine/optim/optimizer/default_constructor.py
+++ b/mmengine/optim/optimizer/default_constructor.py
@@ -219,7 +219,7 @@ class DefaultOptimWrapperConstructor:
                         param_group['weight_decay'] = self.base_wd * decay_mult
                     requires_grad = custom_keys[key].get('requires_grad', True)
                     if not requires_grad:
-                        param_group['params'][0].requires_grad = requires_grad
+                        param_group['params'][0].requires_grad_(requires_grad)
                     # add custom settings to param_group
                     for k, v in custom_keys[key].items():
                         param_group[k] = v

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -726,8 +726,13 @@ class TestBuilder(TestCase):
             for group, settings in zip(groups, group_settings):
                 if name in group:
                     for setting in settings:
-                        assert param_groups[i][setting] == settings[
-                            setting], f'{name} {setting}'
+                        if setting == 'requires_grad':
+                            assert param_groups[i][setting] == settings[
+                                setting] == param_groups[i]['params'][
+                                    0].requires_grad, f'{name} {setting}'
+                        else:
+                            assert param_groups[i][setting] == settings[
+                                setting], f'{name} {setting}'
 
 
 @unittest.skipIf(

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -636,7 +636,7 @@ class TestBuilder(TestCase):
             'momentum': self.momentum,
             'weight_decay': self.base_wd,
         })
-        # group 3, matches of 'sub'
+        # group 3, matches of 'sub.conv1'
         groups.append(['sub.conv1.weight', 'sub.conv1.bias'])
         group_settings.append({
             'lr': self.base_lr * 0.1,
@@ -674,7 +674,10 @@ class TestBuilder(TestCase):
             type='OptimWrapper',
             optimizer=dict(
                 type='SGD', lr=self.base_lr, momentum=self.momentum))
-        paramwise_cfg = dict(custom_keys={'param1': dict(lr_mult=10)})
+        paramwise_cfg = dict(custom_keys={
+            'param1': dict(lr_mult=10),
+            'sub.gn': dict(requires_grad=False)
+        })
 
         optim_constructor = DefaultOptimWrapperConstructor(
             optim_wrapper_cfg, paramwise_cfg)
@@ -697,11 +700,18 @@ class TestBuilder(TestCase):
             'momentum': self.momentum,
             'weight_decay': 0,
         })
-        # group 2, default group
+        # group 2, matches of 'sub.gn'
+        groups.append(['sub.gn.weight', 'sub.gn.bias'])
+        group_settings.append({
+            'lr': self.base_lr,
+            'momentum': self.momentum,
+            'weight_decay': 0,
+            'requires_grad': False,
+        })
+        # group 3, default group
         groups.append([
-            'sub.conv1.weight', 'sub.conv1.bias', 'sub.gn.weight',
-            'sub.gn.bias', 'conv1.weight', 'conv2.weight', 'conv2.bias',
-            'bn.weight', 'bn.bias'
+            'sub.conv1.weight', 'sub.conv1.bias', 'conv1.weight',
+            'conv2.weight', 'conv2.bias', 'bn.weight', 'bn.bias'
         ])
         group_settings.append({
             'lr': self.base_lr,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

issue[#750](https://github.com/open-mmlab/mmengine/issues/750)
```python
optim_wrapper = dict(
    type="OptimWrapper",
    optimizer=dict(type="AdamW", lr=lr, weight_decay=0.01),
    paramwise_cfg=dict(
        custom_keys={
            "backbone": dict(requires_grad=False), # lr_mult=0,
            "neck.conv0":dict(requiers_grad=False),
        }
    ),
)
```
1. it is flexible to detach any part of our model, e.g. backbone, neck, neck.xx, ...
2. more memory save than using lr_mult=0
3. it's friendly to all models without standard mmlab-style implementation

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
