### PR TITLE
support np.ScalarType in message_hub

### DIFF
--- a/mmengine/logging/message_hub.py
+++ b/mmengine/logging/message_hub.py
@@ -329,7 +329,7 @@ class MessageHub(ManagerMixin):
             value = value.item()
         elif isinstance(value, (int, float)):
             value = value
-        elif isinstance(value, np.ScalarType):
+        elif isinstance(value, np.number):
             value = value.item()
         else:
             # check whether value is torch.Tensor but don't want

--- a/mmengine/logging/message_hub.py
+++ b/mmengine/logging/message_hub.py
@@ -324,7 +324,7 @@ class MessageHub(ManagerMixin):
         Returns:
             float or int: python built-in type value.
         """
-        if isinstance(value, (np.ndarray,np.number)):
+        if isinstance(value, (np.ndarray, np.number)):
             assert value.size == 1
             value = value.item()
         elif isinstance(value, (int, float)):

--- a/mmengine/logging/message_hub.py
+++ b/mmengine/logging/message_hub.py
@@ -324,13 +324,11 @@ class MessageHub(ManagerMixin):
         Returns:
             float or int: python built-in type value.
         """
-        if isinstance(value, np.ndarray):
+        if isinstance(value, (np.ndarray,np.number)):
             assert value.size == 1
             value = value.item()
         elif isinstance(value, (int, float)):
             value = value
-        elif isinstance(value, np.number):
-            value = value.item()
         else:
             # check whether value is torch.Tensor but don't want
             # to import torch in this file

--- a/mmengine/logging/message_hub.py
+++ b/mmengine/logging/message_hub.py
@@ -329,6 +329,8 @@ class MessageHub(ManagerMixin):
             value = value.item()
         elif isinstance(value, (int, float)):
             value = value
+        elif isinstance(value, np.ScalarType):
+            value = value.item()
         else:
             # check whether value is torch.Tensor but don't want
             # to import torch in this file


### PR DESCRIPTION
## Motivation
After computing metrics, the evaluation result dict will be parsed to mmengine.
However, if the dict item value is a numpy scalar, the message hub will treat it is torch.Tensor in function  `_get_valid_value`.
This would cause error triggered by `assert hasattr(value, 'numel') and value.numel() == 1`.

We should consider other numpy scalar types.