### PR TITLE
Refine the repr of Registry

### DIFF
--- a/mmengine/registry/registry.py
+++ b/mmengine/registry/registry.py
@@ -1,6 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import inspect
-import io
 import logging
 import sys
 from collections.abc import Callable
@@ -131,11 +130,11 @@ class Registry:
         for name, obj in sorted(self._module_dict.items()):
             table.add_row(name, str(obj))
 
-        with io.StringIO() as sio:
-            console = Console(file=sio)
+        console = Console()
+        with console.capture() as capture:
             console.print(table, end='')
-            table_str = sio.getvalue()
-        return table_str
+
+        return capture.get()
 
     @staticmethod
     def infer_scope() -> str:

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -475,9 +475,7 @@ class TestRegistry:
 
         assert 'Registry of cat' in repr(CATS)
         assert 'BritishShorthair' in repr(CATS)
-        assert "test_repr.<locals>.BritishShorthair'>" in repr(CATS)
         assert 'Munchkin' in repr(CATS)
-        assert "test_repr.<locals>.Munchkin'>" in repr(CATS)
 
 
 @pytest.mark.parametrize('cfg_type', [dict, ConfigDict, Config])

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -475,11 +475,9 @@ class TestRegistry:
 
         assert 'Registry of cat' in repr(CATS)
         assert 'BritishShorthair' in repr(CATS)
-        assert ("<class 'test_registry.TestRegistry.test_repr."
-                "<locals>.BritishShorthair'>") in repr(CATS)
+        assert "test_repr.<locals>.BritishShorthair'>" in repr(CATS)
         assert 'Munchkin' in repr(CATS)
-        assert ("<class 'test_registry.TestRegistry.test_repr."
-                "<locals>.Munchkin'>") in repr(CATS)
+        assert "test_repr.<locals>.Munchkin'>" in repr(CATS)
 
 
 @pytest.mark.parametrize('cfg_type', [dict, ConfigDict, Config])

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -1,9 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import io
 import time
 
 import pytest
-from rich.console import Console
 
 from mmengine.config import Config, ConfigDict  # type: ignore
 from mmengine.registry import (DefaultScope, Registry, build_from_cfg,
@@ -475,12 +473,13 @@ class TestRegistry:
         class Munchkin:
             pass
 
-        with io.StringIO() as sio:
-            console = Console(file=sio)
-            console.print(CATS, end='')
-            repr_str = sio.getvalue()
-
-        assert repr(CATS) == repr_str
+        assert 'Registry of cat' in repr(CATS)
+        assert 'BritishShorthair' in repr(CATS)
+        assert ("<class 'test_registry.TestRegistry.test_repr."
+                "<locals>.BritishShorthair'>") in repr(CATS)
+        assert 'Munchkin' in repr(CATS)
+        assert ("<class 'test_registry.TestRegistry.test_repr."
+                "<locals>.Munchkin'>") in repr(CATS)
 
 
 @pytest.mark.parametrize('cfg_type', [dict, ConfigDict, Config])


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When calling `a = repr(OPTIMIZERS)`, nothing should be printed.

- Before this PR

```python
import mmengine.optim
from mmengine.registry import OPTIMIZERS
a = repr(OPTIMIZERS)  # print a table. It should not print anything.
```

- After this PR

```python
import mmengine.optim
from mmengine.registry import OPTIMIZERS
a = repr(OPTIMIZERS)  # do not print a table
```

```python
print(a)
```

![image](https://user-images.githubusercontent.com/58739961/220163606-2d14680c-1466-4130-96ac-62de04e35018.png)

```python
>>> OPTIMIZERS
```
![image](https://user-images.githubusercontent.com/58739961/220163859-e8f425b4-d481-44cb-a087-fb9cb6fb4b6d.png)

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
