### PR TITLE
[Feature] Support enabling distributed training by `launch`

### DIFF
--- a/docs/en/advanced_tutorials/distributed.md
+++ b/docs/en/advanced_tutorials/distributed.md
@@ -38,6 +38,7 @@ Their functionalities are listed below:
 - [is_main_process](mmengine.dist.is_main_process): Returns `True` if current process is rank 0 in current process group, otherwise `False` . Always returns `True` when non-distributed
 - [master_only](mmengine.dist.master_only): A function decorator. Functions decorated by `master_only` will only execute on rank 0 process.
 - [barrier](mmengine.dist.barrier): A synchronization primitive. Every process will hold until all processes in the current process group reach the same barrier location
+- [launch](mmengine.dist.launch)：A function to launch distributed task. [distributed_training.py](https://github.com/open-mmlab/mmengine/blob/main/examples/distributed_training.py) can enable distributed very simple with the `launch` function.
 
 ## Collective communication
 

--- a/docs/en/api/dist.rst
+++ b/docs/en/api/dist.rst
@@ -56,3 +56,4 @@ utils
    get_data_device
    get_comm_device
    cast_data_device
+   launch

--- a/docs/zh_cn/advanced_tutorials/distributed.md
+++ b/docs/zh_cn/advanced_tutorials/distributed.md
@@ -30,6 +30,7 @@ PyTorch 提供了一套基础的通信原语用于多进程之间张量的通信
 - [is_main_process](mmengine.dist.is_main_process)：判断是否为 0 号主进程，非分布式情况下返回 True
 - [master_only](mmengine.dist.master_only)：函数装饰器，用于修饰只需要全局 0 号进程（rank 0 而不是 local rank 0）执行的函数
 - [barrier](mmengine.dist.barrier)：同步所有进程到达相同位置
+- [launch](mmengine.dist.launch)：分布式任务启动函数。[分布式示例](https://github.com/open-mmlab/mmengine/blob/main/examples/distributed_training.py) 使用 `launch` 函数非常简单地启用多卡训练
 
 ## 分布式通信函数
 

--- a/docs/zh_cn/api/dist.rst
+++ b/docs/zh_cn/api/dist.rst
@@ -56,3 +56,4 @@ utils
    get_data_device
    get_comm_device
    cast_data_device
+   launch

--- a/examples/distributed_training.py
+++ b/examples/distributed_training.py
@@ -6,6 +6,7 @@ import torchvision
 import torchvision.transforms as transforms
 from torch.optim import SGD
 
+from mmengine.dist import launch
 from mmengine.evaluator import BaseMetric
 from mmengine.model import BaseModel
 from mmengine.runner import Runner
@@ -45,16 +46,19 @@ def parse_args():
     parser.add_argument(
         '--launcher',
         choices=['none', 'pytorch', 'slurm', 'mpi'],
-        default='none',
+        default='pytorch',
         help='job launcher')
-    parser.add_argument('--local_rank', type=int, default=0)
-
+    parser.add_argument(
+        '--num-gpus',
+        nargs='+',
+        type=int,
+        help='number of gpus to use',
+        default=[2])
     args = parser.parse_args()
     return args
 
 
-def main():
-    args = parse_args()
+def main(args):
     norm_cfg = dict(mean=[0.491, 0.482, 0.447], std=[0.202, 0.199, 0.201])
     train_set = torchvision.datasets.CIFAR10(
         'data/cifar10',
@@ -98,4 +102,9 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    args = parse_args()
+    launch(
+        main,
+        args.num_gpus,
+        args=(args, ),
+    )

--- a/mmengine/dist/__init__.py
+++ b/mmengine/dist/__init__.py
@@ -7,7 +7,7 @@ from .utils import (get_dist_info, init_dist, init_local_group, get_backend,
                     get_world_size, get_rank, get_local_size, get_local_rank,
                     is_main_process, master_only, barrier, get_local_group,
                     is_distributed, get_default_group, get_data_device,
-                    get_comm_device, cast_data_device)
+                    get_comm_device, cast_data_device, launch)
 
 __all__ = [
     'all_gather_object', 'all_reduce', 'all_gather', 'all_reduce_dict',
@@ -17,5 +17,5 @@ __all__ = [
     'get_world_size', 'get_rank', 'get_local_size', 'get_local_group',
     'get_local_rank', 'is_main_process', 'master_only', 'barrier',
     'is_distributed', 'get_default_group', 'all_reduce_params',
-    'get_data_device', 'get_comm_device', 'cast_data_device'
+    'get_data_device', 'get_comm_device', 'cast_data_device', 'launch'
 ]

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -158,7 +158,7 @@ def _init_dist_slurm(backend, port=None) -> None:
     torch_dist.init_process_group(backend=backend)
 
 
-def init_local_group(node_rank: int, num_gpus_per_node: Union[list, int]):
+def init_local_group(node_rank: int, num_proc_per_node: list):
     """Setup the local process group.
 
     Setup a process group which only includes processes that on the same
@@ -175,11 +175,10 @@ def init_local_group(node_rank: int, num_gpus_per_node: Union[list, int]):
     global _LOCAL_PROCESS_GROUP
     assert _LOCAL_PROCESS_GROUP is None
 
-    num_machines = len(num_gpus_per_node) if isinstance(
-        num_gpus_per_node, list) else 1
+    num_machines = len(num_proc_per_node)
     for i in range(num_machines):
-        start = sum(num_gpus_per_node[:i]) if i != 0 else 0
-        end = sum(num_gpus_per_node[:i + 1])
+        start = sum(num_proc_per_node[:i]) if i != 0 else 0
+        end = sum(num_proc_per_node[:i + 1])
         ranks_on_i = list(range(start, end))
         pg = torch_dist.new_group(ranks_on_i)
         if i == node_rank:
@@ -546,17 +545,35 @@ def cast_data_device(
 
 def launch(
         main_func: Callable,
-        num_gpus_per_machine: Union[list, int],
+        num_proc_per_machine: Union[list, int] = 1,
         num_machines: int = 1,
         machine_rank: int = 0,
         master_addr: str = '127.0.0.1',
         master_port: str = 'auto',
         args: tuple = (),
-):
-    if not isinstance(num_gpus_per_machine, list):
-        num_gpus_per_machine = [num_gpus_per_machine] * num_machines
+) -> None:
+    """Launch distributed task with single or multiple machines/GPU.
 
-    world_size = sum(num_gpus_per_machine)
+    Args:
+        main_func (Callable): Function to be executed in multiple process.
+        num_proc_per_machine (list or int): number of valid gpu for machines.
+            For example, The task will be ran on 2 machine A and machine B.
+            A has 2 valid GPUs, and B has 4 valid GPUs. Then
+            ``num_proc_per_machine`` should be [2, 4]
+        num_machines (int, optional): Number of used machines. Defaults to 1.
+        machine_rank (int, optional): The rank of current machine.
+            Defaults to 0.
+        master_addr (str, optional): The FQDN of the host that is running
+            worker with rank 0; used to initialize the Torch Distributed
+            backend. Defaults to '127.0.0.1'.
+        master_port (str, optional): The port on the ``master_addr`` that can
+            be used to host the C10d TCP store. Defaults to 'auto'.
+        args (tuple, optional): Arguments passde to main_func. Defaults to ().
+    """
+    if not isinstance(num_proc_per_machine, list):
+        num_proc_per_machine = [num_proc_per_machine] * num_machines
+    torch_dist.init_process_group
+    world_size = sum(num_proc_per_machine)
     if master_port == 'auto':
         master_port = str(_find_free_port())
 
@@ -565,11 +582,11 @@ def launch(
 
         mp.start_processes(
             _distributed_worker,
-            nprocs=num_gpus_per_machine[machine_rank],
+            nprocs=num_proc_per_machine[machine_rank],
             args=(
                 main_func,
                 world_size,
-                num_gpus_per_machine,
+                num_proc_per_machine,
                 machine_rank,
                 master_addr,
                 master_port,
@@ -585,33 +602,62 @@ def _distributed_worker(
     local_rank: int,
     main_func: Callable,
     world_size: int,
-    num_gpus_per_machine: list,
+    num_proc_per_machine: list,
     machine_rank: int,
     master_addr: str,
     master_port: str,
     args,
-):
+) -> None:
+    """Run the task after initializing the environment.
+
+    This function will be launched by ``mp.start_processes`` and ``local_rank``
+    will be filled automatically.
+
+    Part of environment variable defined in `pytorch official docs <https://pytorch.org/docs/stable/elastic/run.html#environment-variables>`_
+    will be initialized.
+
+    Warning:
+        :func:`init_dist` must be called in the ``main_func``
+
+    Args:
+        local_rank (int): Local rank of the current machine.
+        main_func (Callable): Function to be executed.
+        world_size (int): The number of all processes launched on all machines.
+        num_proc_per_machine (list): Number of valid gpu for machines.
+        machine_rank (int): The rank of current machine.
+        master_addr (str): The FQDN of the host that is running
+            worker with rank 0; used to initialize the Torch Distributed
+            backend.
+        master_port (str): The port on the ``master_addr`` that can
+            be used to host the C10d TCP store.
+        args (tuple, optional): Arguments passde to main_func. Defaults to ().
+    """  # noqa: E501
     has_gpu = torch.cuda.is_available()
     if has_gpu:
-        assert num_gpus_per_machine[machine_rank] <= torch.cuda.device_count()
+        assert num_proc_per_machine[machine_rank] <= torch.cuda.device_count()
     os.environ['RANK'] = \
-        str(sum(num_gpus_per_machine[:machine_rank]) + local_rank)
+        str(sum(num_proc_per_machine[:machine_rank]) + local_rank)
     os.environ['LOCAL_RANK'] = str(local_rank)
     os.environ['WORLD_SIZE'] = str(world_size)
     os.environ['MASTER_ADDR'] = master_addr
     os.environ['MASTER_PORT'] = master_port
+    num_proc_per_machine = [str(num) for num in num_proc_per_machine]
+    os.environ['NUM_PROC_PER_NODE'] = ' '.join(num_proc_per_machine)
 
-    if has_gpu:
-        torch.cuda.set_device(local_rank)
-
-    # synchronize is needed here to prevent a possible timeout after calling init_process_group
+    # synchronize is needed here to prevent a possible timeout after calling
+    # init_process_group.
     # See: https://github.com/facebookresearch/maskrcnn-benchmark/issues/172
-    # barrier()
+    barrier()
 
     main_func(*args)
 
 
 def _find_free_port() -> str:
+    """Find free port.
+
+    Returns:
+        str: Free port.
+    """
     import socket
 
     # Copied from https://github.com/facebookresearch/detectron2/blob/main/detectron2/engine/launch.py # noqa: E501

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -2,6 +2,7 @@
 import functools
 import os
 import subprocess
+from collections.abc import Iterable, Mapping
 from typing import Callable, Optional, Tuple, Union
 
 import numpy as np
@@ -10,9 +11,8 @@ import torch.multiprocessing as mp
 from torch import Tensor
 from torch import distributed as torch_dist
 from torch.distributed import ProcessGroup
-from mmengine.device import is_mlu_available, is_npu_available
 
-from collections.abc import Iterable, Mapping
+from mmengine.device import is_mlu_available, is_npu_available
 
 _LOCAL_PROCESS_GROUP = None
 
@@ -158,7 +158,7 @@ def _init_dist_slurm(backend, port=None) -> None:
     torch_dist.init_process_group(backend=backend)
 
 
-def init_local_group(node_rank: int, num_gpus_per_node: int):
+def init_local_group(node_rank: int, num_gpus_per_node: Union[list, int]):
     """Setup the local process group.
 
     Setup a process group which only includes processes that on the same
@@ -175,10 +175,15 @@ def init_local_group(node_rank: int, num_gpus_per_node: int):
     global _LOCAL_PROCESS_GROUP
     assert _LOCAL_PROCESS_GROUP is None
 
-    ranks = list(
-        range(node_rank * num_gpus_per_node,
-              (node_rank + 1) * num_gpus_per_node))
-    _LOCAL_PROCESS_GROUP = torch_dist.new_group(ranks)
+    num_machines = len(num_gpus_per_node) if isinstance(
+        num_gpus_per_node, list) else 1
+    for i in range(num_machines):
+        start = sum(num_gpus_per_node[:i]) if i != 0 else 0
+        end = sum(num_gpus_per_node[:i + 1])
+        ranks_on_i = list(range(start, end))
+        pg = torch_dist.new_group(ranks_on_i)
+        if i == node_rank:
+            _LOCAL_PROCESS_GROUP = pg
 
 
 def get_backend(group: Optional[ProcessGroup] = None) -> Optional[str]:
@@ -537,3 +542,83 @@ def cast_data_device(
     else:
         raise TypeError('data should be a Tensor, list of tensor or dict, '
                         f'but got {data}')
+
+
+def launch(
+        main_func: Callable,
+        num_gpus_per_machine: Union[list, int],
+        num_machines: int = 1,
+        machine_rank: int = 0,
+        master_addr: str = '127.0.0.1',
+        master_port: str = 'auto',
+        args: tuple = (),
+):
+    if not isinstance(num_gpus_per_machine, list):
+        num_gpus_per_machine = [num_gpus_per_machine] * num_machines
+
+    world_size = sum(num_gpus_per_machine)
+    if master_port == 'auto':
+        master_port = str(_find_free_port())
+
+    if world_size > 1:
+        # https://github.com/pytorch/pytorch/pull/14391
+
+        mp.start_processes(
+            _distributed_worker,
+            nprocs=num_gpus_per_machine[machine_rank],
+            args=(
+                main_func,
+                world_size,
+                num_gpus_per_machine,
+                machine_rank,
+                master_addr,
+                master_port,
+                args,
+            ),
+            daemon=False,
+        )
+    else:
+        main_func(*args)
+
+
+def _distributed_worker(
+    local_rank: int,
+    main_func: Callable,
+    world_size: int,
+    num_gpus_per_machine: list,
+    machine_rank: int,
+    master_addr: str,
+    master_port: str,
+    args,
+):
+    has_gpu = torch.cuda.is_available()
+    if has_gpu:
+        assert num_gpus_per_machine[machine_rank] <= torch.cuda.device_count()
+    os.environ['RANK'] = \
+        str(sum(num_gpus_per_machine[:machine_rank]) + local_rank)
+    os.environ['LOCAL_RANK'] = str(local_rank)
+    os.environ['WORLD_SIZE'] = str(world_size)
+    os.environ['MASTER_ADDR'] = master_addr
+    os.environ['MASTER_PORT'] = master_port
+
+    if has_gpu:
+        torch.cuda.set_device(local_rank)
+
+    # synchronize is needed here to prevent a possible timeout after calling init_process_group
+    # See: https://github.com/facebookresearch/maskrcnn-benchmark/issues/172
+    # barrier()
+
+    main_func(*args)
+
+
+def _find_free_port() -> str:
+    import socket
+
+    # Copied from https://github.com/facebookresearch/detectron2/blob/main/detectron2/engine/launch.py # noqa: E501
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # Binding to port 0 will cause the OS to find an available port for us
+    sock.bind(('', 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    # NOTE: there is still a chance the port could be taken by other processes.
+    return port

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -22,7 +22,7 @@ from mmengine.config import Config, ConfigDict
 from mmengine.dataset import COLLATE_FUNCTIONS, worker_init_fn
 from mmengine.device import get_device
 from mmengine.dist import (broadcast, get_dist_info, get_rank, init_dist,
-                           is_distributed, master_only)
+                           init_local_group, is_distributed, master_only)
 from mmengine.evaluator import Evaluator
 from mmengine.fileio import FileClient, join_path
 from mmengine.hooks import Hook
@@ -642,6 +642,11 @@ class Runner:
         if self.distributed and not is_distributed():
             dist_cfg: dict = env_cfg.get('dist_cfg', {})
             init_dist(self.launcher, **dist_cfg)
+            rank = int(os.environ['RANK'])
+            num_proc_per_node: Union[List[int], List[str]]
+            num_proc_per_node = os.environ['NUM_PROC_PER_NODE'].split(' ')
+            num_proc_per_node = [int(num) for num in num_proc_per_node]
+            init_local_group(rank, num_proc_per_node)
 
         self._rank, self._world_size = get_dist_info()
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Currently, downstream repositories need to run `python -m torch.distributed.launch` to enable distributed training, which is not friendly for using and debugging. This PR adds the `launch` function to enable distributed training much more easily. As the [example](https://github.com/open-mmlab/mmengine/blob/main/examples/distributed_training.py) shows, you can use `launch` like this:

```python
def parse_args():
    parser = argparse.ArgumentParser(description='Distributed Training')
    parser.add_argument(
        '--launcher',
        choices=['none', 'pytorch', 'slurm', 'mpi'],
        default='pytorch',
        help='job launcher')
    parser.add_argument(
        '--num-gpus',
        nargs='+',
        type=int,
        help='number of gpus to use',
        default=[2])
    args = parser.parse_args()
    return args

def main(args):
    # Implement training process.
   ...

if __name__ == '__main__':
    args = parse_args()
    launch(
        main,
        args.num_gpus,
        args=(args, ),
    )
```



## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
