### PR TITLE
[Speed Up] `BaseDataElement` supports `pin_memory` 

### DIFF
--- a/mmengine/structures/base_data_element.py
+++ b/mmengine/structures/base_data_element.py
@@ -5,6 +5,7 @@ from typing import Any, Iterator, Optional, Tuple, Type, Union
 
 import numpy as np
 import torch
+from torch.utils.data._utils.pin_memory import pin_memory
 
 
 class BaseDataElement:
@@ -560,6 +561,16 @@ class BaseDataElement:
             k: v.to_dict() if isinstance(v, BaseDataElement) else v
             for k, v in self.all_items()
         }
+
+    def pin_memory(self) -> 'BaseDataElement':
+        """BaseDataElement supports pin_memory function to speed up
+        training."""
+        for k, v in self.items():
+            if not isinstance(v, BaseDataElement):
+                setattr(self, k, pin_memory(v))
+            else:
+                setattr(self, k, v.pin_memory())
+        return self
 
     def __repr__(self) -> str:
         """Represent the object."""

--- a/tests/test_structures/test_data_element.py
+++ b/tests/test_structures/test_data_element.py
@@ -458,3 +458,16 @@ class TestBaseDataElement(TestCase):
         metainfo, data = self.setup_data()
         instances = BaseDataElement(metainfo=metainfo, **data)
         self.assertDictEqual(instances.metainfo, metainfo)
+
+    def test_pin_memory(self):
+        metainfo, data = self.setup_data()
+
+        instances = BaseDataElement(metainfo=metainfo, **data)
+        self.assertEqual(instances.gt_instances.bboxes.is_pinned(), False)
+        self.assertEqual(instances.gt_instances.labels.is_pinned(), False)
+        self.assertEqual(instances.pred_instances.bboxes.is_pinned(), False)
+
+        instances = instances.pin_memory()
+        self.assertEqual(instances.gt_instances.bboxes.is_pinned(), True)
+        self.assertEqual(instances.gt_instances.labels.is_pinned(), True)
+        self.assertEqual(instances.pred_instances.bboxes.is_pinned(), True)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Custom object `BaseDataElement` supports `pin_memory` function to speed up training. 

Note: The underlying logic has been modified, it's best to check if the relevant repo has been speeded up.

## Modification

- BaseDataElement add `pin_memory` function
- Add UT

## BC-breaking (Optional)
None

## Use cases (Optional)

dataloader needs to be enabled `pin_memory=True`.  
