### PR TITLE
[Fix] fix pytorch2.0 not support sys._getframe to remove private key

### DIFF
--- a/mmengine/structures/base_data_element.py
+++ b/mmengine/structures/base_data_element.py
@@ -1,6 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
-import sys
 from typing import Any, Iterator, Optional, Tuple, Type, Union
 
 import numpy as np
@@ -309,7 +308,15 @@ class BaseDataElement:
         Returns:
             list: Contains all keys in data_fields.
         """
-        return list(self._data_fields)
+        # We assume that the name of the attribute related to property is
+        # '_' + the name of the property. We use this rule to filter out
+        # private keys.
+        private_keys = {
+            '_' + key
+            for key in self._data_fields
+            if isinstance(getattr(type(self), key, None), property)
+        }
+        return list(self._data_fields - private_keys)
 
     def metainfo_keys(self) -> list:
         """
@@ -466,12 +473,7 @@ class BaseDataElement:
                 raise AttributeError(
                     f'Cannot set {name} to be a field of data '
                     f'because {name} is already a metainfo field')
-            # The name only added to `data_fields` when it is not the
-            # attribute related to property(methods decorated by @property).
-            if not isinstance(
-                    getattr(type(self),
-                            sys._getframe(1).f_code.co_name, None), property):
-                self._data_fields.add(name)
+            self._data_fields.add(name)
         super().__setattr__(name, value)
 
     # Tensor-like methods

--- a/mmengine/structures/base_data_element.py
+++ b/mmengine/structures/base_data_element.py
@@ -311,6 +311,7 @@ class BaseDataElement:
         # We assume that the name of the attribute related to property is
         # '_' + the name of the property. We use this rule to filter out
         # private keys.
+        # TODO: Use a more robust way to solve this problem
         private_keys = {
             '_' + key
             for key in self._data_fields


### PR DESCRIPTION
Same for #690 
PyTorch2.0 does not support sys._getframe, so we remove the redundant inner attribute created by the property function by removing the `_` + property_name at the `keys()` function.