### PR TITLE
[Fix] Support configure torch.backends.cudnn.deterministic when CUDA>=10.2

### DIFF
--- a/mmengine/runner/utils.py
+++ b/mmengine/runner/utils.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import logging
+import os
 import random
 from typing import List, Optional, Tuple
 
@@ -71,11 +72,14 @@ def set_random_seed(seed: Optional[int] = None,
     torch.cuda.manual_seed_all(seed)
     # os.environ['PYTHONHASHSEED'] = str(seed)
     if deterministic:
+        if digit_version(torch.version.cuda) >= digit_version('10.2'):
+            os.environ['CUBLAS_WORKSPACE_CONFIG'] = ':16:8'
         if torch.backends.cudnn.benchmark:
             print_log(
                 'torch.backends.cudnn.benchmark is going to be set as '
                 '`False` to cause cuDNN to deterministically select an '
-                'algorithm',
+                'algorithm, which may limit overall performance, see more '
+                'informaton in https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility',  # noqa: E501
                 logger='current',
                 level=logging.WARNING)
         torch.backends.cudnn.deterministic = True


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Runner will raise an error if `deterministic` is set to False when CUDA >=10.2. According to the [official guide](https://docs.nvidia.com/cuda/cublas/index.html#cublasApi_reproducibility), set `CUBLAS_WORKSPACE_CONFIG=:16:8` in the environment variable could avoid the error (may limit overall performance).

```bash
RuntimeError: Deterministic behavior was enabled with either `torch.use_deterministic_algorithms(True)` or `at::Context::setDeterministicAlgorithms(true)`, but this operation is not deterministic because it uses CuBLAS and you have CUDA >= 10.2. To enable deterministic behavior in this case, you must set an environment variable before running your PyTorch application: CUBLAS_WORKSPACE_CONFIG=:4096:8 or CUBLAS_WORKSPACE_CONFIG=:16:8. For more information, go to https://docs.nvidia.com/cuda/cublas/index.html#cublasApi_reproducibility
```

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
