### PR TITLE
[Fix] BaseModel & BaseDataPreprocessor `to` method to be consistent with torch.nn.Module

### DIFF
--- a/mmengine/model/base_model/base_model.py
+++ b/mmengine/model/base_model/base_model.py
@@ -155,9 +155,9 @@ class BaseModel(BaseModule):
 
         Returns:
             tuple[Tensor, dict]: There are two elements. The first is the
-                loss tensor passed to optim_wrapper which may be a weighted sum
-                of all losses, and the second is log_vars which will be sent to
-                the logger.
+            loss tensor passed to optim_wrapper which may be a weighted sum
+            of all losses, and the second is log_vars which will be sent to
+            the logger.
         """
         log_vars = []
         for loss_name, loss_value in losses.items():

--- a/mmengine/model/base_model/base_model.py
+++ b/mmengine/model/base_model/base_model.py
@@ -184,15 +184,7 @@ class BaseModel(BaseModule):
         Returns:
             nn.Module: The model itself.
         """
-        if 'device' in kwargs:
-            device = kwargs['device']
-        elif args:
-            try:
-                device = torch.device(args[0])
-            except TypeError:
-                device = None
-        else:
-            device = None
+        device = torch._C._nn._parse_to(*args, **kwargs)[0]
         if device is not None:
             self._set_device(torch.device(device))
         return super().to(*args, **kwargs)

--- a/mmengine/model/base_model/base_model.py
+++ b/mmengine/model/base_model/base_model.py
@@ -177,23 +177,25 @@ class BaseModel(BaseModule):
 
         return loss, log_vars  # type: ignore
 
-    def to(self,
-           device: Optional[Union[int, str, torch.device]] = None,
-           *args,
-           **kwargs) -> nn.Module:
+    def to(self, *args, **kwargs) -> nn.Module:
         """Overrides this method to call :meth:`BaseDataPreprocessor.to`
         additionally.
-
-        Args:
-            device (int, str or torch.device, optional): the desired device
-                of the parameters and buffers in this module.
 
         Returns:
             nn.Module: The model itself.
         """
+        if 'device' in kwargs:
+            device = kwargs['device']
+        elif args:
+            try:
+                device = torch.device(args[0])
+            except TypeError:
+                device = None
+        else:
+            device = None
         if device is not None:
             self._set_device(torch.device(device))
-        return super().to(device)
+        return super().to(*args, **kwargs)
 
     def cuda(
         self,

--- a/mmengine/model/base_model/base_model.py
+++ b/mmengine/model/base_model/base_model.py
@@ -155,9 +155,9 @@ class BaseModel(BaseModule):
 
         Returns:
             tuple[Tensor, dict]: There are two elements. The first is the
-            loss tensor passed to optim_wrapper which may be a weighted sum of
-            all losses, and the second is log_vars which will be sent to the
-            logger.
+                loss tensor passed to optim_wrapper which may be a weighted sum
+                of all losses, and the second is log_vars which will be sent to
+                the logger.
         """
         log_vars = []
         for loss_name, loss_value in losses.items():
@@ -238,7 +238,7 @@ class BaseModel(BaseModule):
 
         Args:
             device (torch.device): the desired device of the parameters and
-                    buffers in this module.
+                buffers in this module.
         """
 
         def apply_fn(module):

--- a/mmengine/model/base_model/data_preprocessor.py
+++ b/mmengine/model/base_model/data_preprocessor.py
@@ -84,19 +84,16 @@ class BaseDataPreprocessor(nn.Module):
     def device(self):
         return self._device
 
-    def to(self, device: Optional[Union[int, torch.device]], *args,
-           **kwargs) -> nn.Module:
+    def to(self, *args, **kwargs) -> nn.Module:
         """Overrides this method to set the :attr:`device`
-
-        Args:
-            device (int or torch.device, optional): The desired device of the
-                parameters and buffers in this module.
 
         Returns:
             nn.Module: The model itself.
         """
-        self._device = torch.device(device)
-        return super().to(device)
+        device = torch._C._nn._parse_to(*args, **kwargs)[0]
+        if device is not None:
+            self._device = torch.device(device)
+        return super().to(*args, **kwargs)
 
     def cuda(self, *args, **kwargs) -> nn.Module:
         """Overrides this method to set the :attr:`device`

--- a/tests/test_model/test_base_model/test_base_model.py
+++ b/tests/test_model/test_base_model/test_base_model.py
@@ -1,15 +1,29 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import itertools
 import unittest
 from unittest import TestCase
 
 import torch
 import torch.nn as nn
+from parameterized import parameterized
 from torch.optim import SGD
 
 from mmengine.model import BaseDataPreprocessor, BaseModel
 from mmengine.optim import OptimWrapper
 from mmengine.registry import MODELS
 from mmengine.testing import assert_allclose
+
+dtypes_to_test = [torch.float16, torch.float32, torch.float64, torch.half]
+
+cpu_devices = ['cpu', torch.device('cpu')]
+cuda_devices = ['cuda', 0, torch.device('cuda')]
+devices_to_test = cpu_devices
+if torch.cuda.is_available():
+    devices_to_test += cuda_devices
+
+
+def list_product(*args):
+    return list(itertools.product(*args))
 
 
 @MODELS.register_module()
@@ -158,3 +172,32 @@ class TestBaseModel(TestCase):
         self.assertEqual(model.data_preprocessor._device, torch.device('cuda'))
         self.assertEqual(model.toy_model.data_preprocessor._device,
                          torch.device('cuda'))
+
+    @parameterized.expand(list_product(devices_to_test))
+    def test_to_device(self, device):
+        model = ToyModel().to(device)
+        self.assertTrue(
+            all(p.device.type == torch.device(device).type
+                for p in model.parameters())
+            and model.data_preprocessor._device == torch.device(device))
+
+    @parameterized.expand(list_product(dtypes_to_test))
+    def test_to_dtype(self, dtype):
+        model = ToyModel().to(dtype)
+        self.assertTrue(all(p.dtype == dtype for p in model.parameters()))
+
+    @parameterized.expand(
+        list_product(devices_to_test, dtypes_to_test,
+                     ['args', 'kwargs', 'hybrid']))
+    def test_to_device_and_dtype(self, device, dtype, mode):
+        if mode == 'args':
+            model = ToyModel().to(device, dtype)
+        elif mode == 'kwargs':
+            model = ToyModel().to(device=device, dtype=dtype)
+        elif mode == 'hybrid':
+            model = ToyModel().to(device, dtype=dtype)
+        self.assertTrue(
+            all(p.dtype == dtype for p in model.parameters())
+            and model.data_preprocessor._device == torch.device(device)
+            and all(p.device.type == torch.device(device).type
+                    for p in model.parameters()))


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Make `BaseModel.to` and `BaseDataPreprocessor.to` methods to be consistent with `torch.nn.Module.to`, i.e. it can accept devices and dtypes as arguments and handle these cases properly.

Before this PR:

```python
class Model(BaseModel):
    def __init__(self):
        super().__init__()
        self.linear = nn.Linear(4, 4)
    def forward(self):
        pass

model = Model()
model.to('cuda')  # correct
model.to(torch.half)  # raise TypeError
model.to(device='cuda', dtype=torch.half)  # no exception, but dtype ignored
```

After this PR:

```python
model.to('cuda')
model.to(torch.half)
model.to('cpu', torch.float64)
model.to('cpu', dtype=torch.float64)
model.to(torch.half, device='cpu')  # error, this is not supported by nn.Module
```

## Modification

As in PR

## BC-breaking (Optional)

Probably, because before this PR `dtype` kwargs are ignored

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
