### PR TITLE
[Fix] Fix failed unit tests caused by the new released numpy

### DIFF
--- a/tests/test_visualizer/test_visualizer.py
+++ b/tests/test_visualizer/test_visualizer.py
@@ -364,21 +364,21 @@ class TestVisualizer(TestCase):
             visualizer.draw_polygons(torch.tensor([[1, 1], [2, 2], [16, 4]]))
 
     def test_draw_binary_masks(self):
-        binary_mask = np.random.randint(0, 2, size=(10, 10)).astype(np.bool)
+        binary_mask = np.random.randint(0, 2, size=(10, 10)).astype(bool)
         visualizer = Visualizer(image=self.image)
         visualizer.draw_binary_masks(binary_mask)
         visualizer.draw_binary_masks(torch.from_numpy(binary_mask))
         # multi binary
-        binary_mask = np.random.randint(0, 2, size=(2, 10, 10)).astype(np.bool)
+        binary_mask = np.random.randint(0, 2, size=(2, 10, 10)).astype(bool)
         visualizer = Visualizer(image=self.image)
         visualizer.draw_binary_masks(binary_mask, colors=['r', (0, 255, 0)])
         # test the error that the size of mask and image are different.
         with pytest.raises(AssertionError):
-            binary_mask = np.random.randint(0, 2, size=(8, 10)).astype(np.bool)
+            binary_mask = np.random.randint(0, 2, size=(8, 10)).astype(bool)
             visualizer.draw_binary_masks(binary_mask)
 
         # test non binary mask error
-        binary_mask = np.random.randint(0, 2, size=(10, 10, 3)).astype(np.bool)
+        binary_mask = np.random.randint(0, 2, size=(10, 10, 3)).astype(bool)
         with pytest.raises(AssertionError):
             visualizer.draw_binary_masks(binary_mask)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`np.bool` is a deprecated alias for the builtin `bool` and it was removed in https://github.com/numpy/numpy/releases/tag/v1.24.0

## Modification

replace `np.bool` with `bool` to fix the error.

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
