### PR TITLE
[Fix] Call SyncBufferHook before validation in IterBasedTrainLoop

### DIFF
--- a/mmengine/hooks/sync_buffer_hook.py
+++ b/mmengine/hooks/sync_buffer_hook.py
@@ -25,7 +25,7 @@ class SyncBuffersHook(Hook):
             if not self.called_in_train:
                 all_reduce_params(runner.model.buffers(), op='mean')
             self.called_in_train = False
-                
+
     def after_train_epoch(self, runner) -> None:
         """All-reduce model buffers at the end of each epoch.
 

--- a/mmengine/hooks/sync_buffer_hook.py
+++ b/mmengine/hooks/sync_buffer_hook.py
@@ -41,3 +41,14 @@ class SyncBuffersHook(Hook):
         if self.distributed:
             all_reduce_params(runner.model.buffers(), op='mean')
             self.called_in_train = True
+
+    def before_test_epoch(self, runner) -> None:
+        """All-reduce model buffers before each test epoch.
+
+        Args:
+            runner (Runner): The runner of the training process.
+        """
+        if self.distributed:
+            if not self.called_in_train:
+                all_reduce_params(runner.model.buffers(), op='mean')
+            self.called_in_train = False

--- a/mmengine/hooks/sync_buffer_hook.py
+++ b/mmengine/hooks/sync_buffer_hook.py
@@ -16,7 +16,9 @@ class SyncBuffersHook(Hook):
         self.called_in_train = False
 
     def before_val_epoch(self, runner) -> None:
-        """All-reduce model buffers before each validation epoch.
+        """All-reduce model buffers before each validation epoch. Sync the
+        buffer before each validation if it has not been synced at the end of
+        previous training epoch.
 
         Args:
             runner (Runner): The runner of the training process.

--- a/mmengine/hooks/sync_buffer_hook.py
+++ b/mmengine/hooks/sync_buffer_hook.py
@@ -13,6 +13,8 @@ class SyncBuffersHook(Hook):
 
     def __init__(self) -> None:
         self.distributed = is_distributed()
+        # A flag to mark whether synchronization has been done in
+        # after_train_epoch
         self.called_in_train = False
 
     def before_val_epoch(self, runner) -> None:

--- a/mmengine/hooks/sync_buffer_hook.py
+++ b/mmengine/hooks/sync_buffer_hook.py
@@ -13,7 +13,19 @@ class SyncBuffersHook(Hook):
 
     def __init__(self) -> None:
         self.distributed = is_distributed()
+        self.called_in_train = False
 
+    def before_val_epoch(self, runner) -> None:
+        """All-reduce model buffers before each validation epoch.
+
+        Args:
+            runner (Runner): The runner of the training process.
+        """
+        if self.distributed:
+            if not self.called_in_train:
+                all_reduce_params(runner.model.buffers(), op='mean')
+            self.called_in_train = False
+                
     def after_train_epoch(self, runner) -> None:
         """All-reduce model buffers at the end of each epoch.
 
@@ -22,3 +34,4 @@ class SyncBuffersHook(Hook):
         """
         if self.distributed:
             all_reduce_params(runner.model.buffers(), op='mean')
+            self.called_in_train = True

--- a/mmengine/hooks/sync_buffer_hook.py
+++ b/mmengine/hooks/sync_buffer_hook.py
@@ -41,14 +41,3 @@ class SyncBuffersHook(Hook):
         if self.distributed:
             all_reduce_params(runner.model.buffers(), op='mean')
             self.called_in_train = True
-
-    def before_test_epoch(self, runner) -> None:
-        """All-reduce model buffers before each test epoch.
-
-        Args:
-            runner (Runner): The runner of the training process.
-        """
-        if self.distributed:
-            if not self.called_in_train:
-                all_reduce_params(runner.model.buffers(), op='mean')
-            self.called_in_train = False

--- a/mmengine/hooks/sync_buffer_hook.py
+++ b/mmengine/hooks/sync_buffer_hook.py
@@ -18,9 +18,11 @@ class SyncBuffersHook(Hook):
         self.called_in_train = False
 
     def before_val_epoch(self, runner) -> None:
-        """All-reduce model buffers before each validation epoch. Sync the
-        buffer before each validation if it has not been synced at the end of
-        previous training epoch.
+        """All-reduce model buffers before each validation epoch.
+        
+        Synchronize the buffers before each validation if they have not been
+        synchronized at the end of the previous training epoch. This method
+        will be called when using IterBasedTrainLoop.
 
         Args:
             runner (Runner): The runner of the training process.

--- a/mmengine/hooks/sync_buffer_hook.py
+++ b/mmengine/hooks/sync_buffer_hook.py
@@ -19,7 +19,7 @@ class SyncBuffersHook(Hook):
 
     def before_val_epoch(self, runner) -> None:
         """All-reduce model buffers before each validation epoch.
-        
+
         Synchronize the buffers before each validation if they have not been
         synchronized at the end of the previous training epoch. This method
         will be called when using IterBasedTrainLoop.

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -281,7 +281,6 @@ class IterBasedTrainLoop(BaseLoop):
             if (self.runner.val_loop is not None
                     and self._iter >= self.val_begin
                     and self._iter % self.val_interval == 0):
-                self.runner.call_hook('after_train_epoch')
                 self.runner.val_loop.run()
 
         self.runner.call_hook('after_train_epoch')

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -281,6 +281,7 @@ class IterBasedTrainLoop(BaseLoop):
             if (self.runner.val_loop is not None
                     and self._iter >= self.val_begin
                     and self._iter % self.val_interval == 0):
+                self.runner.call_hook('after_train_epoch')
                 self.runner.val_loop.run()
 
         self.runner.call_hook('after_train_epoch')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This PR is tring to fix the issue mentioned in #517.

## Modification

Add a call to sync buffer before each validation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
