### PR TITLE
[Fix] backend_args should not be modified by get_file_backend

### DIFF
--- a/mmengine/fileio/io.py
+++ b/mmengine/fileio/io.py
@@ -91,8 +91,10 @@ def _get_file_backend(prefix: str, backend_args: dict):
     """
     # backend name has a higher priority
     if 'backend' in backend_args:
-        backend_name = backend_args.pop('backend')
-        backend = backends[backend_name](**backend_args)
+        # backend_args should not be modified
+        backend_args_bak = backend_args.copy()
+        backend_name = backend_args_bak.pop('backend')
+        backend = backends[backend_name](**backend_args_bak)
     else:
         backend = prefix_to_backends[prefix](**backend_args)
     return backend

--- a/tests/test_fileio/test_io.py
+++ b/tests/test_fileio/test_io.py
@@ -107,10 +107,13 @@ def test_get_file_backend():
     backend_args = {'backend': 'local'}
     backend = fileio.get_file_backend(uri=None, backend_args=backend_args)
     assert isinstance(backend, fileio.backends.LocalBackend)
+    # backend_args should not be modified
+    assert backend_args == {'backend': 'local'}
 
     backend_args = {'backend': 'petrel', 'enable_mc': True}
     backend = fileio.get_file_backend(uri=None, backend_args=backend_args)
     assert isinstance(backend, fileio.backends.PetrelBackend)
+    assert backend_args == {'backend': 'petrel', 'enable_mc': True}
 
     # backend name has a higher priority
     backend_args = {'backend': 'http'}


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

```python
>>> import mmengine.fileio as fileio
>>> backend_args = {'backend': 'local'}
>>> res = fileio.get(filepath, backend_args=backend_args)
>>> backend_args
{}
```

`backend` key in `backend_args` will be popped and it will cause the program to fail when users use it again.

## Modification

copy `backend_args` before popping it.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
