### PR TITLE
[Fix] ZeroRedundancyOptimizer ambiguous error with param groups when pytorch < 1.12.0

### DIFF
--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -39,6 +39,10 @@ class ZeroRedundancyOptimizer(_ZeroRedundancyOptimizer):
     Warnings:
         ``ZeroRedundancyOptimizer`` requires PyTorch >= 1.8.
 
+    Warnings:
+        ``ZeroRedundancyOptimizer`` requires PyTorch >= 1.12 to enable param
+        param groups.
+
     Args:
         params (``Iterable``): an ``Iterable`` of :class:`torch.Tensor` s
             or :class:`dict` s giving all parameters, which will be sharded

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -53,6 +53,15 @@ class ZeroRedundancyOptimizer(_ZeroRedundancyOptimizer):
             '`torch.distributed.optim.ZeroReundancyOptimizer` is only '
             'available when pytorch version >= 1.8.')
         assert is_available(), 'torch.distributed.rpc is not available.'
+        # Avoid the generator becoming empty after the following check
+        params = list(params)
+        assert (
+            all(isinstance(p, torch.Tensor) for p in params)
+            or digit_version(TORCH_VERSION) >= digit_version('1.12.0')), (
+                'PyTorch ZeroRedundancyOptimizer started to support param '
+                'groups since 1.12.0. Please update your pytorch version to '
+                'enable this feature, or disable param groups by deleting '
+                '`paramwise_cfg` filed in config file.')
         optimizer_class = getattr(torch.optim, optimizer_type)
         # TODO: Register a DDP communication hook for `overlap_with_ddp=True`.
         # Currently only `overlap_with_ddp=False` is supported. For more

--- a/mmengine/optim/optimizer/zero_optimizer.py
+++ b/mmengine/optim/optimizer/zero_optimizer.py
@@ -41,7 +41,7 @@ class ZeroRedundancyOptimizer(_ZeroRedundancyOptimizer):
 
     Warnings:
         ``ZeroRedundancyOptimizer`` requires PyTorch >= 1.12 to enable param
-        param groups.
+        groups.
 
     Args:
         params (``Iterable``): an ``Iterable`` of :class:`torch.Tensor` s

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 from torch.distributed.rpc import is_available
 
+from mmengine.dist import get_rank
 from mmengine.optim import (OPTIM_WRAPPER_CONSTRUCTORS, OPTIMIZERS,
                             DefaultOptimWrapperConstructor, OptimWrapper,
                             build_optim_wrapper)
@@ -744,7 +745,7 @@ class TestZeroOptimizer(MultiProcessTestCase):
             all(param in params_set for param_group in param_groups
                 for param in param_group['params']))
         state_dict = optimizer.state_dict()
-        if torch.distributed.get_rank() == 0:
+        if get_rank() == 0:
             self.assertEqual(
                 sum(len(pg['params']) for pg in state_dict['param_groups']),
                 len(params_set))

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -786,7 +786,11 @@ class TestZeroOptimizer(MultiProcessTestCase):
         self.base_wd = 0.9
 
         # test build function
-        paramwise_cfg = dict(conv1_lr_mult=1)
+        paramwise_cfg = dict(
+            custom_keys={
+                'conv1': dict(lr_mult=0.0, decay_mult=0.0),
+                'conv2': dict(lr_mult=1.0, decay_mult=2.0)
+            })
         optim_wrapper_cfg = dict(
             optimizer=dict(
                 type='ZeroRedundancyOptimizer',

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -735,29 +735,18 @@ class TestZeroOptimizer(MultiProcessTestCase):
         self.assertEqual(optimizer.defaults['lr'], self.base_lr)
         self.assertEqual(optimizer.defaults['momentum'], self.momentum)
         self.assertEqual(optimizer.defaults['weight_decay'], self.base_wd)
-        param_groups = optimizer.param_groups[0]
-        if MMCV_FULL_AVAILABLE:
-            param_names = [
-                'param1', 'conv1.weight', 'conv2.weight', 'conv2.bias',
-                'bn.weight', 'bn.bias', 'sub.param1', 'sub.conv1.weight',
-                'sub.conv1.bias', 'sub.gn.weight', 'sub.gn.bias', 'dcn.weight',
-                'dcn.conv_offset.weight', 'dcn.conv_offset.bias'
-            ]
-        else:
-            param_names = [
-                'param1', 'conv1.weight', 'conv2.weight', 'conv2.bias',
-                'bn.weight', 'bn.bias', 'sub.param1', 'sub.conv1.weight',
-                'sub.conv1.bias', 'sub.gn.weight', 'sub.gn.bias'
-            ]
-        param_dict = dict(model.named_parameters())
-        self.assertEqual(len(param_groups['params']), len(param_names))
-        for i in range(len(param_groups['params'])):
-            assert torch.equal(param_groups['params'][i],
-                               param_dict[param_names[i]])
+        param_groups = optimizer.param_groups
+        params_set = set(model.parameters())
+        self.assertEqual(
+            sum(len(param_group['params']) for param_group in param_groups),
+            len(params_set))
+        self.assertTrue(
+            all(param in params_set for param_group in param_groups
+                for param in param_group['params']))
 
     def test_build_zero_redundancy_optimizer(self):
-        from torch.distributed.optim import ZeroRedundancyOptimizer
         self._init_dist_env(self.rank, self.world_size)
+        from mmengine.optim.optimizer import ZeroRedundancyOptimizer
         model = ExampleModel()
         self.base_lr = 0.01
         self.momentum = 0.0001
@@ -784,6 +773,31 @@ class TestZeroOptimizer(MultiProcessTestCase):
                     weight_decay=self.base_wd,
                     momentum=self.momentum))
             optim_wrapper = build_optim_wrapper(model, optim_wrapper_cfg)
+
+    @unittest.skipIf(
+        digit_version(TORCH_VERSION) < digit_version('1.12.0'),
+        reason='ZeRO started to support param groups since pytorch 1.12.0')
+    def test_build_zero_redundancy_optimizer_with_paramwise_cfg(self):
+        self._init_dist_env(self.rank, self.world_size)
+        from mmengine.optim.optimizer import ZeroRedundancyOptimizer
+        model = ExampleModel()
+        self.base_lr = 0.01
+        self.momentum = 0.0001
+        self.base_wd = 0.9
+
+        # test build function
+        paramwise_cfg = dict(conv1_lr_mult=1)
+        optim_wrapper_cfg = dict(
+            optimizer=dict(
+                type='ZeroRedundancyOptimizer',
+                optimizer_type='SGD',
+                lr=self.base_lr,
+                weight_decay=self.base_wd,
+                momentum=self.momentum),
+            paramwise_cfg=paramwise_cfg)
+        optim_wrapper = build_optim_wrapper(model, optim_wrapper_cfg)
+        self.assertIsInstance(optim_wrapper.optimizer, ZeroRedundancyOptimizer)
+        self._check_default_optimizer(optim_wrapper.optimizer, model)
 
     def _init_dist_env(self, rank, world_size):
         """Initialize the distributed environment."""


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

See issue #778 

## Modification

Add check for param groups and torch version, and give a better instruction to users.

## BC-breaking (Optional)

No

## Use cases (Optional)

Same as before

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
