### PR TITLE
[Fix] Fix MessageHub set resumed key repeatedly

### DIFF
--- a/examples/distributed_training.py
+++ b/examples/distributed_training.py
@@ -92,6 +92,9 @@ def main():
         val_dataloader=val_dataloader,
         val_cfg=dict(),
         val_evaluator=dict(type=Accuracy),
+        custom_hooks=[
+            dict(type='ProfilerHook', on_trace_ready=dict(type='tb_trace'))
+        ],
         launcher=args.launcher,
     )
     runner.train()

--- a/examples/distributed_training.py
+++ b/examples/distributed_training.py
@@ -92,9 +92,6 @@ def main():
         val_dataloader=val_dataloader,
         val_cfg=dict(),
         val_evaluator=dict(type=Accuracy),
-        custom_hooks=[
-            dict(type='ProfilerHook', on_trace_ready=dict(type='tb_trace'))
-        ],
         launcher=args.launcher,
     )
     runner.train()

--- a/mmengine/logging/message_hub.py
+++ b/mmengine/logging/message_hub.py
@@ -208,7 +208,6 @@ class MessageHub(ManagerMixin):
                 could be resumed.
         """
         self._set_resumed_keys(key, resumed)
-        self._resumed_keys[key] = resumed
         self._runtime_info[key] = value
 
     def update_info_dict(self, info_dict: dict, resumed: bool = True) -> None:

--- a/mmengine/logging/message_hub.py
+++ b/mmengine/logging/message_hub.py
@@ -177,14 +177,14 @@ class MessageHub(ManagerMixin):
                 assert 'value' in log_val, \
                     f'value must be defined in {log_val}'
                 count = self._get_valid_value(log_val.get('count', 1))
-                checked_value = self._get_valid_value(log_val['value'])
+                value = log_val['value']
             else:
                 count = 1
-                checked_value = self._get_valid_value(log_val)
+                value = log_val
             assert isinstance(count,
                               int), ('The type of count must be int. but got '
                                      f'{type(count): {count}}')
-            self.update_scalar(log_name, checked_value, count)
+            self.update_scalar(log_name, value, count, resumed)
 
     def update_info(self, key: str, value: Any, resumed: bool = True) -> None:
         """Update runtime information.

--- a/mmengine/logging/message_hub.py
+++ b/mmengine/logging/message_hub.py
@@ -173,7 +173,6 @@ class MessageHub(ManagerMixin):
         assert isinstance(log_dict, dict), ('`log_dict` must be a dict!, '
                                             f'but got {type(log_dict)}')
         for log_name, log_val in log_dict.items():
-            self._set_resumed_keys(log_name, resumed)
             if isinstance(log_val, dict):
                 assert 'value' in log_val, \
                     f'value must be defined in {log_val}'
@@ -232,7 +231,6 @@ class MessageHub(ManagerMixin):
         assert isinstance(info_dict, dict), ('`log_dict` must be a dict!, '
                                              f'but got {type(info_dict)}')
         for key, value in info_dict.items():
-            self._set_resumed_keys(key, resumed)
             self.update_info(key, value, resumed=resumed)
 
     def _set_resumed_keys(self, key: str, resumed: bool) -> None:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix `MessageHub.update_info` set resumed key twice.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
