### PR TITLE
[Feature] enable bf16 in AmpOptimWrapper

### DIFF
--- a/docs/en/common_usage/speed_up_training.md
+++ b/docs/en/common_usage/speed_up_training.md
@@ -60,7 +60,7 @@ MMEngine supports training models with CPU, single GPU, multiple GPUs in single 
 
 ## Mixed Precision Training
 
-Nvidia introduced the Tensor Core unit into the Volta and Turing architectures to support FP32 and FP16 mixed precision computing. With automatic mixed precision training enabled, some operators operate at FP16 and the rest operate at FP32, which reduces training time and storage requirements without changing the model or degrading its training precision, thus supporting training with larger batch sizes, larger models, and larger input sizes.
+Nvidia introduced the Tensor Core unit into the Volta and Turing architectures to support FP32 and FP16 mixed precision computing. They further support BF16 in Ampere architectures. With automatic mixed precision training enabled, some operators operate at FP16/BF16 and the rest operate at FP32, which reduces training time and storage requirements without changing the model or degrading its training precision, thus supporting training with larger batch sizes, larger models, and larger input sizes.
 
 [PyTorch officially supports amp from 1.6](https://pytorch.org/blog/accelerating-training-on-nvidia-gpus-with-pytorch-automatic-mixed-precision/). If you are interested in the implementation of automatic mixing precision, you can refer to [Mixed Precision Training](https://docs.nvidia.com/deeplearning/performance/mixed-precision-training/index.html).
 
@@ -71,8 +71,16 @@ runner = Runner(
     model=ResNet18(),
     work_dir='./work_dir',
     train_dataloader=train_dataloader_cfg,
-    optim_wrapper=dict(type='AmpOptimWrapper', optimizer=dict(type='SGD', lr=0.001, momentum=0.9)),
+    optim_wrapper=dict(
+        type='AmpOptimWrapper',
+        # If you want to use bfloat16, uncomment the following line
+        # dtype='bfloat16',  # valid values: ('float16', 'bfloat16', None)
+        optimizer=dict(type='SGD', lr=0.001, momentum=0.9)),
     train_cfg=dict(by_epoch=True, max_epochs=3),
 )
 runner.train()
+```
+
+```{warning}
+Up till PyTorch 1.13, `torch.bfloat16` performance on `Convolution` is bad unless manually set environment variable `TORCH_CUDNN_V8_API_ENABLED=1`. More context at [PyTorch issue](https://github.com/pytorch/pytorch/issues/57707#issuecomment-1166656767)
 ```

--- a/docs/zh_cn/common_usage/speed_up_training.md
+++ b/docs/zh_cn/common_usage/speed_up_training.md
@@ -61,7 +61,7 @@ MMEngine 支持 CPU、单卡、单机多卡以及多机多卡的训练。当环�
 
 ## 混合精度训练
 
-Nvidia 在 Volta 和 Turing 架构中引入 Tensor Core 单元，来支持 FP32 和 FP16 混合精度计算。开启自动混合精度训练后，部分算子的操作精度是 FP16，其余算子的操作精度是 FP32。这样在不改变模型、不降低模型训练精度的前提下，可以缩短训练时间，降低存储需求，因而能支持更大的 batch size、更大模型和尺寸更大的输入的训练。
+Nvidia 在 Volta 和 Turing 架构中引入 Tensor Core 单元，来支持 FP32 和 FP16 混合精度计算。在 Ampere 架构中，他们进一步支持了 BF16 计算。开启自动混合精度训练后，部分算子的操作精度是 FP16/BF16，其余算子的操作精度是 FP32。这样在不改变模型、不降低模型训练精度的前提下，可以缩短训练时间，降低存储需求，因而能支持更大的 batch size、更大模型和尺寸更大的输入的训练。
 
 [PyTorch 从 1.6 开始官方支持 amp](https://pytorch.org/blog/accelerating-training-on-nvidia-gpus-with-pytorch-automatic-mixed-precision/)。如果你对自动混合精度的实现感兴趣，可以阅读 [torch.cuda.amp: 自动混合精度详解](https://zhuanlan.zhihu.com/p/348554267)。
 
@@ -72,8 +72,16 @@ runner = Runner(
     model=ResNet18(),
     work_dir='./work_dir',
     train_dataloader=train_dataloader_cfg,
-    optim_wrapper=dict(type='AmpOptimWrapper', optimizer=dict(type='SGD', lr=0.001, momentum=0.9)),
+    optim_wrapper=dict(
+        type='AmpOptimWrapper',
+        # 如果你想要使用 BF16，请取消下面一行的代码注释
+        # dtype='bfloat16',  # 可用值： ('float16', 'bfloat16', None)
+        optimizer=dict(type='SGD', lr=0.001, momentum=0.9)),
     train_cfg=dict(by_epoch=True, max_epochs=3),
 )
 runner.train()
+```
+
+```{warning}
+截止到 PyTorch 1.13 版本，在 `Convolution` 中直接使用 `torch.bfloat16` 性能低下，必须手动设置环境变量 `TORCH_CUDNN_V8_API_ENABLED=1` 以启用 CuDNN 版本的 BF16 Convolution。相关讨论见 [PyTorch Issue](https://github.com/pytorch/pytorch/issues/57707#issuecomment-1166656767)
 ```

--- a/mmengine/optim/optimizer/amp_optimizer_wrapper.py
+++ b/mmengine/optim/optimizer/amp_optimizer_wrapper.py
@@ -48,7 +48,7 @@ class AmpOptimWrapper(OptimWrapper):
 
     Warnings:
         ``dtype`` argument is only available with PyTorch version >= 1.10.0. If
-        you use PyTorch of an older version, it will fallback to ``float16``.
+        you use PyTorch of an older version, it will be ignored.
 
     Note:
         If you use ``IterBasedRunner`` and enable gradient accumulation,

--- a/mmengine/optim/optimizer/amp_optimizer_wrapper.py
+++ b/mmengine/optim/optimizer/amp_optimizer_wrapper.py
@@ -40,8 +40,8 @@ class AmpOptimWrapper(OptimWrapper):
 
         dtype (str or torch.dtype, optional): The data type to autocast in amp.
             If a ``str`` is given, it will be converted to ``torch.dtype``.
-            Valid ``str`` format are `'float16'`, `'float32'`, `'bfloat16'`. If
-            set to ``None``, the default data type will be used.
+            Valid ``str`` format are `'float16'`, `'bfloat16'`, `'float32'`,
+            `'float64'`. If set to ``None``, the default data type will be used.
             Defaults to None.
 
         **kwargs: Keyword arguments passed to OptimWrapper.
@@ -51,6 +51,8 @@ class AmpOptimWrapper(OptimWrapper):
         the original `max_iters` should be multiplied by
         ``accumulative_counts``.
     """
+
+    valid_dtypes = ('float64', 'float32', 'float16', 'bfloat16', 'half')
 
     def __init__(self, loss_scale='dynamic', dtype=None, **kwargs):
         assert digit_version(TORCH_VERSION) >= digit_version('1.6.0'), (
@@ -76,13 +78,10 @@ class AmpOptimWrapper(OptimWrapper):
 
         # convert string value to torch.dtype
         if isinstance(dtype, str):
-            try:
-                dtype = getattr(torch, dtype)
-            except AttributeError:
-                raise ValueError(f'{dtype} does not name a torch.dtype. '
-                                 'You may want to use "float16", '
-                                 '"bfloat16" etc.')
-        # check the type of dtype
+            assert dtype in self.valid_dtypes, (
+                f'dtype should be any of {self.valid_dtypes}, got {dtype}')
+            dtype = getattr(torch, dtype)
+
         assert dtype is None or isinstance(dtype, torch.dtype), (
             f'dtype should be None or instance of torch.dtype, got {dtype}')
         self.cast_dtype = dtype

--- a/mmengine/optim/optimizer/amp_optimizer_wrapper.py
+++ b/mmengine/optim/optimizer/amp_optimizer_wrapper.py
@@ -41,8 +41,9 @@ class AmpOptimWrapper(OptimWrapper):
 
         dtype (str or torch.dtype, optional): The data type to autocast in amp.
             If a ``str`` is given, it will be converted to ``torch.dtype``.
-            Valid ``str`` format are `'float16'` and `'bfloat16'`. If set to
-            ``None``, the default data type will be used. Defaults to None.
+            Valid ``str`` format are `'float16'`, `'bfloat16'`, `'float32'` and
+            `'float64'`. If set to ``None``, the default data type will be used.
+            Defaults to None.
             `New in version 0.6.1.`
         **kwargs: Keyword arguments passed to OptimWrapper.
 
@@ -56,7 +57,7 @@ class AmpOptimWrapper(OptimWrapper):
         ``accumulative_counts``.
     """
 
-    valid_dtypes = ('float16', 'bfloat16')
+    valid_dtypes = ('float16', 'bfloat16', 'float32', 'float64')
 
     def __init__(self,
                  loss_scale: str = 'dynamic',

--- a/mmengine/optim/optimizer/amp_optimizer_wrapper.py
+++ b/mmengine/optim/optimizer/amp_optimizer_wrapper.py
@@ -80,8 +80,8 @@ class AmpOptimWrapper(OptimWrapper):
                 dtype = getattr(torch, dtype)
             except AttributeError:
                 raise ValueError(f'{dtype} does not name a torch.dtype. '
-                                 'You may want to use "float32", '
-                                 '"bfloat32" etc.')
+                                 'You may want to use "float16", '
+                                 '"bfloat16" etc.')
         # check the type of dtype
         assert dtype is None or isinstance(dtype, torch.dtype), (
             f'dtype should be None or instance of torch.dtype, got {dtype}')

--- a/mmengine/optim/optimizer/amp_optimizer_wrapper.py
+++ b/mmengine/optim/optimizer/amp_optimizer_wrapper.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from contextlib import contextmanager
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -54,7 +55,10 @@ class AmpOptimWrapper(OptimWrapper):
 
     valid_dtypes = ('float64', 'float32', 'float16', 'bfloat16', 'half')
 
-    def __init__(self, loss_scale='dynamic', dtype=None, **kwargs):
+    def __init__(self,
+                 loss_scale: str = 'dynamic',
+                 dtype: Optional[Union[str, torch.dtype]] = None,
+                 **kwargs):
         assert digit_version(TORCH_VERSION) >= digit_version('1.6.0'), (
             '`torch.cuda.amp` is only available when pytorch version >= 1.6')
         assert is_cuda_available() or is_npu_available(), (

--- a/mmengine/optim/optimizer/amp_optimizer_wrapper.py
+++ b/mmengine/optim/optimizer/amp_optimizer_wrapper.py
@@ -41,9 +41,8 @@ class AmpOptimWrapper(OptimWrapper):
 
         dtype (str or torch.dtype, optional): The data type to autocast in amp.
             If a ``str`` is given, it will be converted to ``torch.dtype``.
-            Valid ``str`` format are `'float16'`, `'bfloat16'`, `'float32'`,
-            `'float64'`. If set to ``None``, the default data type will be used.
-            Defaults to None.
+            Valid ``str`` format are `'float16'` and `'bfloat16'`. If set to
+            ``None``, the default data type will be used. Defaults to None.
             `New in version 0.6.1.`
         **kwargs: Keyword arguments passed to OptimWrapper.
 
@@ -57,7 +56,7 @@ class AmpOptimWrapper(OptimWrapper):
         ``accumulative_counts``.
     """
 
-    valid_dtypes = ('float64', 'float32', 'float16', 'bfloat16', 'half')
+    valid_dtypes = ('float16', 'bfloat16')
 
     def __init__(self,
                  loss_scale: str = 'dynamic',

--- a/mmengine/optim/optimizer/amp_optimizer_wrapper.py
+++ b/mmengine/optim/optimizer/amp_optimizer_wrapper.py
@@ -38,6 +38,12 @@ class AmpOptimWrapper(OptimWrapper):
             - float: Initialize GradScaler with ``init_scale``.
             - dict: Initialize GradScaler with more detail configuration.
 
+        dtype (str or torch.dtype, optional): The data type to autocast in amp.
+            If a ``str`` is given, it will be converted to ``torch.dtype``.
+            Valid ``str`` format are `'float16'`, `'float32'`, `'bfloat16'`. If
+            set to ``None``, the default data type will be used.
+            Defaults to None.
+
         **kwargs: Keyword arguments passed to OptimWrapper.
 
     Note:

--- a/mmengine/optim/optimizer/amp_optimizer_wrapper.py
+++ b/mmengine/optim/optimizer/amp_optimizer_wrapper.py
@@ -44,8 +44,12 @@ class AmpOptimWrapper(OptimWrapper):
             Valid ``str`` format are `'float16'`, `'bfloat16'`, `'float32'`,
             `'float64'`. If set to ``None``, the default data type will be used.
             Defaults to None.
-
+            `New in version 0.6.1.`
         **kwargs: Keyword arguments passed to OptimWrapper.
+
+    Warnings:
+        ``dtype`` argument is only available with PyTorch version >= 1.10.0. If
+        you use PyTorch of an older version, it will fallback to ``float16``.
 
     Note:
         If you use ``IterBasedRunner`` and enable gradient accumulation,

--- a/mmengine/optim/optimizer/amp_optimizer_wrapper.py
+++ b/mmengine/optim/optimizer/amp_optimizer_wrapper.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from contextlib import contextmanager
-from typing import Optional, Union
+from typing import Union
 
 import torch
 import torch.nn as nn
@@ -60,7 +60,7 @@ class AmpOptimWrapper(OptimWrapper):
 
     def __init__(self,
                  loss_scale: str = 'dynamic',
-                 dtype: Optional[Union[str, torch.dtype]] = None,
+                 dtype: Union[str, torch.dtype] = None,
                  **kwargs):
         assert digit_version(TORCH_VERSION) >= digit_version('1.6.0'), (
             '`torch.cuda.amp` is only available when pytorch version >= 1.6')

--- a/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
+++ b/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
@@ -393,7 +393,7 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        and (digit_version(TORCH_VERSION) >= digit_version('1.6.0')),
+        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
         reason='`torch.cuda.amp` is only available when pytorch-gpu version '
         '>= 1.6')
     def test_init(self):
@@ -428,7 +428,7 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        and (digit_version(TORCH_VERSION) >= digit_version('1.6.0')),
+        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
         reason='`torch.cuda.amp` is only available when pytorch-gpu version '
         '>= 1.6')
     def test_step(self):
@@ -443,7 +443,7 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        and (digit_version(TORCH_VERSION) >= digit_version('1.6.0')),
+        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
         reason='`torch.cuda.amp` is only available when pytorch-gpu version '
         '>= 1.6')
     def test_backward(self):
@@ -460,7 +460,7 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        and (digit_version(TORCH_VERSION) >= digit_version('1.6.0')),
+        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
         reason='`torch.cuda.amp` is only available when pytorch-gpu version '
         '>= 1.6')
     def test_state_dict(self):
@@ -479,7 +479,7 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        and (digit_version(TORCH_VERSION) >= digit_version('1.6.0')),
+        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
         reason='`torch.cuda.amp` is only available when pytorch-gpu version '
         '>= 1.6')
     def test_load_state_dict(self):
@@ -503,7 +503,7 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        and (digit_version(TORCH_VERSION) >= digit_version('1.6.0')),
+        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
         reason='`torch.cuda.amp` is only available when pytorch-gpu version '
         '>= 1.6')
     def test_optim_context(self):
@@ -515,9 +515,9 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        and (digit_version(TORCH_VERSION) >= digit_version('1.6.0'))
-        and hasattr(torch.cuda, 'is_bf16_supported')
-        and torch.cuda.is_bf16_supported(),
+        or (digit_version(TORCH_VERSION) < digit_version('1.6.0'))
+        or not hasattr(torch.cuda, 'is_bf16_supported')
+        or not torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
         'version >= 1.6 && bf16 supported by device')
     def test_step_bf16(self):
@@ -533,9 +533,9 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        and (digit_version(TORCH_VERSION) >= digit_version('1.6.0'))
-        and hasattr(torch.cuda, 'is_bf16_supported')
-        and torch.cuda.is_bf16_supported(),
+        or (digit_version(TORCH_VERSION) < digit_version('1.6.0'))
+        or not hasattr(torch.cuda, 'is_bf16_supported')
+        or not torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
         'version >= 1.6 && bf16 supported by device')
     def test_backward_bf16(self):
@@ -553,9 +553,9 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        and (digit_version(TORCH_VERSION) >= digit_version('1.6.0'))
-        and hasattr(torch.cuda, 'is_bf16_supported')
-        and torch.cuda.is_bf16_supported(),
+        or (digit_version(TORCH_VERSION) < digit_version('1.6.0'))
+        or not hasattr(torch.cuda, 'is_bf16_supported')
+        or not torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
         'version >= 1.6 && bf16 supported by device')
     def test_state_dict_bf16(self):
@@ -575,9 +575,9 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        and (digit_version(TORCH_VERSION) >= digit_version('1.6.0'))
-        and hasattr(torch.cuda, 'is_bf16_supported')
-        and torch.cuda.is_bf16_supported(),
+        or (digit_version(TORCH_VERSION) < digit_version('1.6.0'))
+        or not hasattr(torch.cuda, 'is_bf16_supported')
+        or not torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
         'version >= 1.6 && bf16 supported by device')
     def test_load_state_dict_bf16(self):
@@ -602,9 +602,9 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        and (digit_version(TORCH_VERSION) >= digit_version('1.6.0'))
-        and hasattr(torch.cuda, 'is_bf16_supported')
-        and torch.cuda.is_bf16_supported(),
+        or (digit_version(TORCH_VERSION) < digit_version('1.6.0'))
+        or not hasattr(torch.cuda, 'is_bf16_supported')
+        or not torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
         'version >= 1.6 && bf16 supported by device')
     def test_optim_context_bf16(self):

--- a/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
+++ b/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     pass
 
-amp_valid_dtypes = ['float16', 'bfloat16', None]
+amp_valid_dtypes = ['float64', 'float32', 'float16', 'bfloat16', None]
 torch_dtypes = [
     torch.float16 if dtype is None else getattr(torch, dtype)
     for dtype in amp_valid_dtypes
@@ -514,7 +514,8 @@ class TestAmpOptimWrapper(TestCase):
     def test_optim_context(self, dtype, target_dtype):
         if dtype == 'bfloat16' and not bf16_supported():
             raise unittest.SkipTest('bfloat16 not supported by device')
-        amp_optim_wrapper = AmpOptimWrapper(optimizer=self.optimizer)
+        amp_optim_wrapper = AmpOptimWrapper(
+            optimizer=self.optimizer, dtype=dtype)
         with amp_optim_wrapper.optim_context(self.model):
             x = torch.randn(1, 1, 1, 1).cuda()
             y = nn.Conv2d(1, 1, 1).cuda()(x)

--- a/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
+++ b/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
@@ -433,10 +433,10 @@ class TestAmpOptimWrapper(TestCase):
                                     'loss_scale must be of type float'):
             AmpOptimWrapper(optimizer=self.optimizer, loss_scale='unknown')
 
+    @parameterized.expand(list(zip(amp_valid_dtypes)))
     @unittest.skipIf(
         not torch.cuda.is_available(),
         reason='`torch.cuda.amp` is only available when pytorch-gpu installed')
-    @parameterized.expand(list(zip(amp_valid_dtypes)))
     def test_step(self, dtype):
         if dtype == 'bfloat16' and not bf16_supported():
             raise unittest.SkipTest('bfloat16 not supported by device')
@@ -449,10 +449,10 @@ class TestAmpOptimWrapper(TestCase):
         amp_optim_wrapper.loss_scaler.update.assert_called_with(
             amp_optim_wrapper._scale_update_param)
 
+    @parameterized.expand(list(zip(amp_valid_dtypes)))
     @unittest.skipIf(
         not torch.cuda.is_available(),
         reason='`torch.cuda.amp` is only available when pytorch-gpu installed')
-    @parameterized.expand(list(zip(amp_valid_dtypes)))
     def test_backward(self, dtype):
         if dtype == 'bfloat16' and not bf16_supported():
             raise unittest.SkipTest('bfloat16 not supported by device')
@@ -507,10 +507,10 @@ class TestAmpOptimWrapper(TestCase):
         self.assertDictEqual(amp_optim_wrapper.loss_scaler.state_dict(),
                              amp_optim_wrapper_.loss_scaler.state_dict())
 
+    @parameterized.expand(list(zip(amp_valid_dtypes, torch_dtypes)))
     @unittest.skipIf(
         not torch.cuda.is_available(),
         reason='`torch.cuda.amp` is only available when pytorch-gpu installed')
-    @parameterized.expand(list(zip(amp_valid_dtypes, torch_dtypes)))
     def test_optim_context(self, dtype, target_dtype):
         if dtype == 'bfloat16' and not bf16_supported():
             raise unittest.SkipTest('bfloat16 not supported by device')

--- a/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
+++ b/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
@@ -17,8 +17,6 @@ from mmengine.logging import MessageHub, MMLogger
 from mmengine.optim import AmpOptimWrapper, ApexOptimWrapper, OptimWrapper
 from mmengine.testing import assert_allclose
 from mmengine.testing._internal import MultiProcessTestCase
-from mmengine.utils import digit_version
-from mmengine.utils.dl_utils import TORCH_VERSION
 
 is_apex_available = False
 try:
@@ -392,10 +390,8 @@ class TestAmpOptimWrapper(TestCase):
         self.optimizer = SGD(self.model.parameters(), lr=0.1)
 
     @unittest.skipIf(
-        not torch.cuda.is_available()
-        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
-        reason='`torch.cuda.amp` is only available when pytorch-gpu version '
-        '>= 1.6')
+        not torch.cuda.is_available(),
+        reason='`torch.cuda.amp` is only available when pytorch-gpu installed')
     def test_init(self):
         # Test with default arguments.
         amp_optim_wrapper = AmpOptimWrapper(optimizer=self.optimizer)
@@ -427,10 +423,8 @@ class TestAmpOptimWrapper(TestCase):
             AmpOptimWrapper(optimizer=self.optimizer, loss_scale='unknown')
 
     @unittest.skipIf(
-        not torch.cuda.is_available()
-        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
-        reason='`torch.cuda.amp` is only available when pytorch-gpu version '
-        '>= 1.6')
+        not torch.cuda.is_available(),
+        reason='`torch.cuda.amp` is only available when pytorch-gpu installed')
     def test_step(self):
         optimizer = MagicMock(spec=Optimizer)
         amp_optim_wrapper = AmpOptimWrapper(optimizer=optimizer)
@@ -442,10 +436,8 @@ class TestAmpOptimWrapper(TestCase):
             amp_optim_wrapper._scale_update_param)
 
     @unittest.skipIf(
-        not torch.cuda.is_available()
-        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
-        reason='`torch.cuda.amp` is only available when pytorch-gpu version '
-        '>= 1.6')
+        not torch.cuda.is_available(),
+        reason='`torch.cuda.amp` is only available when pytorch-gpu installed')
     def test_backward(self):
         amp_optim_wrapper = AmpOptimWrapper(optimizer=self.optimizer)
         loss_scaler = MagicMock()
@@ -459,10 +451,8 @@ class TestAmpOptimWrapper(TestCase):
         scale_return.backward.assert_called_with()
 
     @unittest.skipIf(
-        not torch.cuda.is_available()
-        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
-        reason='`torch.cuda.amp` is only available when pytorch-gpu version '
-        '>= 1.6')
+        not torch.cuda.is_available(),
+        reason='`torch.cuda.amp` is only available when pytorch-gpu installed')
     def test_state_dict(self):
         self.model = self.model.cuda()
         amp_optim_wrapper = AmpOptimWrapper(optimizer=self.optimizer)
@@ -478,10 +468,8 @@ class TestAmpOptimWrapper(TestCase):
                              amp_optim_wrapper.loss_scaler.state_dict())
 
     @unittest.skipIf(
-        not torch.cuda.is_available()
-        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
-        reason='`torch.cuda.amp` is only available when pytorch-gpu version '
-        '>= 1.6')
+        not torch.cuda.is_available(),
+        reason='`torch.cuda.amp` is only available when pytorch-gpu installed')
     def test_load_state_dict(self):
         amp_optim_wrapper = AmpOptimWrapper(optimizer=self.optimizer)
         self.model = self.model.cuda()
@@ -502,10 +490,8 @@ class TestAmpOptimWrapper(TestCase):
                              amp_optim_wrapper_.loss_scaler.state_dict())
 
     @unittest.skipIf(
-        not torch.cuda.is_available()
-        or (digit_version(TORCH_VERSION) < digit_version('1.6.0')),
-        reason='`torch.cuda.amp` is only available when pytorch-gpu version '
-        '>= 1.6')
+        not torch.cuda.is_available(),
+        reason='`torch.cuda.amp` is only available when pytorch-gpu installed')
     def test_optim_context(self):
         amp_optim_wrapper = AmpOptimWrapper(optimizer=self.optimizer)
         with amp_optim_wrapper.optim_context(self.model):
@@ -515,11 +501,10 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        or (digit_version(TORCH_VERSION) < digit_version('1.6.0'))
         or not hasattr(torch.cuda, 'is_bf16_supported')
         or not torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
-        'version >= 1.6 && bf16 supported by device')
+        'installed && bf16 supported by device')
     def test_step_bf16(self):
         optimizer = MagicMock(spec=Optimizer)
         amp_optim_wrapper = AmpOptimWrapper(
@@ -533,11 +518,10 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        or (digit_version(TORCH_VERSION) < digit_version('1.6.0'))
         or not hasattr(torch.cuda, 'is_bf16_supported')
         or not torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
-        'version >= 1.6 && bf16 supported by device')
+        'installed && bf16 supported by device')
     def test_backward_bf16(self):
         amp_optim_wrapper = AmpOptimWrapper(
             optimizer=self.optimizer, dtype='bfloat16')
@@ -553,11 +537,10 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        or (digit_version(TORCH_VERSION) < digit_version('1.6.0'))
         or not hasattr(torch.cuda, 'is_bf16_supported')
         or not torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
-        'version >= 1.6 && bf16 supported by device')
+        'installed && bf16 supported by device')
     def test_state_dict_bf16(self):
         self.model = self.model.cuda()
         amp_optim_wrapper = AmpOptimWrapper(
@@ -575,11 +558,10 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        or (digit_version(TORCH_VERSION) < digit_version('1.6.0'))
         or not hasattr(torch.cuda, 'is_bf16_supported')
         or not torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
-        'version >= 1.6 && bf16 supported by device')
+        'installed && bf16 supported by device')
     def test_load_state_dict_bf16(self):
         amp_optim_wrapper = AmpOptimWrapper(
             optimizer=self.optimizer, dtype='bfloat16')
@@ -602,11 +584,10 @@ class TestAmpOptimWrapper(TestCase):
 
     @unittest.skipIf(
         not torch.cuda.is_available()
-        or (digit_version(TORCH_VERSION) < digit_version('1.6.0'))
         or not hasattr(torch.cuda, 'is_bf16_supported')
         or not torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
-        'version >= 1.6 && bf16 supported by device')
+        'installed && bf16 supported by device')
     def test_optim_context_bf16(self):
         amp_optim_wrapper = AmpOptimWrapper(
             optimizer=self.optimizer, dtype='bfloat16')

--- a/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
+++ b/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
@@ -516,6 +516,7 @@ class TestAmpOptimWrapper(TestCase):
     @unittest.skipIf(
         not torch.cuda.is_available()
         and (digit_version(TORCH_VERSION) >= digit_version('1.6.0'))
+        and hasattr(torch.cuda, 'is_bf16_supported')
         and torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
         'version >= 1.6 && bf16 supported by device')
@@ -533,6 +534,7 @@ class TestAmpOptimWrapper(TestCase):
     @unittest.skipIf(
         not torch.cuda.is_available()
         and (digit_version(TORCH_VERSION) >= digit_version('1.6.0'))
+        and hasattr(torch.cuda, 'is_bf16_supported')
         and torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
         'version >= 1.6 && bf16 supported by device')
@@ -552,6 +554,7 @@ class TestAmpOptimWrapper(TestCase):
     @unittest.skipIf(
         not torch.cuda.is_available()
         and (digit_version(TORCH_VERSION) >= digit_version('1.6.0'))
+        and hasattr(torch.cuda, 'is_bf16_supported')
         and torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
         'version >= 1.6 && bf16 supported by device')
@@ -573,6 +576,7 @@ class TestAmpOptimWrapper(TestCase):
     @unittest.skipIf(
         not torch.cuda.is_available()
         and (digit_version(TORCH_VERSION) >= digit_version('1.6.0'))
+        and hasattr(torch.cuda, 'is_bf16_supported')
         and torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
         'version >= 1.6 && bf16 supported by device')
@@ -599,6 +603,7 @@ class TestAmpOptimWrapper(TestCase):
     @unittest.skipIf(
         not torch.cuda.is_available()
         and (digit_version(TORCH_VERSION) >= digit_version('1.6.0'))
+        and hasattr(torch.cuda, 'is_bf16_supported')
         and torch.cuda.is_bf16_supported(),
         reason='`torch.cuda.amp` with bf16 is only available when pytorch-gpu'
         'version >= 1.6 && bf16 supported by device')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Enable `torch.bfloat16` in `AmpOptimWrapper` and config file

## Modification

New optional argument `dtype` in `AmpOptimWrapper`, can be `str` or `torch.dtype`

## BC-breaking (Optional)

No

## Use cases (Optional)

```python
optim_wrapper = dict(
    type='AmpOptimWrapper',
    dtype='bfloat16',  # (None, float32, float16, bfloat16, ...)
    ....
)
```

## Test results

### mmcls::resnet50_8xb256-rsb-a3-100e_in1k

| setting | iter_time | memory | acc_top1 | acc_top5 |
|  :---      |    :---:      |  :---: | :---: | :---: |
| no amp                          | 0.4230 | 21665 | 78.30 | 93.80 |
| amp float16                   | 0.4239 | 11481 | -- | -- |
| amp bfloat16                 | 1.0812 | 11494 | -- | -- |
| amp bfloat16 + cudnn8 | 0.4251 | 11478 | 78.42 | 93.85 |

**Hint**: Amp with `dtype=torch.bfloat16` works bad on convolutions, because it doesn't use CuDNN by default. Enable CuDNN version bfloat16 convolution by environment variable: `TORCH_CUDNN_V8_API_ENABLED=1`

### mmdet::retinanet_r50_fpn_1x_coco

Failed due to `torch.bfloat16` not supported by `F.interpolate`.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
