### PR TITLE
[Docs] Temporarily skip errors in building pdf docs at readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,6 @@
 version: 2
 
 formats:
-    - html
     - epub
 
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,8 @@
 version: 2
 
-formats: all
+formats:
+    - html
+    - epub
 
 python:
   version: 3.7

--- a/docs/en/advanced_tutorials/test_time_augmentation.md
+++ b/docs/en/advanced_tutorials/test_time_augmentation.md
@@ -4,7 +4,7 @@ Test time augmentation (TTA) is a data augmentation strategy used during the tes
 
 The core implementation of TTA is usually divided into two parts：
 
-1. Data augmentation: This part is implemented in MMCV, see the api docs [TestTimeAug](mmcv.transform.TestTimeAug) for more information.
+1. Data augmentation: This part is implemented in MMCV, see the api docs [TestTimeAug](mmcv.transforms.TestTimeAug) for more information.
 2. Merge the predictions: The subclasses of `BaseTTAModel` will merge the predictions of enhanced data in the `test_step` method to improve the accuracy of predictions.
 
 ## Get started

--- a/docs/en/notes/contributing.md
+++ b/docs/en/notes/contributing.md
@@ -214,11 +214,11 @@ We use the following tools for linting and formatting:
 - [mdformat](https://github.com/executablebooks/mdformat): Mdformat is an opinionated Markdown formatter that can be used to enforce a consistent style in Markdown files.
 - [docformatter](https://github.com/myint/docformatter): A formatter to format docstring.
 
-Style configurations of yapf and isort can be found in [setup.cfg](../../../setup.cfg).
+Style configurations of yapf and isort can be found in setup.cfg.
 
 We use [pre-commit hook](https://pre-commit.com/) that checks and formats for `flake8`, `yapf`, `isort`, `trailing whitespaces`, `markdown files`,
 fixes `end-of-files`, `double-quoted-strings`, `python-encoding-pragma`, `mixed-line-ending`, sorts `requirments.txt` automatically on every commit.
-The config for a pre-commit hook is stored in [.pre-commit-config](../../../.pre-commit-config.yaml).
+The config for a pre-commit hook is stored in .pre-commit-config.
 
 ## PR Specs
 

--- a/docs/en/notes/contributing.md
+++ b/docs/en/notes/contributing.md
@@ -214,11 +214,11 @@ We use the following tools for linting and formatting:
 - [mdformat](https://github.com/executablebooks/mdformat): Mdformat is an opinionated Markdown formatter that can be used to enforce a consistent style in Markdown files.
 - [docformatter](https://github.com/myint/docformatter): A formatter to format docstring.
 
-Style configurations of yapf and isort can be found in setup.cfg.
+Style configurations of yapf and isort can be found in [setup.cfg](https://github.com/open-mmlab/mmengine/blob/main/setup.cfg).
 
 We use [pre-commit hook](https://pre-commit.com/) that checks and formats for `flake8`, `yapf`, `isort`, `trailing whitespaces`, `markdown files`,
 fixes `end-of-files`, `double-quoted-strings`, `python-encoding-pragma`, `mixed-line-ending`, sorts `requirments.txt` automatically on every commit.
-The config for a pre-commit hook is stored in .pre-commit-config.
+The config for a pre-commit hook is stored in [.pre-commit-config](https://github.com/open-mmlab/mmengine/blob/main/.pre-commit-config.yaml).
 
 ## PR Specs
 

--- a/docs/zh_cn/advanced_tutorials/test_time_augmentation.md
+++ b/docs/zh_cn/advanced_tutorials/test_time_augmentation.md
@@ -4,7 +4,7 @@
 
 TTA 的核心实现通常分为两个部分：
 
-1. 测试时的数据增强：测试时数据增强主要在 MMCV 中实现，可以参考 [TestTimeAug 的 API 文档](mmcv.transform.TestTimeAug)，本文档不再赘述。
+1. 测试时的数据增强：测试时数据增强主要在 MMCV 中实现，可以参考 [TestTimeAug 的 API 文档](mmcv.transforms.TestTimeAug)，本文档不再赘述。
 2. 模型推理以及结果融合：`BaseTTAModel` 的主要功能就是实现这一部分，`BaseTTAModel.test_step` 会解析测试时增强后的数据并进行推理。用户继承 `BaseTTAModel` 后只需实现相应的融合策略即可。
 
 ## 快速上手

--- a/docs/zh_cn/notes/contributing.md
+++ b/docs/zh_cn/notes/contributing.md
@@ -227,7 +227,7 @@ make html
 yapf 和 isort 的配置可以在 [setup.cfg](https://github.com/open-mmlab/mmengine/blob/main/setup.cfg) 找到
 
 通过配置 [pre-commit hook](https://pre-commit.com/) ，我们可以在提交代码时自动检查和格式化 `flake8`、`yapf`、`isort`、`trailing whitespaces`、`markdown files`，修复 `end-of-files`、`double-quoted-strings`、`python-encoding-pragma`、`mixed-line-ending`，调整 `requirments.txt` 的包顺序。
-pre-commit 钩子的配置可以在 [.pre-commit-config](https://github.com/open-mmlab/mmengine/blob/main/.pre-commit-config.yaml) 找到。
+pre-commit 钩子的配置可以在 [.pre-commit-config](https://github.com/open-mmlab/mmengine/blob/main/.pre-commit-config-zh-cn.yaml) 找到。
 
 pre-commit 具体的安装使用方式见[拉取请求](#2-配置-pre-commit)。
 

--- a/docs/zh_cn/notes/contributing.md
+++ b/docs/zh_cn/notes/contributing.md
@@ -224,10 +224,10 @@ make html
 - [mdformat](https://github.com/executablebooks/mdformat): 检查 markdown 文件的工具
 - [docformatter](https://github.com/myint/docformatter): 格式化 docstring 的工具
 
-yapf 和 isort 的配置可以在 [setup.cfg](../../../setup.cfg) 找到
+yapf 和 isort 的配置可以在 setup.cfg 找到
 
 通过配置 [pre-commit hook](https://pre-commit.com/) ，我们可以在提交代码时自动检查和格式化 `flake8`、`yapf`、`isort`、`trailing whitespaces`、`markdown files`，修复 `end-of-files`、`double-quoted-strings`、`python-encoding-pragma`、`mixed-line-ending`，调整 `requirments.txt` 的包顺序。
-pre-commit 钩子的配置可以在 [.pre-commit-config](../../../.pre-commit-config.yaml) 找到。
+pre-commit 钩子的配置可以在 .pre-commit-config 找到。
 
 pre-commit 具体的安装使用方式见[拉取请求](#2-配置-pre-commit)。
 

--- a/docs/zh_cn/notes/contributing.md
+++ b/docs/zh_cn/notes/contributing.md
@@ -224,10 +224,10 @@ make html
 - [mdformat](https://github.com/executablebooks/mdformat): 检查 markdown 文件的工具
 - [docformatter](https://github.com/myint/docformatter): 格式化 docstring 的工具
 
-yapf 和 isort 的配置可以在 setup.cfg 找到
+yapf 和 isort 的配置可以在 [setup.cfg](https://github.com/open-mmlab/mmengine/blob/main/setup.cfg) 找到
 
 通过配置 [pre-commit hook](https://pre-commit.com/) ，我们可以在提交代码时自动检查和格式化 `flake8`、`yapf`、`isort`、`trailing whitespaces`、`markdown files`，修复 `end-of-files`、`double-quoted-strings`、`python-encoding-pragma`、`mixed-line-ending`，调整 `requirments.txt` 的包顺序。
-pre-commit 钩子的配置可以在 .pre-commit-config 找到。
+pre-commit 钩子的配置可以在 [.pre-commit-config](https://github.com/open-mmlab/mmengine/blob/main/.pre-commit-config.yaml) 找到。
 
 pre-commit 具体的安装使用方式见[拉取请求](#2-配置-pre-commit)。
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

PR #915 spoiled docs building process in readthedocs. Reasons under investigation. This PR temporarily disabled building pdf docs to skip this error.

## Modification

## BC-breaking (Optional)

## Use cases (Optional)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
