### PR TITLE
[Enhance] Move noisy logs to DEBUG level.

### DIFF
--- a/mmengine/model/base_module.py
+++ b/mmengine/model/base_module.py
@@ -4,7 +4,6 @@ import logging
 import warnings
 from abc import ABCMeta
 from collections import defaultdict
-from logging import FileHandler
 from typing import Iterable, Optional
 
 import torch.nn as nn
@@ -141,25 +140,12 @@ class BaseModule(nn.Module, metaclass=ABCMeta):
         """
 
         logger = MMLogger.get_current_instance()
-        logger_name = logger.instance_name
-        with_file_handler = False
-        # dump the information to the logger file if there is a `FileHandler`
-        for handler in logger.handlers:
-            if isinstance(handler, FileHandler):
-                handler.stream.write(
-                    'Name of parameter - Initialization information\n')
-                for name, param in self.named_parameters():
-                    handler.stream.write(
-                        f'\n{name} - {param.shape}: '
-                        f"\n{self._params_init_info[param]['init_info']} \n")
-                handler.stream.flush()
-                with_file_handler = True
-        if not with_file_handler:
-            for name, param in self.named_parameters():
-                print_log(
-                    f'\n{name} - {param.shape}: '
-                    f"\n{self._params_init_info[param]['init_info']} \n ",
-                    logger=logger_name)
+
+        init_info = ['Name of parameter - Initialization information']
+        for name, param in self.named_parameters():
+            init_info.append(f'\n{name} - {param.shape}: '
+                             f"\n{self._params_init_info[param]['init_info']}")
+        logger.debug('\n'.join(init_info))
 
     def __repr__(self):
         s = super().__repr__()

--- a/mmengine/optim/optimizer/default_constructor.py
+++ b/mmengine/optim/optimizer/default_constructor.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import logging
 import warnings
 from typing import List, Optional, Union
 
@@ -255,7 +256,8 @@ class DefaultOptimWrapperConstructor:
                 full_name = f'{prefix}.{name}' if prefix else name
                 print_log(
                     f'paramwise_options -- {full_name}:{key}={value}',
-                    logger='current')
+                    logger='current',
+                    level=logging.DEBUG)
 
         if mmcv_full_available():
             from mmcv.ops import DeformConv2d, ModulatedDeformConv2d


### PR DESCRIPTION
## Motivation

The parameter initialization and optimizer options logs are too noisy! In most cases, they are useless but disturb us from checking output.

## Modification

Move these logs to DEBUG level, if you want them, set the `log_level` of runner to `"DEBUG"` to check them.

## BC-breaking (Optional)

No

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
