### PR TITLE
[Feature] Feature  NPUProfilerHook 

### DIFF
--- a/docs/en/api/hooks.rst
+++ b/docs/en/api/hooks.rst
@@ -23,4 +23,5 @@ mmengine.hooks
    SyncBuffersHook
    EmptyCacheHook
    ProfilerHook
+   NPUProfilerHook
    PrepareTTAHook

--- a/docs/zh_cn/api/hooks.rst
+++ b/docs/zh_cn/api/hooks.rst
@@ -23,4 +23,5 @@ mmengine.hooks
    SyncBuffersHook
    EmptyCacheHook
    ProfilerHook
+   NPUProfilerHook
    PrepareTTAHook

--- a/mmengine/hooks/__init__.py
+++ b/mmengine/hooks/__init__.py
@@ -7,7 +7,7 @@ from .iter_timer_hook import IterTimerHook
 from .logger_hook import LoggerHook
 from .naive_visualization_hook import NaiveVisualizationHook
 from .param_scheduler_hook import ParamSchedulerHook
-from .profiler_hook import ProfilerHook
+from .profiler_hook import NPUProfilerHook, ProfilerHook
 from .runtime_info_hook import RuntimeInfoHook
 from .sampler_seed_hook import DistSamplerSeedHook
 from .sync_buffer_hook import SyncBuffersHook
@@ -17,5 +17,5 @@ __all__ = [
     'Hook', 'IterTimerHook', 'DistSamplerSeedHook', 'ParamSchedulerHook',
     'SyncBuffersHook', 'EmptyCacheHook', 'CheckpointHook', 'LoggerHook',
     'NaiveVisualizationHook', 'EMAHook', 'RuntimeInfoHook', 'ProfilerHook',
-    'PrepareTTAHook'
+    'NPUProfilerHook', 'PrepareTTAHook'
 ]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Implement the profiler function on NPU devices.

## Modification


Added NPUProfilerHook class.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
No

## Use cases (Optional)

\>>> cfg = Config.fromfile(args.config) 
\>>> profiler_config = [dict(type='NPUProfilerHook', profiler_result_path='./cann_profiling')]
\>>> cfg.merge_from_dict({'custom_hooks': profiler_config })
\>>> runner = Runner.from_cfg(cfg)

Export timeline data
python /usr/local/Ascend/ascend-toolkit/latest/toolkit/tools/profiler/profiler_tool/analysis/msprof/msprof.py export  timeline -dir ./cann_profiling

Export summary data
python /usr/local/Ascend/ascend-toolkit/latest/toolkit/tools/profiler/profiler_tool/analysis/msprof/msprof.py export  summary -dir ./cann_profiling

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.