### PR TITLE
[Refactor] runner save & load checkpoint

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1911,8 +1911,7 @@ class Runner:
                resume_param_scheduler: bool = True,
                map_location: Union[str, Callable] = 'default',
                strict: bool = False,
-               revise_keys: list = [(r'^module.', '')],
-               custom_callbacks: List[Callable] = []) -> None:
+               revise_keys: list = [(r'^module.', '')]) -> None:
         """Resume everything from checkpoint once specified.
 
         Args:
@@ -1940,10 +1939,6 @@ class Runner:
                 before loaded to the model. Only take effect when
                 ``resume_model=True``.
                 Defaults to [(r'^module.', '')].
-            custom_callbacks (list): A list of callable as callback functions.
-                Each callback function will receive runner and checkpoint as
-                its arguments, i.e. invoked as func(runner, checkpoint)
-                Defaults to []
         """
         device = get_device() if map_location == 'default' else map_location
         checkpoint = _load_checkpoint(filename, map_location=device)
@@ -1963,9 +1958,6 @@ class Runner:
 
         if resume_param_scheduler:
             self.resume_param_scheduler(checkpoint)
-
-        for callback in custom_callbacks:
-            callback(self, checkpoint)
 
         self.logger.info(f'resumed epoch: {self.epoch}, iter: {self.iter}')
         self._has_loaded = True


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1. Eliminate misdirection in function name. 
> `load_checkpoint()` not only load and return the checkpoint, but also load its `state_dict` field to `runner.model`. Besides, `resume()` depends on this behavior, which might be misleading.
2. Make checkpoint related functions friendly for overriding. This should help integration with other frameworks.

## Modification

1. `runner.load_checkpoint()` functionality merged into `resume()`. Now, `resume(...)` is equivalent to the former `resume()`, while `resume(resume_model=True, resume_xxx=False)` is equivalent to the former `load_checkpoint()`
2. Mark `load_checkpoint()` as deprecated
3. Split `resume()` and `save_checkpoint()` into multiple small functions. This should make `Runner` more friendly to overriding.

## BC-breaking (Optional)

No

## Use cases (Optional)

Use `resume(resume_model=True, resume_xxx=False)` instead of `load_checkpoint()`

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
