### PR TITLE
[Enhance] Support non-scalar type metric value.

### DIFF
--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -280,9 +280,7 @@ class LoggerHook(Hook):
                 return value.tolist()
             # Drop unsupported values.
 
-        processed_tags = OrderedDict(
-            {k: process_val(v)
-             for k, v in tags.items()})
+        processed_tags = OrderedDict(process_val(tags))
 
         return processed_tags
 

--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -2,8 +2,12 @@
 import os
 import os.path as osp
 import warnings
+from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, Optional, Sequence, Union
+
+import numpy as np
+import torch
 
 from mmengine.fileio import FileClient, dump
 from mmengine.fileio.io import get_file_backend
@@ -254,7 +258,33 @@ class LoggerHook(Hook):
         tag, log_str = runner.log_processor.get_log_after_epoch(
             runner, len(runner.test_dataloader), 'test')
         runner.logger.info(log_str)
-        dump(tag, osp.join(runner.log_dir, self.json_log_path))  # type: ignore
+        dump(
+            self._process_tags(tag),
+            osp.join(runner.log_dir, self.json_log_path))  # type: ignore
+
+    @staticmethod
+    def _process_tags(tags: dict):
+        """Convert tag values to json-friendly type."""
+
+        def process_val(value):
+            if isinstance(value, (list, tuple)):
+                # Array type of json
+                return [process_val(item) for item in value]
+            elif isinstance(value, dict):
+                # Object type of json
+                return {k: process_val(v) for k, v in value.items()}
+            elif isinstance(value, (str, int, float, bool)) or value is None:
+                # Other supported type of json
+                return value
+            elif isinstance(value, (torch.Tensor, np.ndarray)):
+                return value.tolist()
+            # Drop unsupported values.
+
+        processed_tags = OrderedDict(
+            {k: process_val(v)
+             for k, v in tags.items()})
+
+        return processed_tags
 
     def after_run(self, runner) -> None:
         """Copy logs to ``self.out_dir`` if ``self.out_dir is not None``

--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -256,7 +256,7 @@ class LoggerHook(Hook):
                 metrics, and the values are corresponding results.
         """
         tag, log_str = runner.log_processor.get_log_after_epoch(
-            runner, len(runner.test_dataloader), 'test')
+            runner, len(runner.test_dataloader), 'test', with_non_scalar=True)
         runner.logger.info(log_str)
         dump(
             self._process_tags(tag),

--- a/mmengine/hooks/runtime_info_hook.py
+++ b/mmengine/hooks/runtime_info_hook.py
@@ -1,5 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
+
+import numpy as np
+import torch
 
 from mmengine.registry import HOOKS
 from mmengine.utils import get_git_hash
@@ -7,6 +10,24 @@ from mmengine.version import __version__
 from .hook import Hook
 
 DATA_BATCH = Optional[Union[dict, tuple, list]]
+
+
+def _is_scalar(value: Any) -> bool:
+    """Determine the value is a scalar type value.
+
+    Args:
+        value (Any): value of log.
+
+    Returns:
+        bool: whether the value is a scalar type value.
+    """
+    if isinstance(value, np.ndarray):
+        return value.size == 1
+    elif isinstance(value, (int, float)):
+        return True
+    elif isinstance(value, torch.Tensor):
+        return value.numel() == 1
+    return False
 
 
 @HOOKS.register_module()
@@ -112,7 +133,10 @@ class RuntimeInfoHook(Hook):
         """
         if metrics is not None:
             for key, value in metrics.items():
-                runner.message_hub.update_scalar(f'val/{key}', value)
+                if _is_scalar(value):
+                    runner.message_hub.update_scalar(f'val/{key}', value)
+                else:
+                    runner.logger.info(f'{key}:\n{value}')
 
     def after_test_epoch(self,
                          runner,
@@ -128,4 +152,7 @@ class RuntimeInfoHook(Hook):
         """
         if metrics is not None:
             for key, value in metrics.items():
-                runner.message_hub.update_scalar(f'test/{key}', value)
+                if _is_scalar(value):
+                    runner.message_hub.update_scalar(f'test/{key}', value)
+                else:
+                    runner.logger.info(f'{key}:\n{value}')

--- a/mmengine/hooks/runtime_info_hook.py
+++ b/mmengine/hooks/runtime_info_hook.py
@@ -136,7 +136,7 @@ class RuntimeInfoHook(Hook):
                 if _is_scalar(value):
                     runner.message_hub.update_scalar(f'val/{key}', value)
                 else:
-                    runner.logger.info(f'{key}:\n{value}')
+                    runner.message_hub.update_info(f'val/{key}', value)
 
     def after_test_epoch(self,
                          runner,
@@ -155,4 +155,4 @@ class RuntimeInfoHook(Hook):
                 if _is_scalar(value):
                     runner.message_hub.update_scalar(f'test/{key}', value)
                 else:
-                    runner.logger.info(f'{key}:\n{value}')
+                    runner.message_hub.update_info(f'test/{key}', value)

--- a/tests/test_hooks/test_logger_hook.py
+++ b/tests/test_hooks/test_logger_hook.py
@@ -3,7 +3,9 @@ import os.path as osp
 from unittest.mock import ANY, MagicMock
 
 import pytest
+import torch
 
+from mmengine.fileio import load
 from mmengine.fileio.file_client import HardDiskBackend
 from mmengine.hooks import LoggerHook
 
@@ -178,12 +180,17 @@ class TestLoggerHook:
         runner.log_dir = tmp_path
         runner.timestamp = 'test_after_test_epoch'
         runner.log_processor.get_log_after_epoch = MagicMock(
-            return_value=(dict(a=1, b=2), 'log_str'))
+            return_value=(
+                dict(a=1, b=2, c={'list': [1, 2]}, d=torch.tensor([1, 2, 3])),
+                'log_str'))
         logger_hook.before_run(runner)
         logger_hook.after_test_epoch(runner)
         runner.log_processor.get_log_after_epoch.assert_called()
         runner.logger.info.assert_called()
         osp.isfile(osp.join(runner.log_dir, 'test_after_test_epoch.json'))
+        json_content = load(
+            osp.join(runner.log_dir, 'test_after_test_epoch.json'))
+        assert json_content == dict(a=1, b=2, c={'list': [1, 2]}, d=[1, 2, 3])
 
     def test_after_val_iter(self):
         logger_hook = LoggerHook()

--- a/tests/test_runner/test_log_processor.py
+++ b/tests/test_runner/test_log_processor.py
@@ -144,19 +144,28 @@ class TestLogProcessor:
         # Prepare LoggerHook
         log_processor = LogProcessor(by_epoch=by_epoch)
         # Prepare validation information.
-        val_logs = dict(accuracy=0.9, data_time=1.0)
-        log_processor._collect_scalars = MagicMock(return_value=val_logs)
+        scalar_logs = dict(accuracy=0.9, data_time=1.0)
+        non_scalar_logs = dict(
+            recall={
+                'cat': 1,
+                'dog': 0
+            }, cm=torch.tensor([1, 2, 3]))
+        log_processor._collect_scalars = MagicMock(return_value=scalar_logs)
+        log_processor._collect_non_scalars = MagicMock(
+            return_value=non_scalar_logs)
         _, out = log_processor.get_log_after_epoch(self.runner, 2, mode)
+        expect_metric_str = ("accuracy: 0.9000  recall: {'cat': 1, 'dog': 0}  "
+                             'cm: \ntensor([1, 2, 3])\n')
         if by_epoch:
             if mode == 'test':
-                assert out == 'Epoch(test) [5/5]  accuracy: 0.9000'
+                assert out == 'Epoch(test) [5/5]  ' + expect_metric_str
             else:
-                assert out == 'Epoch(val) [1][10/10]  accuracy: 0.9000'
+                assert out == 'Epoch(val) [1][10/10]  ' + expect_metric_str
         else:
             if mode == 'test':
-                assert out == 'Iter(test) [5/5]  accuracy: 0.9000'
+                assert out == 'Iter(test) [5/5]  ' + expect_metric_str
             else:
-                assert out == 'Iter(val) [10/10]  accuracy: 0.9000'
+                assert out == 'Iter(val) [10/10]  ' + expect_metric_str
 
     def test_collect_scalars(self):
         history_count = np.ones(100)
@@ -195,6 +204,21 @@ class TestLogProcessor:
             copy.deepcopy(custom_cfg), self.runner, mode='val')
         assert list(tag.keys()) == ['metric']
         assert tag['metric'] == metric_scalars[-1]
+
+    def test_collect_non_scalars(self):
+        metric1 = np.random.rand(10)
+        metric2 = torch.tensor(10)
+
+        log_processor = LogProcessor()
+        # Collect with prefix.
+        log_infos = {'test/metric1': metric1, 'test/metric2': metric2}
+        self.runner.message_hub._runtime_info = log_infos
+        tag = log_processor._collect_non_scalars(self.runner, mode='test')
+        # Test training key in tag.
+        assert list(tag.keys()) == ['metric1', 'metric2']
+        # Test statistics lr with `current`, loss and time with 'mean'
+        assert tag['metric1'] is metric1
+        assert tag['metric2'] is metric2
 
     @patch('torch.cuda.max_memory_allocated', MagicMock())
     @patch('torch.cuda.reset_peak_memory_stats', MagicMock())


### PR DESCRIPTION
## Motivation

In the original implementation, the `RuntimeInfoHook` will raise an error if the metric value is not a scalar. But some metric result is non-scalar type, like confusion-matrix.

## Modification

If the metric value is not scalar, the value will be saved into the `runtime_info`. And in the `LogProcessor`, it will extract runtime info according to the mode.

## BC-breaking (Optional)

No

## Use cases (Optional)

```
01/10 10:59:49 - mmengine - INFO - Load checkpoint from /home/PJLAB/mazerun/ckpt/v0/resnet/resnet18_b16x8_cifar10_20210528-bd6371c8.pth
01/10 10:59:51 - mmengine - INFO - Epoch(test) [100/625]    eta: 0:00:08  time: 0.0068  data_time: 0.0001  memory: 84  
01/10 10:59:51 - mmengine - INFO - Epoch(test) [200/625]    eta: 0:00:04  time: 0.0068  data_time: 0.0001  memory: 85  
01/10 10:59:52 - mmengine - INFO - Epoch(test) [300/625]    eta: 0:00:03  time: 0.0068  data_time: 0.0001  memory: 86  
01/10 10:59:53 - mmengine - INFO - Epoch(test) [400/625]    eta: 0:00:02  time: 0.0069  data_time: 0.0001  memory: 86  
01/10 10:59:54 - mmengine - INFO - Epoch(test) [500/625]    eta: 0:00:01  time: 0.0068  data_time: 0.0001  memory: 87  
01/10 10:59:54 - mmengine - INFO - Epoch(test) [600/625]    eta: 0:00:00  time: 0.0068  data_time: 0.0001  memory: 88  
01/10 10:59:55 - mmengine - INFO - Epoch(test) [625/625]  accuracy/top1: 94.8200  single-label/precision_classwise: 
tensor([94.7473, 97.4975, 94.1414, 89.7670, 94.1642, 90.6931, 95.9446, 98.0652,
        96.0474, 97.1689])
  single-label/recall_classwise: 
tensor([95.6000, 97.4000, 93.2000, 88.6000, 95.2000, 91.6000, 97.0000, 96.3000,
        97.2000, 96.1000])
  single-label/f1-score_classwise: 
tensor([95.1717, 97.4487, 93.6683, 89.1797, 94.6793, 91.1443, 96.4694, 97.1746,
        96.6203, 96.6315])
  confusion_matrix/result: 
tensor([[956,   2,  10,   4,   3,   1,   4,   0,  17,   3],
        [  4, 974,   0,   1,   1,   0,   0,   0,   3,  17],
        [  9,   0, 932,  20,  15,   5,  13,   3,   2,   1],
        [  6,   0,  14, 886,  12,  64,  10,   3,   5,   0],
        [  1,   0,  10,  11, 952,  11,   8,   7,   0,   0],
        [  5,   0,   8,  48,  10, 916,   6,   5,   1,   1],
        [  5,   0,  10,   6,   5,   3, 970,   0,   0,   1],
        [  3,   0,   4,   6,  13,  10,   0, 963,   1,   0],
        [ 15,   4,   1,   3,   0,   0,   0,   0, 972,   5],
        [  5,  19,   1,   2,   0,   0,   0,   1,  11, 961]])
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
