### PR TITLE
[Enhance] Get model configs from model-index without installation

### DIFF
--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -397,8 +397,8 @@ class BaseInferencer(metaclass=InferencerMeta):
         Returns:
             str: The directory of the ``Config``.
         """
-        project = MODULE2PACKAGE[scope]
         try:
+            project = MODULE2PACKAGE[scope]
             module = importlib.import_module(scope)
         except ImportError as e:
             if scope not in MODULE2PACKAGE:

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -18,7 +18,8 @@ from mmengine.config import Config, ConfigDict
 from mmengine.config.utils import MODULE2PACKAGE
 from mmengine.dataset import COLLATE_FUNCTIONS, pseudo_collate
 from mmengine.device import get_device
-from mmengine.fileio import get_file_backend, list_dir_or_file, load
+from mmengine.fileio import (get_file_backend, isdir, join_path,
+                             list_dir_or_file, load)
 from mmengine.logging import print_log
 from mmengine.registry import MODELS, VISUALIZERS, DefaultScope
 from mmengine.runner.checkpoint import (_load_checkpoint,
@@ -241,13 +242,13 @@ class BaseInferencer(metaclass=InferencerMeta):
         """
         if isinstance(inputs, str):
             backend = get_file_backend(inputs)
-            if hasattr(backend, 'isdir') and osp.isdir(inputs):
+            if hasattr(backend, 'isdir') and isdir(inputs):
                 # Backends like HttpsBackend do not implement `isdir`, so only
                 # those backends that implement `isdir` could accept the inputs
                 # as a directory
                 filename_list = list_dir_or_file(inputs, list_dir=False)
                 inputs = [
-                    osp.join(inputs, filename) for filename in filename_list
+                    join_path(inputs, filename) for filename in filename_list
                 ]
 
         if not isinstance(inputs, (list, tuple)):

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -398,16 +398,17 @@ class BaseInferencer(metaclass=InferencerMeta):
             str: The directory of the ``Config``.
         """
         try:
-            project = MODULE2PACKAGE[scope]
             module = importlib.import_module(scope)
-        except ImportError as e:
+        except ImportError:
             if scope not in MODULE2PACKAGE:
-                raise ValueError(
+                raise KeyError(
                     f'{scope} is not a valid scope. The available scopes '
                     f'are {MODULE2PACKAGE.keys()}')
-            raise ImportError(
-                f'Cannot import {scope} correctly, please try to install '
-                f'the {project} by "pip install {project}"') from e
+            else:
+                project = MODULE2PACKAGE[scope]
+                raise ImportError(
+                    f'Cannot import {scope} correctly, please try to install '
+                    f'the {project} by "pip install {project}"')
         # Since none of OpenMMLab series packages are namespace packages
         # (https://docs.python.org/3/glossary.html#term-namespace-package),
         # The first element of module.__path__ means package installation path.

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
+import importlib
 import os.path as osp
 import re
 import warnings
@@ -24,7 +25,6 @@ from mmengine.registry import MODELS, VISUALIZERS, DefaultScope
 from mmengine.runner.checkpoint import (_load_checkpoint,
                                         _load_checkpoint_to_model)
 from mmengine.structures import InstanceData
-from mmengine.utils import get_installed_path, is_installed
 from mmengine.visualization import Visualizer
 
 InstanceList = List[InstanceData]
@@ -368,10 +368,9 @@ class BaseInferencer(metaclass=InferencerMeta):
         assert self.scope in MODULE2PACKAGE, (
             f'{self.scope} not in {MODULE2PACKAGE}!,'
             'please pass a valid scope.')
-        project = MODULE2PACKAGE[self.scope]
-        assert is_installed(project), f'Please install {project}'
-        package_path = get_installed_path(project)
-        for model_cfg in BaseInferencer._get_models_from_package(package_path):
+
+        config_dir = BaseInferencer._get_config_dir(self.scope)
+        for model_cfg in BaseInferencer._get_models_from_package(config_dir):
             model_name = model_cfg['Name'].lower()
             model_aliases = model_cfg.get('Alias', [])
             if isinstance(model_aliases, str):
@@ -380,11 +379,48 @@ class BaseInferencer(metaclass=InferencerMeta):
                 model_aliases = [alias.lower() for alias in model_aliases]
             if (model_name == model or model in model_aliases):
                 cfg = Config.fromfile(
-                    osp.join(package_path, '.mim', model_cfg['Config']))
+                    osp.join(config_dir, model_cfg['Config']))
                 weights = model_cfg['Weights']
                 weights = weights[0] if isinstance(weights, list) else weights
                 return cfg, weights
-        raise ValueError(f'Cannot find model: {model} in {project}')
+        raise ValueError(f'Cannot find model: {model} in {self.scope}')
+
+    @staticmethod
+    def _get_config_dir(scope):
+        """Get the directory of the ``Config`` when package is installed or
+        ``PYTHONPATH`` is set.
+
+        Args:
+            scope (str): The scope of repository.
+
+        Returns:
+            str: The directory of the ``Config``.
+        """
+        project = MODULE2PACKAGE[scope]
+        try:
+            module = importlib.import_module(scope)
+        except ImportError as e:
+            if scope not in MODULE2PACKAGE:
+                raise ValueError(
+                    f'{scope} is not a valid scope. The available scopes '
+                    f'are {MODULE2PACKAGE.keys()}')
+            raise ImportError(
+                f'Cannot import {scope} correctly, please try to install '
+                f'the {project} by "pip install {project}"') from e
+        # Since none of OpenMMLab series packages are namespace packages
+        # (https://docs.python.org/3/glossary.html#term-namespace-package),
+        # The first element of module.__path__ means package installation path.
+        package_path = module.__path__[0]
+
+        if osp.exists(osp.join(package_path, '.mim')):
+            config_dir = osp.join(package_path, '.mim')
+        else:
+            assert osp.exists(
+                osp.join(osp.dirname(package_path), 'configs')
+            ), (f'Cannot find Configs directory in {package_path}!, please '
+                f'check the completeness of the {scope}.')
+            config_dir = osp.dirname(package_path)
+        return config_dir
 
     def _init_model(
         self,
@@ -591,19 +627,21 @@ class BaseInferencer(metaclass=InferencerMeta):
         )
 
     @staticmethod
-    def _get_models_from_package(package_path: str):
+    def _get_models_from_package(config_dir: str):
         """Load model config defined in metafile from package path.
 
         Args:
-            package_path (str): Path to the package.
+            config_dir (str): Path to the directory of Config. It requires the
+                directory ``Config``, file ``model-index.yml`` exists in the
+                ``config_dir``.
 
         Yields:
             dict: Model config defined in metafile.
         """
-        meta_indexes = load(osp.join(package_path, '.mim', 'model-index.yml'))
+        meta_indexes = load(osp.join(config_dir, 'model-index.yml'))
         for meta_path in meta_indexes['Import']:
             # meta_path example: mmcls/.mim/configs/conformer/metafile.yml
-            meta_path = osp.join(package_path, '.mim', meta_path)
+            meta_path = osp.join(config_dir, meta_path)
             metainfo = load(meta_path)
             yield from metainfo['Models']
 
@@ -631,11 +669,8 @@ class BaseInferencer(metaclass=InferencerMeta):
         assert scope in MODULE2PACKAGE, (
             f'{scope} not in {MODULE2PACKAGE}!, please make pass a valid '
             'scope.')
-        project = MODULE2PACKAGE[scope]
-        assert is_installed(project), (f'Please install {project}')
-        package_path = get_installed_path(project)
-
-        for model_cfg in BaseInferencer._get_models_from_package(package_path):
+        config_dir = BaseInferencer._get_config_dir(scope)
+        for model_cfg in BaseInferencer._get_models_from_package(config_dir):
             model_name = [model_cfg['Name']]
             model_name.extend(model_cfg.get('Alias', []))
             for name in model_name:

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -18,8 +18,7 @@ from mmengine.config import Config, ConfigDict
 from mmengine.config.utils import MODULE2PACKAGE
 from mmengine.dataset import COLLATE_FUNCTIONS, pseudo_collate
 from mmengine.device import get_device
-from mmengine.fileio import (get_file_backend, isdir, join_path,
-                             list_dir_or_file, load)
+from mmengine.fileio import get_file_backend, list_dir_or_file, load
 from mmengine.logging import print_log
 from mmengine.registry import MODELS, VISUALIZERS, DefaultScope
 from mmengine.runner.checkpoint import (_load_checkpoint,
@@ -242,13 +241,13 @@ class BaseInferencer(metaclass=InferencerMeta):
         """
         if isinstance(inputs, str):
             backend = get_file_backend(inputs)
-            if hasattr(backend, 'isdir') and isdir(inputs):
+            if hasattr(backend, 'isdir') and osp.isdir(inputs):
                 # Backends like HttpsBackend do not implement `isdir`, so only
                 # those backends that implement `isdir` could accept the inputs
                 # as a directory
                 filename_list = list_dir_or_file(inputs, list_dir=False)
                 inputs = [
-                    join_path(inputs, filename) for filename in filename_list
+                    osp.join(inputs, filename) for filename in filename_list
                 ]
 
         if not isinstance(inputs, (list, tuple)):

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -369,7 +369,7 @@ class BaseInferencer(metaclass=InferencerMeta):
             f'{self.scope} not in {MODULE2PACKAGE}!,'
             'please pass a valid scope.')
 
-        config_dir = BaseInferencer._get_config_dir(self.scope)
+        config_dir = BaseInferencer._get_repo_or_mim_dir(self.scope)
         for model_cfg in BaseInferencer._get_models_from_config_dir(
                 config_dir):
             model_name = model_cfg['Name'].lower()
@@ -387,9 +387,9 @@ class BaseInferencer(metaclass=InferencerMeta):
         raise ValueError(f'Cannot find model: {model} in {self.scope}')
 
     @staticmethod
-    def _get_config_dir(scope):
-        """Get the directory of the ``Config`` when package is installed or
-        ``PYTHONPATH`` is set.
+    def _get_repo_or_mim_dir(scope):
+        """Get the directory where the ``Configs`` located when the package is
+        installed or ``PYTHONPATH`` is set.
 
         Args:
             scope (str): The scope of repository.
@@ -415,14 +415,15 @@ class BaseInferencer(metaclass=InferencerMeta):
         package_path = module.__path__[0]
 
         if exists(join_path(osp.dirname(package_path), 'configs')):
-            config_dir = osp.dirname(package_path)
+            repo_dir = osp.dirname(package_path)
+            return repo_dir
         else:
-            config_dir = join_path(package_path, '.mim', 'configs')
-            if not exists(config_dir):
+            mim_dir = join_path(package_path, '.mim')
+            if not exists(join_path(mim_dir, 'Configs')):
                 raise FileNotFoundError(
                     f'Cannot find Configs directory in {package_path}!, '
                     f'please check the completeness of the {scope}.')
-        return config_dir
+            return mim_dir
 
     def _init_model(
         self,
@@ -671,9 +672,9 @@ class BaseInferencer(metaclass=InferencerMeta):
         assert scope in MODULE2PACKAGE, (
             f'{scope} not in {MODULE2PACKAGE}!, please make pass a valid '
             'scope.')
-        config_dir = BaseInferencer._get_config_dir(scope)
+        root_or_mim_dir = BaseInferencer._get_repo_or_mim_dir(scope)
         for model_cfg in BaseInferencer._get_models_from_config_dir(
-                config_dir):
+                root_or_mim_dir):
             model_name = [model_cfg['Name']]
             model_name.extend(model_cfg.get('Alias', []))
             for name in model_name:

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -18,8 +18,8 @@ from mmengine.config import Config, ConfigDict
 from mmengine.config.utils import MODULE2PACKAGE
 from mmengine.dataset import COLLATE_FUNCTIONS, pseudo_collate
 from mmengine.device import get_device
-from mmengine.fileio import (exists, get_file_backend, isdir, isfile,
-                             join_path, list_dir_or_file, load)
+from mmengine.fileio import (get_file_backend, isdir, join_path,
+                             list_dir_or_file, load)
 from mmengine.logging import print_log
 from mmengine.registry import MODELS, VISUALIZERS, DefaultScope
 from mmengine.runner.checkpoint import (_load_checkpoint,
@@ -148,7 +148,7 @@ class BaseInferencer(metaclass=InferencerMeta):
         # Load config to cfg
         cfg: ConfigType
         if isinstance(model, str):
-            if isfile(model):
+            if osp.isfile(model):
                 cfg = Config.fromfile(model)
             else:
                 # Load config and weights from metafile. If `weights` is
@@ -380,7 +380,7 @@ class BaseInferencer(metaclass=InferencerMeta):
                 model_aliases = [alias.lower() for alias in model_aliases]
             if (model_name == model or model in model_aliases):
                 cfg = Config.fromfile(
-                    join_path(config_dir, model_cfg['Config']))
+                    osp.join(config_dir, model_cfg['Config']))
                 weights = model_cfg['Weights']
                 weights = weights[0] if isinstance(weights, list) else weights
                 return cfg, weights
@@ -414,12 +414,12 @@ class BaseInferencer(metaclass=InferencerMeta):
         # The first element of module.__path__ means package installation path.
         package_path = module.__path__[0]
 
-        if exists(join_path(osp.dirname(package_path), 'configs')):
+        if osp.exists(osp.join(osp.dirname(package_path), 'configs')):
             repo_dir = osp.dirname(package_path)
             return repo_dir
         else:
-            mim_dir = join_path(package_path, '.mim')
-            if not exists(join_path(mim_dir, 'Configs')):
+            mim_dir = osp.join(package_path, '.mim')
+            if not osp.exists(osp.join(mim_dir, 'Configs')):
                 raise FileNotFoundError(
                     f'Cannot find Configs directory in {package_path}!, '
                     f'please check the completeness of the {scope}.')
@@ -641,10 +641,10 @@ class BaseInferencer(metaclass=InferencerMeta):
         Yields:
             dict: Model config defined in metafile.
         """
-        meta_indexes = load(join_path(config_dir, 'model-index.yml'))
+        meta_indexes = load(osp.join(config_dir, 'model-index.yml'))
         for meta_path in meta_indexes['Import']:
             # meta_path example: mmcls/.mim/configs/conformer/metafile.yml
-            meta_path = join_path(config_dir, meta_path)
+            meta_path = osp.join(config_dir, meta_path)
             metainfo = load(meta_path)
             yield from metainfo['Models']
 

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -370,7 +370,8 @@ class BaseInferencer(metaclass=InferencerMeta):
             'please pass a valid scope.')
 
         config_dir = BaseInferencer._get_config_dir(self.scope)
-        for model_cfg in BaseInferencer._get_models_from_package(config_dir):
+        for model_cfg in BaseInferencer._get_models_from_config_dir(
+                config_dir):
             model_name = model_cfg['Name'].lower()
             model_aliases = model_cfg.get('Alias', [])
             if isinstance(model_aliases, str):
@@ -627,7 +628,7 @@ class BaseInferencer(metaclass=InferencerMeta):
         )
 
     @staticmethod
-    def _get_models_from_package(config_dir: str):
+    def _get_models_from_config_dir(config_dir: str):
         """Load model config defined in metafile from package path.
 
         Args:
@@ -670,7 +671,8 @@ class BaseInferencer(metaclass=InferencerMeta):
             f'{scope} not in {MODULE2PACKAGE}!, please make pass a valid '
             'scope.')
         config_dir = BaseInferencer._get_config_dir(scope)
-        for model_cfg in BaseInferencer._get_models_from_package(config_dir):
+        for model_cfg in BaseInferencer._get_models_from_config_dir(
+                config_dir):
             model_name = [model_cfg['Name']]
             model_name.extend(model_cfg.get('Alias', []))
             for name in model_name:

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -18,8 +18,8 @@ from mmengine.config import Config, ConfigDict
 from mmengine.config.utils import MODULE2PACKAGE
 from mmengine.dataset import COLLATE_FUNCTIONS, pseudo_collate
 from mmengine.device import get_device
-from mmengine.fileio import (get_file_backend, isdir, join_path,
-                             list_dir_or_file, load)
+from mmengine.fileio import (exists, get_file_backend, isdir, isfile,
+                             join_path, list_dir_or_file, load)
 from mmengine.logging import print_log
 from mmengine.registry import MODELS, VISUALIZERS, DefaultScope
 from mmengine.runner.checkpoint import (_load_checkpoint,
@@ -148,7 +148,7 @@ class BaseInferencer(metaclass=InferencerMeta):
         # Load config to cfg
         cfg: ConfigType
         if isinstance(model, str):
-            if osp.isfile(model):
+            if isfile(model):
                 cfg = Config.fromfile(model)
             else:
                 # Load config and weights from metafile. If `weights` is
@@ -380,7 +380,7 @@ class BaseInferencer(metaclass=InferencerMeta):
                 model_aliases = [alias.lower() for alias in model_aliases]
             if (model_name == model or model in model_aliases):
                 cfg = Config.fromfile(
-                    osp.join(config_dir, model_cfg['Config']))
+                    join_path(config_dir, model_cfg['Config']))
                 weights = model_cfg['Weights']
                 weights = weights[0] if isinstance(weights, list) else weights
                 return cfg, weights
@@ -414,13 +414,14 @@ class BaseInferencer(metaclass=InferencerMeta):
         # The first element of module.__path__ means package installation path.
         package_path = module.__path__[0]
 
-        if osp.exists(osp.join(osp.dirname(package_path), 'configs')):
+        if exists(join_path(osp.dirname(package_path), 'configs')):
             config_dir = osp.dirname(package_path)
         else:
-            config_dir = osp.exists(osp.join(package_path, '.mim'))
-            assert config_dir, (
-                f'Cannot find Configs directory in {package_path}!, please '
-                f'check the completeness of the {scope}.')
+            config_dir = join_path(package_path, '.mim', 'configs')
+            if not exists(config_dir):
+                raise FileNotFoundError(
+                    f'Cannot find Configs directory in {package_path}!, '
+                    f'please check the completeness of the {scope}.')
         return config_dir
 
     def _init_model(
@@ -639,10 +640,10 @@ class BaseInferencer(metaclass=InferencerMeta):
         Yields:
             dict: Model config defined in metafile.
         """
-        meta_indexes = load(osp.join(config_dir, 'model-index.yml'))
+        meta_indexes = load(join_path(config_dir, 'model-index.yml'))
         for meta_path in meta_indexes['Import']:
             # meta_path example: mmcls/.mim/configs/conformer/metafile.yml
-            meta_path = osp.join(config_dir, meta_path)
+            meta_path = join_path(config_dir, meta_path)
             metainfo = load(meta_path)
             yield from metainfo['Models']
 

--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -413,14 +413,13 @@ class BaseInferencer(metaclass=InferencerMeta):
         # The first element of module.__path__ means package installation path.
         package_path = module.__path__[0]
 
-        if osp.exists(osp.join(package_path, '.mim')):
-            config_dir = osp.join(package_path, '.mim')
-        else:
-            assert osp.exists(
-                osp.join(osp.dirname(package_path), 'configs')
-            ), (f'Cannot find Configs directory in {package_path}!, please '
-                f'check the completeness of the {scope}.')
+        if osp.exists(osp.join(osp.dirname(package_path), 'configs')):
             config_dir = osp.dirname(package_path)
+        else:
+            config_dir = osp.exists(osp.join(package_path, '.mim'))
+            assert config_dir, (
+                f'Cannot find Configs directory in {package_path}!, please '
+                f'check the completeness of the {scope}.')
         return config_dir
 
     def _init_model(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Sometimes, downstream developers would like to set `PYTHONPATH=xxx` rather than install the package by `pip install -e .`. , then and `BaseInferencer` will raise an error in this case.

This PR will get the module path from `module.__path__` and do not check the installation of the downstream repos anymore. It will try to get the directory of `Config` from `${module._path}/.mim` (package is installed) or ``../${module._path}`` (package is not installed, but PYTHONPATH is set).

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
