### PR TITLE
[Enhance] beautify the print result of the registry

### DIFF
--- a/mmengine/registry/registry.py
+++ b/mmengine/registry/registry.py
@@ -7,6 +7,8 @@ from contextlib import contextmanager
 from importlib import import_module
 from typing import Any, Dict, Generator, List, Optional, Tuple, Type, Union
 
+from tabulate import tabulate
+
 from mmengine.config.utils import MODULE2PACKAGE
 from mmengine.utils import is_seq_of
 from .default_scope import DefaultScope
@@ -120,9 +122,12 @@ class Registry:
         return self.get(key) is not None
 
     def __repr__(self):
-        format_str = self.__class__.__name__ + \
-                     f'(name={self._name}, ' \
-                     f'items={self._module_dict})'
+        table_headers = ['Names', 'Objects']
+        table = tabulate(
+            self._module_dict.items(),
+            headers=table_headers,
+            tablefmt='fancy_grid')
+        format_str = f'Registry of {self._name}:\n' + table
         return format_str
 
     @staticmethod

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -4,5 +4,6 @@ numpy
 pyyaml
 regex;sys_platform=='win32'
 rich
+tabulate
 termcolor
 yapf

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -2,6 +2,7 @@
 import time
 
 import pytest
+from tabulate import tabulate
 
 from mmengine.config import Config, ConfigDict  # type: ignore
 from mmengine.registry import (DefaultScope, Registry, build_from_cfg,
@@ -473,14 +474,17 @@ class TestRegistry:
         class Munchkin:
             pass
 
-        repr_str = 'Registry(name=cat, items={'
-        repr_str += (
-            "'BritishShorthair': <class 'test_registry.TestRegistry.test_repr."
-            "<locals>.BritishShorthair'>, ")
-        repr_str += (
-            "'Munchkin': <class 'test_registry.TestRegistry.test_repr."
-            "<locals>.Munchkin'>")
-        repr_str += '})'
+        table_content = [
+            ('BritishShorthair',
+             "<class 'test_registry.TestRegistry.test_repr."
+             "<locals>.BritishShorthair'>"),
+            ('Munchkin', "<class 'test_registry.TestRegistry.test_repr."
+             "<locals>.Munchkin'>"),
+        ]
+        table = tabulate(
+            table_content, headers=['Names', 'Objects'], tablefmt='fancy_grid')
+        repr_str = 'Registry of cat:\n'
+        repr_str += table
         assert repr(CATS) == repr_str
 
 

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -474,12 +474,10 @@ class TestRegistry:
         class Munchkin:
             pass
 
+        item_prefix = "<class 'test_registry.TestRegistry.test_repr.<locals>."
         table_content = [
-            ('BritishShorthair',
-             "<class 'test_registry.TestRegistry.test_repr."
-             "<locals>.BritishShorthair'>"),
-            ('Munchkin', "<class 'test_registry.TestRegistry.test_repr."
-             "<locals>.Munchkin'>"),
+            ('BritishShorthair', item_prefix + "BritishShorthair'>"),
+            ('Munchkin', item_prefix + "Munchkin'>"),
         ]
         table = tabulate(
             table_content, headers=['Names', 'Objects'], tablefmt='fancy_grid')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

For better debug usages

## Modification

- `requirements/runtime.txt`
    - add tabulate requirement
- `mmengine\registry\registry.py`
    - use tabulate to format the repr str
- `tests\test_registry\test_registry.py`
    - modify the repr test

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
