### PR TITLE
[Enhancement] Enable timeout in dist training

### DIFF
--- a/docs/en/advanced_tutorials/distributed.md
+++ b/docs/en/advanced_tutorials/distributed.md
@@ -23,6 +23,16 @@ We will detail on these APIs in the following chapters.
 
 - [init_dist](mmengine.dist.init_dist): Launch function of distributed training. Currently it supports 3 launchers including pytorch, slurm and MPI. It also setup the given communication backends, defaults to NCCL.
 
+If you need to change the runtime timeout (default=30 minutes) for distributed operations that take very long, you can specify a different timeout in your runtime configuration like this:
+
+```python
+env_cfg = dict(
+    cudnn_benchmark=True,
+    mp_cfg=dict(mp_start_method='fork', opencv_num_threads=0),
+    dist_cfg=dict(backend='nccl', timeout="10800"), # Sets the timeout to 3h (10800 seconds)
+)
+```
+
 ## Query and control
 
 The query and control functions are all argument free.

--- a/docs/en/advanced_tutorials/distributed.md
+++ b/docs/en/advanced_tutorials/distributed.md
@@ -29,7 +29,7 @@ If you need to change the runtime timeout (default=30 minutes) for distributed o
 env_cfg = dict(
     cudnn_benchmark=True,
     mp_cfg=dict(mp_start_method='fork', opencv_num_threads=0),
-    dist_cfg=dict(backend='nccl', timeout="10800"), # Sets the timeout to 3h (10800 seconds)
+    dist_cfg=dict(backend='nccl', timeout=10800), # Sets the timeout to 3h (10800 seconds)
 )
 ```
 

--- a/docs/en/advanced_tutorials/distributed.md
+++ b/docs/en/advanced_tutorials/distributed.md
@@ -23,15 +23,16 @@ We will detail on these APIs in the following chapters.
 
 - [init_dist](mmengine.dist.init_dist): Launch function of distributed training. Currently it supports 3 launchers including pytorch, slurm and MPI. It also setup the given communication backends, defaults to NCCL.
 
-If you need to change the runtime timeout (default=30 minutes) for distributed operations that take very long, you can specify a different timeout in your runtime configuration like this:
+  If you need to change the runtime timeout (default=30 minutes) for distributed operations that take very long, you can specify a different timeout in your `env_cfg` configuration passing in [Runner](mmengine.runner.Runner) like this:
 
-```python
-env_cfg = dict(
-    cudnn_benchmark=True,
-    mp_cfg=dict(mp_start_method='fork', opencv_num_threads=0),
-    dist_cfg=dict(backend='nccl', timeout=10800), # Sets the timeout to 3h (10800 seconds)
-)
-```
+  ```python
+  env_cfg = dict(
+      cudnn_benchmark=True,
+      mp_cfg=dict(mp_start_method='fork', opencv_num_threads=0),
+      dist_cfg=dict(backend='nccl', timeout=10800), # Sets the timeout to 3h (10800 seconds)
+  )
+  runner = Runner(xxx, env_cfg=env_cfg)
+  ```
 
 ## Query and control
 

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -56,14 +56,14 @@ def init_dist(launcher, backend='nccl', **kwargs) -> None:
         # If a timeout (in seconds) is specified, it must be converted
         # to a timedelta object before forwarding the call to
         # the respective backend, because they expect a timedelta object.
-        if type(timeout) == int:
+        try:
             kwargs['timeout'] = datetime.timedelta(seconds=kwargs['timeout'])
-        else:
+        except TypeError as exception:
             raise TypeError(
                 f'Timeout for distributed training must be provided as '
-                f"integer (timeout in seconds), but we've received the type "
+                f"timeout in seconds, but we've received the type "
                 f'{type(timeout)}. Please specify the timeout like this: '
-                f"dist_cfg=dict(backend='nccl', timeout=1800)")
+                f"dist_cfg=dict(backend='nccl', timeout=1800)") from exception
     if mp.get_start_method(allow_none=True) is None:
         mp.set_start_method('spawn')
     if launcher == 'pytorch':

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import datetime
 import functools
 import os
 import subprocess
@@ -50,6 +51,20 @@ def init_dist(launcher, backend='nccl', **kwargs) -> None:
             'gloo' and 'mpi'. Defaults to 'nccl'.
         **kwargs: keyword arguments are passed to ``init_process_group``.
     """
+    timeout = kwargs.get('timeout', None)
+    if timeout:
+        # If a timeout (in seconds) is specified, it must be converted
+        # to a timedelta object before forwarding the call to
+        # the respective backend, because they expect a timedelta object.
+        if type(timeout) == int:
+            kwargs['timeout'] = datetime.timedelta(
+                seconds=int(kwargs['timeout']))
+        else:
+            raise TypeError(
+                f'Timeout for distributed training must be provided as '
+                f"integer (timeout in seconds), but we've received the type "
+                f'{type(timeout)}. Please specify the timeout like this: '
+                f"dist_cfg=dict(backend='nccl', timeout=1800)")
     if mp.get_start_method(allow_none=True) is None:
         mp.set_start_method('spawn')
     if launcher == 'pytorch':

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -57,8 +57,7 @@ def init_dist(launcher, backend='nccl', **kwargs) -> None:
         # to a timedelta object before forwarding the call to
         # the respective backend, because they expect a timedelta object.
         if type(timeout) == int:
-            kwargs['timeout'] = datetime.timedelta(
-                seconds=int(kwargs['timeout']))
+            kwargs['timeout'] = datetime.timedelta(seconds=kwargs['timeout'])
         else:
             raise TypeError(
                 f'Timeout for distributed training must be provided as '

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -57,7 +57,7 @@ def init_dist(launcher, backend='nccl', **kwargs) -> None:
         # to a timedelta object before forwarding the call to
         # the respective backend, because they expect a timedelta object.
         try:
-            kwargs['timeout'] = datetime.timedelta(seconds=kwargs['timeout'])
+            kwargs['timeout'] = datetime.timedelta(seconds=timeout)
         except TypeError as exception:
             raise TypeError(
                 f'Timeout for distributed training must be provided as '

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -52,7 +52,7 @@ def init_dist(launcher, backend='nccl', **kwargs) -> None:
         **kwargs: keyword arguments are passed to ``init_process_group``.
     """
     timeout = kwargs.get('timeout', None)
-    if timeout:
+    if timeout is not None:
         # If a timeout (in seconds) is specified, it must be converted
         # to a timedelta object before forwarding the call to
         # the respective backend, because they expect a timedelta object.

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -625,7 +625,7 @@ class Runner:
                     mp_start_method='fork',
                     opencv_num_threads=0
                 ),
-                dist_cfg=dict(backend='nccl'),
+                dist_cfg=dict(backend='nccl', timeout=1800),
                 resource_limit=4096
             )
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,5 +1,4 @@
 coverage
 lmdb
 parameterized
-pre-commit
 pytest

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,5 @@
 coverage
 lmdb
 parameterized
+pre-commit
 pytest


### PR DESCRIPTION
This PR fixes https://github.com/open-mmlab/mmengine/issues/873:
* Adds option to specify a runtime timeout for distributed training
* Safe conversion of the specified timeout in seconds to `timedelta` with type-check
* Adding documentation on how to use it