### PR TITLE
[Enhance] Support dump custom class in Config

### DIFF
--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import ast
 import copy
+import logging
 import os
 import os.path as osp
 import platform
@@ -723,7 +724,16 @@ class Config:
             if isinstance(v, str):
                 v_str = repr(v)
             else:
-                v_str = str(v)
+                try:
+                    ast.parse(str(v))
+                except SyntaxError:
+                    v_str = repr(str(v))
+                    print_log(
+                        f'Cannot parse the value: {v} of key "{k}"',
+                        logger='current',
+                        level=logging.WARNING)
+                else:
+                    v_str = str(v)
 
             if use_mapping:
                 k_str = f"'{k}'" if isinstance(k, str) else str(k)

--- a/tests/data/config/py_config/test_custom_class.py
+++ b/tests/data/config/py_config/test_custom_class.py
@@ -1,0 +1,5 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+class A:
+    ...
+
+item_a = dict(a=A)

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -274,6 +274,14 @@ class TestConfig:
         text_cfg = Config.fromfile(text_cfg_filename)
         assert text_cfg._cfg_dict == cfg._cfg_dict
 
+        cfg_file = osp.join(self.data_path,
+                            'config/py_config/test_custom_class.py')
+        cfg = Config.fromfile(cfg_file)
+        with open(text_cfg_filename, 'w') as f:
+            f.write(cfg.pretty_text)
+        text_cfg = Config.fromfile(text_cfg_filename)
+        assert text_cfg.item_a.a == ("<class 'A'>")
+
     def test_repr(self, tmp_path):
         cfg_file = osp.join(self.data_path,
                             'config/py_config/simple_config.py')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The original `Config` will raise an error when dumping a config with defining a custom type variable:
```python
# config.py
class A:
    ...

a = dict(a=A)

# read_config.py

cfg = Config.fromfile('config.py')
cfg.dump()
# yapf error
```

This PR allows `Config` to dump custom type variable.



## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
