### PR TITLE
[Fix] Fix creating a new logger at PretrainedInit

### DIFF
--- a/mmengine/model/weight_init.py
+++ b/mmengine/model/weight_init.py
@@ -481,7 +481,7 @@ class PretrainedInit:
         from mmengine.runner.checkpoint import (_load_checkpoint_with_prefix,
                                                 load_checkpoint,
                                                 load_state_dict)
-        logger = MMLogger.get_instance('mmengine')
+        logger = MMLogger.get_current_instance()
         if self.prefix is None:
             print_log(f'load model from: {self.checkpoint}', logger=logger)
             load_checkpoint(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When training with a pre-trained model, MMEngine will create a new logger.

## Modification

Use `MMLogger.get_current_instance()` instead of `MMLogger.get_instance('mmengine')`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.


