### PR TITLE
[Fix] Distributed use correct local rank

### DIFF
--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -152,9 +152,9 @@ def _init_dist_slurm(backend, port=None) -> None:
     ntasks = int(os.environ['SLURM_NTASKS'])
     node_list = os.environ['SLURM_NODELIST']
     # Not sure when this environment variable could be None, so use a fallback
-    local_id = os.environ.get('SLURM_LOCALID', None)
-    if local_id is not None:
-        local_rank = int(local_id)
+    local_rank_env = os.environ.get('SLURM_LOCALID', None)
+    if local_rank_env is not None:
+        local_rank = int(local_rank_env)
     else:
         num_gpus = torch.cuda.device_count()
         local_rank = proc_id % num_gpus

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -104,7 +104,8 @@ def _init_dist_pytorch(backend, **kwargs) -> None:
             **kwargs)
     else:
         num_gpus = torch.cuda.device_count()
-        torch.cuda.set_device(rank % num_gpus)
+        local_rank = os.environ.get('LOCAL_RANK', None) or rank % num_gpus
+        torch.cuda.set_device(local_rank)
         torch_dist.init_process_group(backend=backend, **kwargs)
 
 
@@ -152,7 +153,8 @@ def _init_dist_slurm(backend, port=None) -> None:
     ntasks = int(os.environ['SLURM_NTASKS'])
     node_list = os.environ['SLURM_NODELIST']
     num_gpus = torch.cuda.device_count()
-    torch.cuda.set_device(proc_id % num_gpus)
+    local_rank = os.environ.get('SLURM_LOCALID', None) or proc_id % num_gpus
+    torch.cuda.set_device(local_rank)
     addr = subprocess.getoutput(
         f'scontrol show hostname {node_list} | head -n1')
     # specify master port
@@ -167,7 +169,7 @@ def _init_dist_slurm(backend, port=None) -> None:
     if 'MASTER_ADDR' not in os.environ:
         os.environ['MASTER_ADDR'] = addr
     os.environ['WORLD_SIZE'] = str(ntasks)
-    os.environ['LOCAL_RANK'] = str(proc_id % num_gpus)
+    os.environ['LOCAL_RANK'] = str(local_rank)
     os.environ['RANK'] = str(proc_id)
     torch_dist.init_process_group(backend=backend)
 

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -84,7 +84,6 @@ def _init_dist_pytorch(backend, **kwargs) -> None:
             'nccl', 'gloo' and 'mpi'. Defaults to 'nccl'.
         **kwargs: keyword arguments are passed to ``init_process_group``.
     """
-    # TODO: use local_rank instead of rank % num_gpus
     rank = int(os.environ['RANK'])
     if is_mlu_available():
         import torch_mlu  # noqa: F401
@@ -103,8 +102,8 @@ def _init_dist_pytorch(backend, **kwargs) -> None:
             world_size=int(os.environ['WORLD_SIZE']),
             **kwargs)
     else:
-        num_gpus = torch.cuda.device_count()
-        local_rank = os.environ.get('LOCAL_RANK', None) or rank % num_gpus
+        # LOCAL_RANK is set by `torch.distributed.launch` since PyTorch 1.1
+        local_rank = int(os.environ['LOCAL_RANK'])
         torch.cuda.set_device(local_rank)
         torch_dist.init_process_group(backend=backend, **kwargs)
 
@@ -152,8 +151,13 @@ def _init_dist_slurm(backend, port=None) -> None:
     proc_id = int(os.environ['SLURM_PROCID'])
     ntasks = int(os.environ['SLURM_NTASKS'])
     node_list = os.environ['SLURM_NODELIST']
-    num_gpus = torch.cuda.device_count()
-    local_rank = os.environ.get('SLURM_LOCALID', None) or proc_id % num_gpus
+    # Not sure when this environment variable could be None, so use a fallback
+    local_id = os.environ.get('SLURM_LOCALID', None)
+    if local_id is not None:
+        local_rank = int(local_id)
+    else:
+        num_gpus = torch.cuda.device_count()
+        local_rank = proc_id % num_gpus
     torch.cuda.set_device(local_rank)
     addr = subprocess.getoutput(
         f'scontrol show hostname {node_list} | head -n1')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Related to [MMCV PR](https://github.com/open-mmlab/mmcv/pull/2625)

In [dist.utils](https://github.com/open-mmlab/mmengine/blob/ff27b723dbc2f6c2846489b8b134c353f39a4ec6/mmengine/dist/utils.py#L106-L108) we set `torch.cuda.set_device(rank % num_gpus)`, while in [Runner.wrap_model](https://github.com/open-mmlab/mmengine/blob/ff27b723dbc2f6c2846489b8b134c353f39a4ec6/mmengine/runner/runner.py#L870-L874) we set `device_ids=[os.environ['LOCAL_RANK']`. These 2 values, `local_rank` and `rank % device_counts`, are the same when each node has the same number of devices, but are different otherwise.

Besides, `_init_dist_slurm` can also use `SLURM_PROCID` instead of `rank % num_gpus`. Although the original code won't raise errors (because we [exported](https://github.com/open-mmlab/mmengine/blob/ff27b723dbc2f6c2846489b8b134c353f39a4ec6/mmengine/dist/utils.py#L170) that to `LOCAL_RANK`), it might be better to keep pytorch local_rank consistent with slurm local_rank for some corner use cases.

## Reproduction

Since I can only access slurm cluster, I simulate torchrun with [torchrun_in_slurm.py](https://gist.github.com/C1rN09/051da40e4689db7689f0e2f9f7b2d546)

```bash
# 2 nodes with 5 gpus, so that they cannot have same number of gpus
srun -N 2 -n 5 --gpus-per-task=1 -p my_partition python torchrun_in_slurm.py tools/train.py configs/resnet/resnet18_8xb32_in1k.py --launcher pytorch
```

Before this PR:

```text
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:1 and cuda:0! (when checking argument for argument weight in method wrapper__cudnn_convolution)
```

After this PR, its all fine.

Below are some experiments on slurm with [test_dist_slurm_env.py](https://gist.github.com/C1rN09/72c0cdc2ee030643a72254a0dd8985c7)

```python
srun -p my_partition -c 1 -n 5 -N 2 --gpus-per-task=1 python test_dist_slurm_env.py
```

![image](https://user-images.githubusercontent.com/112053249/221892575-719c6c73-b006-46ac-85d7-ba09e1b971e5.png)

Obviously `rank % device_counts != local_rank`, although it won't cause error in MMEngine.

## Modification

Use `os.environ['LOCAL_RANK']` in pytorch dist init.

Use `os.environ['SLURM_LOCALID']` in slurm dist init.

## BC-breaking (Optional)

Theoretically not.

`LOCAL_RANK` has been set in `torch.distributed.launch` since [v1.5.0](https://github.com/pytorch/pytorch/blob/4ff3872a2099993bf7e8c588f7182f3df777205b/torch/distributed/launch.py#L226-L230) (and even older versions). Also in `torchrun`

`SLURM_LOCALID` is documented [here](https://slurm.schedmd.com/srun.html#SECTION_OUTPUT-ENVIRONMENT-VARIABLES)

## Use cases (Optional)

Not changed.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
