### PR TITLE
[Fix] Fix `Config` cannot parse base config when there is `.` in tmp path, etc. `tmp/a.b/c`

### DIFF
--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -550,8 +550,8 @@ class Config:
         Returns:
             list: A list of base config.
         """
-        file_format = filename.partition('.')[-1]
-        if file_format == 'py':
+        file_format = os.path.splitext(filename)[1]
+        if file_format == '.py':
             Config._validate_py_syntax(filename)
             with open(filename, encoding='utf-8') as f:
                 codes = ast.parse(f.read()).body
@@ -568,7 +568,7 @@ class Config:
                     base_files = eval(compile(base_code, '', mode='eval'))
                 else:
                     base_files = []
-        elif file_format in ('yml', 'yaml', 'json'):
+        elif file_format in ('.yml', '.yaml', '.json'):
             import mmengine
             cfg_dict = mmengine.load(filename)
             base_files = cfg_dict.get(BASE_KEY, [])

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -550,7 +550,7 @@ class Config:
         Returns:
             list: A list of base config.
         """
-        file_format = os.path.splitext(filename)[1]
+        file_format = osp.splitext(filename)[1]
         if file_format == '.py':
             Config._validate_py_syntax(filename)
             with open(filename, encoding='utf-8') as f:

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -718,7 +718,8 @@ class TestConfig:
         assert cfg == dict(item1=dict(a=1))
 
         # Simulate the case that the temporary directory include `.`, etc.
-        # /tmp/test.axsgr12/
+        # /tmp/test.axsgr12/. This patch is to check the issue
+        # https://github.com/open-mmlab/mmengine/issues/788 has been solved.
         class PatchedTempDirectory(tempfile.TemporaryDirectory):
 
             def __init__(self, *args, prefix='test.', **kwargs):

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -5,8 +5,10 @@ import os
 import os.path as osp
 import platform
 import sys
+import tempfile
 from importlib import import_module
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -714,6 +716,18 @@ class TestConfig:
                             'config/py_config/test_py_modify_key.py')
         cfg = Config._file2dict(cfg_file)[0]
         assert cfg == dict(item1=dict(a=1))
+
+        class PatchedTempDirectory(tempfile.TemporaryDirectory):
+
+            def __init__(self, *args, prefix='test.', **kwargs):
+                super().__init__(*args, prefix=prefix, **kwargs)
+
+        with patch('mmengine.config.config.tempfile.TemporaryDirectory',
+                   PatchedTempDirectory):
+            cfg_file = osp.join(self.data_path,
+                                'config/py_config/test_py_modify_key.py')
+            cfg = Config._file2dict(cfg_file)[0]
+            assert cfg == dict(item1=dict(a=1))
 
     def _merge_recursive_bases(self):
         cfg_file = osp.join(self.data_path,

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -717,6 +717,8 @@ class TestConfig:
         cfg = Config._file2dict(cfg_file)[0]
         assert cfg == dict(item1=dict(a=1))
 
+        # Simulate the case that the temporary directory include `.`, etc.
+        # /tmp/test.axsgr12/
         class PatchedTempDirectory(tempfile.TemporaryDirectory):
 
             def __init__(self, *args, prefix='test.', **kwargs):

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -717,7 +717,7 @@ class TestConfig:
         cfg = Config._file2dict(cfg_file)[0]
         assert cfg == dict(item1=dict(a=1))
 
-        # Simulate the case that the temporary directory include `.`, etc.
+        # Simulate the case that the temporary directory includes `.`, etc.
         # /tmp/test.axsgr12/. This patch is to check the issue
         # https://github.com/open-mmlab/mmengine/issues/788 has been solved.
         class PatchedTempDirectory(tempfile.TemporaryDirectory):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Resolve #788.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
