### PR TITLE
[Fix] Support calculate the flops of `matmul` with single dimension matrix

### DIFF
--- a/mmengine/analysis/jit_handles.py
+++ b/mmengine/analysis/jit_handles.py
@@ -209,13 +209,16 @@ def einsum_flop_jit(inputs: List[Any], outputs: List[Any]) -> Union[int, Any]:
 
 def matmul_flop_jit(inputs: List[Any], outputs: List[Any]) -> Union[int, Any]:
     """Count flops for matmul."""
-    # Inputs should be a list of length 2.
-    # Inputs contains the shapes of two matrices.
-    input_shapes = [get_shape(v) for v in inputs]
-    assert len(input_shapes) == 2, input_shapes
-    assert input_shapes[0][-1] == input_shapes[1][  # type: ignore
-        -2], input_shapes  # type: ignore
-    flop = prod(input_shapes[0]) * input_shapes[-1][-1]  # type: ignore
+    input_shapes: list = [get_shape(v) for v in inputs]
+    input1, input2 = input_shapes
+    # input_shapes is a list of length 2.
+    if len(input1) == 1:
+        input1 = [1, input1[0]]
+    if len(input2) == 1:
+        input2 = [input2[0], 1]
+
+    assert input1[-1] == input2[-2], input_shapes  # type: ignore
+    flop = prod(input1) * input2[-1]  # type: ignore
     return flop
 
 

--- a/mmengine/analysis/jit_handles.py
+++ b/mmengine/analysis/jit_handles.py
@@ -217,8 +217,8 @@ def matmul_flop_jit(inputs: List[Any], outputs: List[Any]) -> Union[int, Any]:
     if len(input2) == 1:
         input2 = [input2[0], 1]
 
-    assert input1[-1] == input2[-2], input_shapes  # type: ignore
-    flop = prod(input1) * input2[-1]  # type: ignore
+    assert input1[-1] == input2[-2], input_shapes
+    flop = prod(input1) * input2[-1]
     return flop
 
 

--- a/mmengine/analysis/jit_handles.py
+++ b/mmengine/analysis/jit_handles.py
@@ -209,9 +209,9 @@ def einsum_flop_jit(inputs: List[Any], outputs: List[Any]) -> Union[int, Any]:
 
 def matmul_flop_jit(inputs: List[Any], outputs: List[Any]) -> Union[int, Any]:
     """Count flops for matmul."""
+    # input_shapes is a list of length 2.
     input_shapes: list = [get_shape(v) for v in inputs]
     input1, input2 = input_shapes
-    # input_shapes is a list of length 2.
     if len(input1) == 1:
         input1 = [1, input1[0]]
     if len(input2) == 1:

--- a/tests/test_analysis/test_flop_count.py
+++ b/tests/test_analysis/test_flop_count.py
@@ -580,8 +580,6 @@ class TestFlopAnalyzer(unittest.TestCase):
             transpose=True,
             output_padding=output_padding9,
         )
-
-    def test_matmul(self) -> None:
         """Test flop count for operation matmul."""
         m = 20
         n = 10
@@ -593,6 +591,13 @@ class TestFlopAnalyzer(unittest.TestCase):
         gt_flop = m * n * p / 1e9
         gt_dict = defaultdict(float)
         gt_dict['matmul'] = gt_flop
+        self.assertDictEqual(
+            flop_dict, gt_dict,
+            'Matmul operation failed to pass the flop count test.')
+        # Test with single dimension y
+        y = torch.randn(n)
+        gt_dict['matmul'] = m * n * 1 / 1e9
+        flop_dict, _ = flop_count(m_net, (x, y))
         self.assertDictEqual(
             flop_dict, gt_dict,
             'Matmul operation failed to pass the flop count test.')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

If user write the code like:

```python
import torch
import torch.nn as nn

from mmengine.analysis import flop_count


class MatmulNet(nn.Module):
    """A network with a single torch.matmul operation.

    This is used for testing flop count for torch.matmul.
    """

    def __init__(self) -> None:
        super().__init__()

    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
        x = torch.matmul(x, y)
        return x

m = 20
n = 10
p = 1
m_net = MatmulNet()
x = torch.randn(m, n)
y = torch.randn(n)
flop_dict, _ = flop_count(m_net, (x, y))
```

`flop_count` will raise an error since it requires both of x, y at least have two dims:

```shell
Traceback (most recent call last):
  File "/home/yehaochen/codebase/mmengine/work_dirs/demo_train.py", line 26, in <module>
    flop_dict, _ = flop_count(m_net, (x, y))
  File "/home/yehaochen/codebase/mmengine/mmengine/analysis/complexity_analysis.py", line 230, in flop_count
    for op, flop in flop_counter.by_operator().items():
  File "/home/yehaochen/codebase/mmengine/mmengine/analysis/jit_analysis.py", line 287, in by_operator
    stats = self._analyze()
  File "/home/yehaochen/codebase/mmengine/mmengine/analysis/jit_analysis.py", line 616, in _analyze
    op_counts = self._op_handles[kind](inputs, outputs)
  File "/home/yehaochen/codebase/mmengine/mmengine/analysis/jit_handles.py", line 216, in matmul_flop_jit
    assert input_shapes[0][-1] == input_shapes[1][  # type: ignore
IndexError: list index out of range
```

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
