### PR TITLE
[Enhance] Disable warning of subprocess launched by dataloader

### DIFF
--- a/mmengine/dataset/utils.py
+++ b/mmengine/dataset/utils.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import random
+import warnings
 from typing import Any, Mapping, Sequence
 
 import numpy as np
@@ -13,8 +14,11 @@ from mmengine.structures import BaseDataElement
 COLLATE_FUNCTIONS = Registry('Collate Functions')
 
 
-def worker_init_fn(worker_id: int, num_workers: int, rank: int,
-                   seed: int) -> None:
+def worker_init_fn(worker_id: int,
+                   num_workers: int,
+                   rank: int,
+                   seed: int,
+                   disable_subprocess_warning=False) -> None:
     """This function will be called on each worker subprocess after seeding and
     before data loading.
 
@@ -31,6 +35,8 @@ def worker_init_fn(worker_id: int, num_workers: int, rank: int,
     np.random.seed(worker_seed)
     random.seed(worker_seed)
     torch.manual_seed(worker_seed)
+    if disable_subprocess_warning and worker_id != 0:
+        warnings.simplefilter('ignore')
 
 
 @COLLATE_FUNCTIONS.register_module()

--- a/mmengine/dataset/utils.py
+++ b/mmengine/dataset/utils.py
@@ -18,7 +18,7 @@ def worker_init_fn(worker_id: int,
                    num_workers: int,
                    rank: int,
                    seed: int,
-                   disable_subprocess_warning=False) -> None:
+                   disable_subprocess_warning: bool = False) -> None:
     """This function will be called on each worker subprocess after seeding and
     before data loading.
 

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1367,12 +1367,20 @@ class Runner:
 
         # build dataloader
         init_fn: Optional[partial]
+
         if seed is not None:
+            disable_subprocess_warning = dataloader_cfg.pop(
+                'disable_subprocess_warning', False)
+            assert isinstance(
+                disable_subprocess_warning,
+                bool), ('disable_subprocess_warning should be a bool, but got '
+                        f'{type(disable_subprocess_warning)}')
             init_fn = partial(
                 worker_init_fn,
                 num_workers=dataloader_cfg.get('num_workers'),
                 rank=get_rank(),
-                seed=seed)
+                seed=seed,
+                disable_subprocess_warning=disable_subprocess_warning)
         else:
             init_fn = None
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Disable warning of subprocess launched by dataloader. Since [this PR in MMCV](https://github.com/open-mmlab/mmcv/pull/2539) will raise a warning in transform, duplicated warnings raised by subprocesses will be shown in the terminal if `num_workers > 1` is set for the `Dataloader`.

This PR provides an option to disable all warnings of subprocesses, such as:

```python
train_dataloader = dict(
    ...
    disable_subprocess_warning=True
)
```

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
