### PR TITLE
[Fix] Add preprocess inputs to inference

### DIFF
--- a/docs/en/api/infer.rst
+++ b/docs/en/api/infer.rst
@@ -1,7 +1,7 @@
 .. role:: hidden
     :class: hidden-section
 
-mmengine.hub
+mmengine.infer
 ===================================
 
 .. currentmodule:: mmengine.infer
@@ -9,5 +9,6 @@ mmengine.hub
 .. autosummary::
    :toctree: generated
    :nosignatures:
+   :template: classtemplate.rst
 
    BaseInferencer

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -80,6 +80,7 @@ You can switch between Chinese and English documents in the lower-left corner of
    mmengine.evaluator <api/evaluator>
    mmengine.structures <api/structures>
    mmengine.dataset <api/dataset>
+   mmengine.infer <api/infer>
    mmengine.device <api/device>
    mmengine.hub <api/hub>
    mmengine.logging <api/logging>

--- a/docs/zh_cn/api/infer.rst
+++ b/docs/zh_cn/api/infer.rst
@@ -1,7 +1,7 @@
 .. role:: hidden
     :class: hidden-section
 
-mmengine.hub
+mmengine.infer
 ===================================
 
 .. currentmodule:: mmengine.infer
@@ -9,5 +9,6 @@ mmengine.hub
 .. autosummary::
    :toctree: generated
    :nosignatures:
+   :template: classtemplate.rst
 
    BaseInferencer

--- a/docs/zh_cn/index.rst
+++ b/docs/zh_cn/index.rst
@@ -80,6 +80,7 @@
    mmengine.evaluator <api/evaluator>
    mmengine.structures <api/structures>
    mmengine.dataset <api/dataset>
+   mmengine.infer <api/infer>
    mmengine.device <api/device>
    mmengine.hub <api/hub>
    mmengine.logging <api/logging>

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -203,7 +203,7 @@ class BaseInferencer(metaclass=InferencerMeta):
             postprocess_kwargs,
         ) = self._dispatch_kwargs(**kwargs)
 
-        ori_inputs = self.preprocess_inputs(inputs)
+        ori_inputs = self._inputs_to_list(inputs)
         inputs = self.preprocess(
             ori_inputs, batch_size=batch_size, **preprocess_kwargs)
         preds = []
@@ -216,15 +216,17 @@ class BaseInferencer(metaclass=InferencerMeta):
                                    **postprocess_kwargs)
         return results
 
-    def preprocess_inputs(self, inputs: InputsType) -> list:
+    def _inputs_to_list(self, inputs: InputsType) -> list:
         """Preprocess the inputs to a list.
 
         Preprocess inputs to a list according to its type:
 
-            - list or tuple: return inputs
-            - str:
-                - Directory path: return all files in the directory
-                - normal string: return a list containing the string
+        - list or tuple: return inputs
+        - str:
+            - Directory path: return all files in the directory
+            - other cases: return a list containing the string. The string
+              could be a path to file, a url or other types of string according
+              to the task.
 
         Args:
             inputs (InputsType): Inputs for the inferencer.

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -216,7 +216,7 @@ class BaseInferencer(metaclass=InferencerMeta):
                                    **postprocess_kwargs)
         return results
 
-    def preprocess_inputs(self, inputs: InputsType):
+    def preprocess_inputs(self, inputs: InputsType) -> list:
         """Preprocess the inputs to a list.
 
         Preprocess inputs to a list according to its type:
@@ -225,6 +225,12 @@ class BaseInferencer(metaclass=InferencerMeta):
             - str:
                 - Directory path: return all files in the directory
                 - normal string: return a list containing the string
+
+        Args:
+            inputs (InputsType): Inputs for the inferencer.
+
+        Returns:
+            list: List of input for the :meth:`preprocess`.
         """
         if isinstance(inputs, str):
             backend = get_file_backend(inputs)
@@ -237,10 +243,10 @@ class BaseInferencer(metaclass=InferencerMeta):
                     join_path(inputs, filename) for filename in filename_list
                 ]
 
-        if not isinstance(inputs, list):
+        if not isinstance(inputs, (list, tuple)):
             inputs = [inputs]
 
-        return inputs
+        return list(inputs)
 
     def preprocess(self, inputs: InputsType, batch_size: int = 1, **kwargs):
         """Process the inputs into a model-feedable format.

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -296,7 +296,7 @@ class BaseInferencer(metaclass=InferencerMeta):
         other objects.
 
         Args:
-            inputs (list): Inputs preprocessed by :meth:`preprocess`.
+            inputs (list): Inputs preprocessed by :meth:`_inputs_to_list`.
             preds (Any): Predictions of the model.
             show (bool): Whether to display the image in a popup window.
                 Defaults to False.

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -338,10 +338,10 @@ class BaseInferencer(metaclass=InferencerMeta):
 
             - ``visualization (Any)``: Returned by :meth:`visualize`
             - ``predictions`` (dict or DataSample): Returned by
-                :meth:`forward` and processed in :meth:`postprocess`.
-                If ``return_datasample=False``, it usually should be a
-                json-serializable dict containing only basic data elements such
-                as strings and numbers.
+              :meth:`forward` and processed in :meth:`postprocess`.
+              If ``return_datasample=False``, it usually should be a
+              json-serializable dict containing only basic data elements such
+              as strings and numbers.
         """
 
     def _load_model_from_metafile(self, model: str) -> Tuple[Config, str]:

--- a/tests/test_infer/test_infer.py
+++ b/tests/test_infer/test_infer.py
@@ -194,8 +194,9 @@ class TestBaseInferencer(RunnerTestCase):
             img = np.array(1)
             img.dump(osp.join(self.temp_dir.name, 'imgs', f'{i}.npy'))
         # Test with directory inputs
-        dataloader = inferencer.preprocess(
+        inputs = inferencer.preprocess_inputs(
             osp.join(self.temp_dir.name, 'imgs'))
+        dataloader = inferencer.preprocess(inputs, batch_size=3)
         for data in dataloader:
             self.assertTrue(is_list_of(data, torch.Tensor))
 

--- a/tests/test_infer/test_infer.py
+++ b/tests/test_infer/test_infer.py
@@ -194,7 +194,7 @@ class TestBaseInferencer(RunnerTestCase):
             img = np.array(1)
             img.dump(osp.join(self.temp_dir.name, 'imgs', f'{i}.npy'))
         # Test with directory inputs
-        inputs = inferencer.preprocess_inputs(
+        inputs = inferencer._inputs_to_list(
             osp.join(self.temp_dir.name, 'imgs'))
         dataloader = inferencer.preprocess(inputs, batch_size=3)
         for data in dataloader:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`inferencer.visualize` needs the original inputs rather than the preprocessed inputs to show the visualization result, therefore we need to pass the original inputs to `visualize`. 

This PR extract some logics from `preprocess` to `preprocess_data`, which is responsible for listing the files from a directory and converting the inputs to a list. `__call__` will call preprocess_data and pass the returned value to `visualize`

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
