### PR TITLE
[Fix] hub.get_model fails on some mmcls models

### DIFF
--- a/mmengine/hub/hub.py
+++ b/mmengine/hub/hub.py
@@ -75,6 +75,8 @@ def get_model(cfg_path: str, pretrained: bool = False, **kwargs):
     package = cfg_path.split('::')[0]
     with DefaultScope.overwrite_default_scope(package):  # type: ignore
         cfg = get_config(cfg_path, pretrained)
+        if 'data_preprocessor' in cfg:
+            cfg.model.data_preprocessor = cfg.data_preprocessor
         models_module = importlib.import_module(f'{package}.utils')
         models_module.register_all_modules()  # type: ignore
         model = MODELS.build(cfg.model, default_args=kwargs)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

mmcls moved some `data_preprocessor` field to config file's root field, instead of model's field. Runner changed logic to adapt to this change, but hub didn't.

Before this PR:

```python
model = mmengine.hub.get_model('mmcls::deit/deit-small_pt-4xb256_in1k.py')
model.data_preprocessor.num_classes
# got None, which lead to error in training
```

After this PR:

```python
model = mmengine.hub.get_model('mmcls::deit/deit-small_pt-4xb256_in1k.py')
model.data_preprocessor.num_classes
# got 1000
```

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
