### PR TITLE
[Feature] Publish models after training if  published_keys is set in CheckpointHook

### DIFF
--- a/docs/en/tutorials/hook.md
+++ b/docs/en/tutorials/hook.md
@@ -120,7 +120,7 @@ The four features mentioned above are described below.
   ```python
   default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=5, out_dir='/path/of/directory'))
   ```
-  
+
 - Automatically publish the best and the last checkpoints
 
   If you want to publish the best and the last checkpoints after train, you can set the `published_keys` parameter. You can select any keys in checkpoint to be published.

--- a/docs/en/tutorials/hook.md
+++ b/docs/en/tutorials/hook.md
@@ -123,7 +123,7 @@ The four features mentioned above are described below.
 
 - Make checkpoints for publish
 
-  If you want to automatically generate publishable checkpoints after training (remove unnecessary keys, such as optimizer state), you can set the `published_keys` parameter to choose which information to keep. Note: You need to set the `save_best` or `save_last` parameters accordingly, so that the releasable checkpoints will be generated. Setting `save_best` will generate the releasable weights of the optimal checkpoint, and setting `save_last` will generate the releasable final checkpoint. These two parameters can also be used set at the same time.
+  If you want to automatically generate publishable checkpoints after training (remove unnecessary keys, such as optimizer state), you can set the `published_keys` parameter to choose which information to keep. Note: You need to set the `save_best` or `save_last` parameters accordingly so that the releasable checkpoints will be generated. Setting `save_best` will generate the releasable weights of the optimal checkpoint, and setting `save_last` will generate the releasable final checkpoint. These two parameters can also be set at the same time.
 
   ```python
   default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=1, save_best='accuracy', rule='less', published_keys=['meta', 'state_dict']))

--- a/docs/en/tutorials/hook.md
+++ b/docs/en/tutorials/hook.md
@@ -70,7 +70,7 @@ runner.train()
 - Save the most recent checkpoints
 - Save the best checkpoints
 - Specify the path to save the checkpoints
-- Automatically publish the best and the last checkpoints
+- Make checkpoints for publish
 
 For more features, please read the [CheckpointHook API documentation](mmengine.hooks.CheckpointHook).
 
@@ -121,9 +121,9 @@ The four features mentioned above are described below.
   default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=5, out_dir='/path/of/directory'))
   ```
 
-- Automatically publish the best and the last checkpoints
+- Make checkpoints for publish
 
-  If you want to publish the best and the last checkpoints after training, you can set the `published_keys` parameter. You can select any keys in checkpoint to be published.
+  If you want to automatically generate publishable checkpoints after training (remove unnecessary keys, such as optimizer state), you can set the `published_keys` parameter to choose which information to keep. Note: You need to set the `save_best` or `save_last` parameters accordingly, so that the releasable checkpoints will be generated. Setting `save_best` will generate the releasable weights of the optimal checkpoint, and setting `save_last` will generate the releasable final checkpoint. These two parameters can also be used set at the same time.
 
   ```python
   default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=1, save_best='accuracy', rule='less', published_keys=['meta', 'state_dict']))

--- a/docs/en/tutorials/hook.md
+++ b/docs/en/tutorials/hook.md
@@ -70,6 +70,7 @@ runner.train()
 - Save the most recent checkpoints
 - Save the best checkpoints
 - Specify the path to save the checkpoints
+- Automatically publish the best and the last checkpoints
 
 For more features, please read the [CheckpointHook API documentation](mmengine.hooks.CheckpointHook).
 
@@ -118,6 +119,14 @@ The four features mentioned above are described below.
 
   ```python
   default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=5, out_dir='/path/of/directory'))
+  ```
+  
+- Automatically publish the best and the last checkpoints
+
+  If you want to publish the best and the last checkpoints after train, you can set the `published_keys` parameter. You can select any keys in checkpoint to be published.
+
+  ```python
+  default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=1, save_best='accuracy', rule='less', published_keys=['meta', 'state_dict']))
   ```
 
 [LoggerHook](mmengine.hooks.LoggerHook) collects logs from different components of `Runner` and write them to terminal, JSON file, tensorboard and wandb .etc.

--- a/docs/en/tutorials/hook.md
+++ b/docs/en/tutorials/hook.md
@@ -123,7 +123,7 @@ The four features mentioned above are described below.
 
 - Automatically publish the best and the last checkpoints
 
-  If you want to publish the best and the last checkpoints after train, you can set the `published_keys` parameter. You can select any keys in checkpoint to be published.
+  If you want to publish the best and the last checkpoints after training, you can set the `published_keys` parameter. You can select any keys in checkpoint to be published.
 
   ```python
   default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=1, save_best='accuracy', rule='less', published_keys=['meta', 'state_dict']))

--- a/docs/zh_cn/tutorials/hook.md
+++ b/docs/zh_cn/tutorials/hook.md
@@ -71,7 +71,7 @@ runner.train()
 - 保存最新的多个权重
 - 保存最优权重
 - 指定保存权重的路径
-- 自动发布最好的和最后的权重
+- 制作发布用的权重
 
 如需了解其他功能，请阅读 [CheckpointHook API 文档](mmengine.hooks.CheckpointHook)。
 

--- a/docs/zh_cn/tutorials/hook.md
+++ b/docs/zh_cn/tutorials/hook.md
@@ -124,7 +124,7 @@ runner.train()
 
 - 制作发布用的权重
 
-  如果你想在训练结束后自动生成可发布的权重（删除不需要的权重，例如优化器状态），你可以设置 `published_keys` 参数，选择需要保留的信息。注意：需要相应设置 save_best 或者 save_last 参数，这样才会生成可发布的权重，其中设置 save_best 会生成最优权重的可发布权重，设置 save_last 会生成最后一个权重的可发布权重，这两个参数也可同时设置。
+  如果你想在训练结束后自动生成可发布的权重（删除不需要的权重，例如优化器状态），你可以设置 `published_keys` 参数，选择需要保留的信息。注意：需要相应设置 `save_best` 或者 `save_last` 参数，这样才会生成可发布的权重，其中设置 `save_best` 会生成最优权重的可发布权重，设置 `save_last` 会生成最后一个权重的可发布权重，这两个参数也可同时设置。
 
   ```python
   default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=1, save_best='accuracy', rule='less', published_keys=['meta', 'state_dict']))

--- a/docs/zh_cn/tutorials/hook.md
+++ b/docs/zh_cn/tutorials/hook.md
@@ -122,9 +122,9 @@ runner.train()
   default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=5, out_dir='/path/of/directory'))
   ```
 
-- 自动发布最好的和最后的权重
+- 制作发布用的权重
 
-  如果你想在训练后发布最好的和最后的权重，你可以设置`published_keys`参数。 通过这个参数，您可以选择要发布权重中所要保存的键。
+  如果你想在训练结束后自动生成可发布的权重（删除不需要的权重，例如优化器状态），你可以设置 `published_keys` 参数，选择需要保留的信息。注意：需要相应设置 save_best 或者 save_last 参数，这样才会生成可发布的权重，其中设置 save_best 会生成最优权重的可发布权重，设置 save_last 会生成最后一个权重的可发布权重，这两个参数也可同时设置。
 
   ```python
   default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=1, save_best='accuracy', rule='less', published_keys=['meta', 'state_dict']))

--- a/docs/zh_cn/tutorials/hook.md
+++ b/docs/zh_cn/tutorials/hook.md
@@ -71,6 +71,7 @@ runner.train()
 - 保存最新的多个权重
 - 保存最优权重
 - 指定保存权重的路径
+- 自动发布最好的和最后的权重
 
 如需了解其他功能，请阅读 [CheckpointHook API 文档](mmengine.hooks.CheckpointHook)。
 
@@ -119,6 +120,14 @@ runner.train()
 
   ```python
   default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=5, out_dir='/path/of/directory'))
+  ```
+
+- 自动发布最好的和最后的权重
+
+  如果你想在训练后发布最好的和最后的权重，你可以设置`published_keys`参数。 通过这个参数，您可以选择要发布权重中所要保存的键。
+
+  ```python
+  default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=1, save_best='accuracy', rule='less', published_keys=['meta', 'state_dict']))
   ```
 
 ### LoggerHook

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -336,7 +336,7 @@ class CheckpointHook(Hook):
         if self.published_keys is None:
             return
 
-        if self.save_last and 'last_ckpt' in self.runtime_info:
+        if self.save_last and 'last_ckpt' in runner.message_hub.runtime_info:
             last_ckpt = runner.message_hub.get_info('last_ckpt')
             self._publish_model(runner, last_ckpt)
 
@@ -362,7 +362,6 @@ class CheckpointHook(Hook):
                 'found in published_keys. If you want to keep them, '
                 f'please set `{removed_keys}` in published_keys',
                 logger='current')
-        print(runner.timestamp)
         final_file = osp.splitext(out_file)[0] + f'-published-{runner.timestamp}.pth'
         torch.save(checkpoint, final_file)
         print_log(

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -345,7 +345,7 @@ class CheckpointHook(Hook):
                 raise RuntimeError(xxx)
             self._publish_model(runner, best_ckpt)
 
-    def _publish_model(self, runner, out_file) -> None:
+    def _publish_model(self, runner, out_file: str) -> None:
         import subprocess
 
         import torch

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -350,8 +350,6 @@ class CheckpointHook(Hook):
 
     def _publish_model(self, runner, out_file: str) -> None:
 
-        if published_keys is None:
-            return
         checkpoint = runner.load_checkpoint(out_file)
         removed_keys = []
         for key in checkpoint.keys():

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -340,13 +340,11 @@ class CheckpointHook(Hook):
             last_ckpt = runner.message_hub.get_info('last_ckpt')
             self._publish_model(runner, last_ckpt)
 
-        if self.save_best is not None:
-            if len(self.key_indicators) == 1:
-                if self.best_ckpt_path is not None:
-                    self._publish_model(runner, self.best_ckpt_path)
-            else:
-                for key, best_ckpt in self.best_ckpt_path_dict.items():
-                    self._publish_model(runner, best_ckpt)
+        if getattr(self, 'best_ckpt_path', None) is not None:
+            self._publish_model(runner, self.best_ckpt_path)
+        if getattr(self, 'best_ckpt_path_dict', None) is not None:
+            for key, best_ckpt in self.best_ckpt_path_dict.items():
+                self._publish_model(runner, best_ckpt)
 
     def _publish_model(self, runner, out_file: str) -> None:
 

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -238,7 +238,7 @@ class CheckpointHook(Hook):
             published_keys = [published_keys]    
         elif isinstance(published_keys, list):
             assert len(published_keys) == len(set(published_keys)), (
-                'Find duplicate element in "published_keys".')
+                'Find duplicate elements in "published_keys".')
         self.published_keys = published_keys
 
     def before_train(self, runner) -> None:

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -351,16 +351,17 @@ class CheckpointHook(Hook):
         if published_keys is None:
             return
         checkpoint = runner.load_checkpoint(out_file)
-        ckpt_keys = list(checkpoint.keys())
-        published_keys = self.published_keys
-        for k in ckpt_keys:
-            if k not in published_keys:
-                print_log(
-                    f'Key `{k}` will be removed because it is not in '
-                    f'save_keys. If you want to keep it, '
-                    f'please set `{k}` in published_keys',
-                    logger='current')
+        removed_keys = []
+        for key in checkpoint.keys():
+            if key not in self.published_keys:
+                removed_keys.append(key)
                 checkpoint.pop(k)
+        if removed_keys:     
+            print_log(
+                f'Key {removed_keys} will be removed because they are not '
+                'found in published_keys. If you want to keep them, '
+                f'please set `{removed_keys}` in published_keys',
+                logger='current')
         out_file_name = osp.splitext(out_file)[0]
         tmp_out_file_name = out_file + '.pth'
         torch.save(checkpoint, tmp_out_file_name)

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -232,12 +232,12 @@ class CheckpointHook(Hook):
                     f'but got {type(published_keys)}'):
                     raise TypeError(...)
 
-        if isinstance(published_keys, list):
+        if isinstace(published_keys, str):
+            published_keys = [published_keys]    
+        elif isinstance(published_keys, list):
             assert len(published_keys) == len(set(published_keys)), (
                 'Find duplicate element in "published_keys".')
-        else:
-            if published_keys is not None:
-                published_keys = [published_keys]
+        self.published_keys = published_keys
         self.published_keys = published_keys
 
     def before_train(self, runner) -> None:

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -232,8 +232,8 @@ class CheckpointHook(Hook):
         if not (isinstance(published_keys, str)
                 or is_seq_of(published_keys, str) or published_keys is None):
             raise TypeError(
-                '"published_keys" should be a str or a sequence of str or None, '
-                f'but got {type(published_keys)}')
+                '"published_keys" should be a str or a sequence of str or '
+                f'None, but got {type(published_keys)}')
 
         if isinstance(published_keys, str):
             published_keys = [published_keys]

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -371,6 +371,13 @@ class CheckpointHook(Hook):
         save_checkpoint(checkpoint, final_path)
         print_log(
             f'The published model is saved at {final_path}.', logger='current')
+        if 'publish_ckpt_names' not in runner.message_hub.runtime_info:
+            runner.message_hub.update_info('publish_ckpt_names', [final_path])
+        else:
+            ckpt_path_list = runner.message_hub.get_info('publish_ckpt_names')
+            ckpt_path_list.append(final_path)
+            runner.message_hub.update_info('publish_ckpt_names',
+                                           ckpt_path_list)
 
     def _save_checkpoint(self, runner) -> None:
         """Save the current checkpoint and delete outdated checkpoint.

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -88,7 +88,7 @@ class CheckpointHook(Hook):
             New in v0.2.0.
         published_keys (str, List[str], optional): If ``save_last`` is ``True``
             or ``save_best`` is not ``None``, it will automatically
-            publish model with keys in list after train. Defaults to None.
+            publish model with keys in the list after training. Defaults to None.
     Examples:
         >>> # Save best based on single metric
         >>> CheckpointHook(interval=2, by_epoch=True, save_best='acc',

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -229,10 +229,10 @@ class CheckpointHook(Hook):
         # published keys
         if not (isinstance(published_keys, str)
                 or is_list_of(published_keys, str)
-                or (published_keys is None)), (
-                    '"published_keys" should be a str or list of str or None, '
-                    f'but got {type(published_keys)}'):
-                    raise TypeError(...)
+                or published_keys is None):
+            raise TypeError(
+                '"published_keys" should be a str or list of str or None, '
+                f'but got {type(published_keys)}'):
 
         if isinstace(published_keys, str):
             published_keys = [published_keys]    

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -363,7 +363,7 @@ class CheckpointHook(Hook):
                 f'please set `{removed_keys}` in published_keys',
                 logger='current')
         print(runner.timestamp)
-        final_file = osp.splitext(out_file)[0] + f'-{runner.timestamp}.pth'
+        final_file = osp.splitext(out_file)[0] + f'-published-{runner.timestamp}.pth'
         torch.save(checkpoint, final_file)
         print_log(
             f'The published model is saved at {final_file}.', logger='current')

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -354,6 +354,8 @@ class CheckpointHook(Hook):
         checkpoint = runner.load_checkpoint(out_file)
         ckpt_keys = list(checkpoint.keys())
         published_keys = self.published_keys
+        if not isinstance(published_keys, list):
+            return
         for k in ckpt_keys:
             if k not in published_keys:
                 print_log(

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -225,11 +225,12 @@ class CheckpointHook(Hook):
                 self.best_ckpt_path_dict: Dict = dict()
 
         # published keys
-        assert (isinstance(published_keys, str)
+        if not (isinstance(published_keys, str)
                 or is_list_of(published_keys, str)
                 or (published_keys is None)), (
                     '"published_keys" should be a str or list of str or None, '
-                    f'but got {type(published_keys)}')
+                    f'but got {type(published_keys)}'):
+                    raise TypeError(...)
 
         if isinstance(published_keys, list):
             assert len(published_keys) == len(set(published_keys)), (

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -9,8 +9,6 @@ from mmengine.dist import is_main_process
 from mmengine.fileio import FileClient, get_file_backend
 from mmengine.logging import print_log
 from mmengine.registry import HOOKS
-from mmengine.runner import save_checkpoint
-from mmengine.runner.checkpoint import _load_checkpoint
 from mmengine.utils import is_list_of, is_seq_of
 from .hook import Hook
 
@@ -353,6 +351,8 @@ class CheckpointHook(Hook):
             runner (Runner): The runner of the training process.
             ckpt_path (str): The checkpoint path that ought to be published.
         """
+        from mmengine.runner import save_checkpoint
+        from mmengine.runner.checkpoint import _load_checkpoint
         checkpoint = _load_checkpoint(ckpt_path)
         published_keys = self.published_keys
         removed_keys = []

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -362,7 +362,7 @@ class CheckpointHook(Hook):
                     f'save_keys. If you want to keep it, '
                     f'please set `{k}` in published_keys',
                     logger='current')
-                checkpoint.pop(k, None)
+                checkpoint.pop(k)
         if out_file.endswith('.pth'):
             out_file_name = out_file[:-4]
         else:

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -328,7 +328,7 @@ class CheckpointHook(Hook):
         self._save_best_checkpoint(runner, metrics)
 
     def after_train(self, runner) -> None:
-        """Publish the checkpoint after train epoch.
+        """Publish the checkpoint after training.
 
         Args:
             runner (Runner): The runner of the training process.

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -1,5 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import logging
+import subprocess
+import torch
 import os.path as osp
 from math import inf
 from pathlib import Path
@@ -238,7 +240,6 @@ class CheckpointHook(Hook):
             assert len(published_keys) == len(set(published_keys)), (
                 'Find duplicate element in "published_keys".')
         self.published_keys = published_keys
-        self.published_keys = published_keys
 
     def before_train(self, runner) -> None:
         """Finish all operations, related to checkpoint.
@@ -346,9 +347,6 @@ class CheckpointHook(Hook):
             self._publish_model(runner, best_ckpt)
 
     def _publish_model(self, runner, out_file: str) -> None:
-        import subprocess
-
-        import torch
 
         if published_keys is None:
             return

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -373,7 +373,7 @@ class CheckpointHook(Hook):
         save_checkpoint(checkpoint, final_path)
         assert self.file_client.isfile(final_path)
         print_log(
-            f'The published model is saved at {final_path}.', logger='current')
+            f'The published model ({ckpt_path}) is saved at {final_path}.', logger='current')
 
     def _save_checkpoint(self, runner) -> None:
         """Save the current checkpoint and delete outdated checkpoint.

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -99,7 +99,7 @@ class CheckpointHook(Hook):
         >>> # Save best based on multi metrics with different comparison rule
         >>> CheckpointHook(interval=2, by_epoch=True,
         >>>                save_best=['FID', 'IS'], rule=['less', 'greater'])
-        >>> # Save best based on single metric and publish model after train
+        >>> # Save best based on single metric and publish model after training
         >>> CheckpointHook(interval=2, by_epoch=True, save_best='acc',
         >>>                rule='less', published_keys=['meta', 'state_dict'])
     """

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -342,9 +342,12 @@ class CheckpointHook(Hook):
             self._publish_model(runner, last_ckpt)
 
         if self.save_best is not None:
-            if not self.best_ckpt_path:
-                raise RuntimeError(xxx)
-            self._publish_model(runner, best_ckpt)
+            if len(self.key_indicators) == 1:
+                if self.best_ckpt_path is not None:
+                    self._publish_model(runner, self.best_ckpt_path)
+            else:
+                for key, best_ckpt in self.best_ckpt_path_dict.items():
+                    self._publish_model(runner, best_ckpt)
 
     def _publish_model(self, runner, out_file: str) -> None:
 

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -352,7 +352,7 @@ class CheckpointHook(Hook):
 
         checkpoint = _load_checkpoint(out_file)
         removed_keys = []
-        for key in checkpoint.keys():
+        for key in list(checkpoint.keys()):
             if key not in self.published_keys:
                 removed_keys.append(key)
                 checkpoint.pop(k)

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -346,14 +346,14 @@ class CheckpointHook(Hook):
             for key, best_ckpt in self.best_ckpt_path_dict.items():
                 self._publish_model(runner, best_ckpt)
 
-    def _publish_model(self, runner, out_file: str) -> None:
-        """Publish the checkpoint.
+    def _publish_model(self, runner, ckpt_path: str) -> None:
+        """Remove unnecessary keys from ckpt_path and save the new checkpoint.
 
         Args:
             runner (Runner): The runner of the training process.
-            out_file (str): The checkpoint path that ought to be published.
+            ckpt_path (str): The checkpoint path that ought to be published.
         """
-        checkpoint = _load_checkpoint(out_file)
+        checkpoint = _load_checkpoint(ckpt_path)
         published_keys = self.published_keys
         removed_keys = []
         for key in list(checkpoint.keys()):
@@ -366,11 +366,11 @@ class CheckpointHook(Hook):
                 'found in published_keys. If you want to keep them, '
                 f'please set `{removed_keys}` in published_keys',
                 logger='current')
-        final_file = osp.splitext(
-            out_file)[0] + f'-published-{runner.timestamp}.pth'
-        save_checkpoint(checkpoint, final_file)
+        final_path = osp.splitext(
+            ckpt_path)[0] + f'-published-{runner.timestamp}.pth'
+        save_checkpoint(checkpoint, final_path)
         print_log(
-            f'The published model is saved at {final_file}.', logger='current')
+            f'The published model is saved at {final_path}.', logger='current')
 
     def _save_checkpoint(self, runner) -> None:
         """Save the current checkpoint and delete outdated checkpoint.

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -350,11 +350,11 @@ class CheckpointHook(Hook):
 
         import torch
 
+        if published_keys is None:
+            return
         checkpoint = runner.load_checkpoint(out_file)
         ckpt_keys = list(checkpoint.keys())
         published_keys = self.published_keys
-        if not isinstance(published_keys, list):
-            return
         for k in ckpt_keys:
             if k not in published_keys:
                 print_log(

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -332,7 +332,7 @@ class CheckpointHook(Hook):
         Args:
             runner (Runner): The runner of the training process.
         """
-        if not self.published_keys:
+        if self.published_keys is None:
             return
 
         if self.save_last:

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -336,9 +336,8 @@ class CheckpointHook(Hook):
         if self.published_keys is None:
             return
 
-        if self.save_last:
+        if self.save_last and 'last_ckpt' in self.runtime_info:
             last_ckpt = runner.message_hub.get_info('last_ckpt')
-            assert last_ckpt ('Did not find last_checkpoint to be resumed.')
             self._publish_model(runner, last_ckpt)
 
         if self.save_best is not None:

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -339,7 +339,7 @@ class CheckpointHook(Hook):
             self._publish_model(runner, last_ckpt)
 
         if getattr(self, 'best_ckpt_path', None) is not None:
-            self._publish_model(runner, self.best_ckpt_path)
+            self._publish_model(runner, str(self.best_ckpt_path))
         if getattr(self, 'best_ckpt_path_dict', None) is not None:
             for key, best_ckpt in self.best_ckpt_path_dict.items():
                 self._publish_model(runner, best_ckpt)
@@ -357,7 +357,8 @@ class CheckpointHook(Hook):
         published_keys = self.published_keys
         removed_keys = []
         for key in list(checkpoint.keys()):
-            if key not in published_keys:
+            if published_keys is not None and\
+                    key not in published_keys:
                 removed_keys.append(key)
                 checkpoint.pop(key)
         if removed_keys:

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -230,14 +230,14 @@ class CheckpointHook(Hook):
 
         # published keys
         if not (isinstance(published_keys, str)
-                or is_list_of(published_keys, str) or published_keys is None):
+                or is_seq_of(published_keys, str) or published_keys is None):
             raise TypeError(
-                '"published_keys" should be a str or list of str or None, '
+                '"published_keys" should be a str or a sequence of str or None, '
                 f'but got {type(published_keys)}')
 
         if isinstance(published_keys, str):
             published_keys = [published_keys]
-        elif isinstance(published_keys, list):
+        elif isinstance(published_keys, (list, tuple)):
             assert len(published_keys) == len(set(published_keys)), (
                 'Find duplicate elements in "published_keys".')
         self.published_keys = published_keys

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -354,7 +354,7 @@ class CheckpointHook(Hook):
         from mmengine.runner import save_checkpoint
         from mmengine.runner.checkpoint import _load_checkpoint
         checkpoint = _load_checkpoint(ckpt_path)
-        published_keys: Union[list, str] = self.published_keys
+        published_keys: Optional[Union[List[str], str]] = self.published_keys
         removed_keys = []
         for key in list(checkpoint.keys()):
             if published_keys is not None and\

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -365,13 +365,7 @@ class CheckpointHook(Hook):
                 checkpoint.pop(k)
         out_file_name = osp.splitext(out_file)[0]
         tmp_out_file_name = out_file + '.pth'
-        if torch.__version__ >= '1.6':
-            torch.save(
-                checkpoint,
-                tmp_out_file_name,
-                _use_new_zipfile_serialization=False)
-        else:
-            torch.save(checkpoint, tmp_out_file_name)
+        torch.save(checkpoint, tmp_out_file_name)
         sha = subprocess.check_output(['sha256sum',
                                        tmp_out_file_name]).decode()
         final_file = out_file_name + f'-{sha[:8]}.pth'

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -354,7 +354,7 @@ class CheckpointHook(Hook):
         from mmengine.runner import save_checkpoint
         from mmengine.runner.checkpoint import _load_checkpoint
         checkpoint = _load_checkpoint(ckpt_path)
-        published_keys = self.published_keys
+        published_keys: Union[list, str] = self.published_keys
         removed_keys = []
         for key in list(checkpoint.keys()):
             if published_keys is not None and\

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -354,11 +354,10 @@ class CheckpointHook(Hook):
         from mmengine.runner import save_checkpoint
         from mmengine.runner.checkpoint import _load_checkpoint
         checkpoint = _load_checkpoint(ckpt_path)
-        published_keys: Optional[Union[List[str], str]] = self.published_keys
+        assert self.published_keys is not None
         removed_keys = []
         for key in list(checkpoint.keys()):
-            if published_keys is not None and\
-                    key not in published_keys:
+            if key not in self.published_keys:
                 removed_keys.append(key)
                 checkpoint.pop(key)
         if removed_keys:

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -377,8 +377,6 @@ class CheckpointHook(Hook):
         else:
             ckpt_path_list = runner.message_hub.get_info('publish_ckpt_names')
             ckpt_path_list.append(final_path)
-            runner.message_hub.update_info('publish_ckpt_names',
-                                           ckpt_path_list)
 
     def _save_checkpoint(self, runner) -> None:
         """Save the current checkpoint and delete outdated checkpoint.

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -337,8 +337,7 @@ class CheckpointHook(Hook):
 
         if self.save_last:
             last_ckpt = runner.message_hub.get_info('last_ckpt')
-            if not last_ckpt:
-                assert ('Did not find last_checkpoint to be resumed.')
+            assert last_ckpt ('Did not find last_checkpoint to be resumed.')
             self._publish_model(runner, last_ckpt)
 
         if self.save_best is not None:

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -368,14 +368,12 @@ class CheckpointHook(Hook):
                 logger='current')
         final_path = osp.splitext(
             ckpt_path)[0] + f'-published-{runner.timestamp}.pth'
+        for key in list(checkpoint.keys()):
+            assert key in list(self.published_keys)
         save_checkpoint(checkpoint, final_path)
+        assert self.file_client.isfile(final_path)
         print_log(
             f'The published model is saved at {final_path}.', logger='current')
-        if 'publish_ckpt_names' not in runner.message_hub.runtime_info:
-            runner.message_hub.update_info('publish_ckpt_names', [final_path])
-        else:
-            ckpt_path_list = runner.message_hub.get_info('publish_ckpt_names')
-            ckpt_path_list.append(final_path)
 
     def _save_checkpoint(self, runner) -> None:
         """Save the current checkpoint and delete outdated checkpoint.

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -363,10 +363,7 @@ class CheckpointHook(Hook):
                     f'please set `{k}` in published_keys',
                     logger='current')
                 checkpoint.pop(k)
-        if out_file.endswith('.pth'):
-            out_file_name = out_file[:-4]
-        else:
-            out_file_name = out_file
+        out_file_name = osp.splitext(out_file)[0]
         tmp_out_file_name = out_file + '.pth'
         if torch.__version__ >= '1.6':
             torch.save(

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -232,9 +232,9 @@ class CheckpointHook(Hook):
                 or published_keys is None):
             raise TypeError(
                 '"published_keys" should be a str or list of str or None, '
-                f'but got {type(published_keys)}'):
+                f'but got {type(published_keys)}')
 
-        if isinstace(published_keys, str):
+        if isinstance(published_keys, str):
             published_keys = [published_keys]    
         elif isinstance(published_keys, list):
             assert len(published_keys) == len(set(published_keys)), (

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -90,6 +90,7 @@ class CheckpointHook(Hook):
             or ``save_best`` is not ``None``, it will automatically
             publish model with keys in the list after training.
             Defaults to None.
+            `New in version 0.7.1.`
     Examples:
         >>> # Save best based on single metric
         >>> CheckpointHook(interval=2, by_epoch=True, save_best='acc',
@@ -370,10 +371,10 @@ class CheckpointHook(Hook):
                 logger='current')
         checkpoint_data = pickle.dumps(checkpoint)
         sha = hashlib.sha256(checkpoint_data).hexdigest()
-        final_path = osp.splitext(ckpt_path)[0] + f'-published-{sha[:8]}.pth'
+        final_path = osp.splitext(ckpt_path)[0] + f'-{sha[:8]}.pth'
         save_checkpoint(checkpoint, final_path)
         print_log(
-            f'The published model ({ckpt_path}) is saved at '
+            f'The checkpoint ({ckpt_path}) is published to '
             f'{final_path}.',
             logger='current')
 

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -341,9 +341,8 @@ class CheckpointHook(Hook):
             self._publish_model(runner, last_ckpt)
 
         if self.save_best is not None:
-            best_ckpt = self.best_ckpt_path
-            if not best_ckpt:
-                assert ('Did not find best_checkpoint to be resumed.')
+            if not self.best_ckpt_path:
+                raise RuntimeError(xxx)
             self._publish_model(runner, best_ckpt)
 
     def _publish_model(self, runner, out_file) -> None:

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -15,7 +15,7 @@ from mmengine.logging import MessageHub
 from mmengine.model import BaseModel
 from mmengine.optim import OptimWrapper
 from mmengine.runner import Runner
-
+from mmengine.runner.checkpoint import _load_checkpoint
 
 class ToyModel(BaseModel):
 
@@ -496,4 +496,7 @@ class TestCheckpointHook:
             path = osp.join(work_dir, tmpl.format(epoch))
             assert osp.isfile(path=path)
         for path in runner.message_hub.get_info('publish_ckpt_names'):
+            checkpoint = _load_checkpoint(path)
             assert osp.isfile(path=path)
+            for key in list(checkpoint.keys()):
+                assert key in list(checkpoint_cfg['published_keys'])

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -17,6 +17,7 @@ from mmengine.optim import OptimWrapper
 from mmengine.runner import Runner
 from mmengine.runner.checkpoint import _load_checkpoint
 
+
 class ToyModel(BaseModel):
 
     def __init__(self):

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -15,7 +15,6 @@ from mmengine.logging import MessageHub
 from mmengine.model import BaseModel
 from mmengine.optim import OptimWrapper
 from mmengine.runner import Runner
-from mmengine.runner.checkpoint import _load_checkpoint
 
 
 class ToyModel(BaseModel):
@@ -496,8 +495,3 @@ class TestCheckpointHook:
                 continue
             path = osp.join(work_dir, tmpl.format(epoch))
             assert osp.isfile(path=path)
-        for path in runner.message_hub.get_info('publish_ckpt_names'):
-            checkpoint = _load_checkpoint(path)
-            assert osp.isfile(path=path)
-            for key in list(checkpoint.keys()):
-                assert key in list(checkpoint_cfg['published_keys'])

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -465,7 +465,10 @@ class TestCheckpointHook:
             type='CheckpointHook',
             interval=save_interval,
             filename_tmpl=tmpl,
-            by_epoch=True)
+            by_epoch=True,
+            save_best='test/acc',
+            rule='less',
+            published_keys=['meta', 'state_dict'])
         runner = Runner(
             model=ToyModel(),
             work_dir=work_dir,
@@ -491,4 +494,6 @@ class TestCheckpointHook:
             if epoch % save_interval != 0 or epoch == 0:
                 continue
             path = osp.join(work_dir, tmpl.format(epoch))
+            assert osp.isfile(path=path)
+        for path in runner.message_hub.get_info('publish_ckpt_names'):
             assert osp.isfile(path=path)


### PR DESCRIPTION
## Motivation

As https://github.com/open-mmlab/mmengine/issues/905 described.

## Modification

[Enhancement] add automatically Publish in checkpointhook.py and corresponding update document in hook.md

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.

For example：

I am training cifar10 using the resnet50 model from the code in the mmengine example docs. And add default_hook in runner

```
default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=1,
                                     save_best='accuracy', rule='less', published_keys=['meta', 'state_dict']))
runner = Runner(
    model=MMResNet50(),
    work_dir='./work_dir',
    train_dataloader=train_dataloader,
    optim_wrapper=dict(optimizer=dict(type=SGD, lr=0.001, momentum=0.9)),
    train_cfg=dict(by_epoch=True, max_epochs=5, val_interval=1),
    val_dataloader=val_dataloader,
    val_cfg=dict(),
    val_evaluator=dict(type=Accuracy),
    default_hooks=default_hooks,
)
```

After trainning will publish the model, here is logs:
```
Loads checkpoint by local backend from path: /data/run01/scz0b6e/mm-lab/run_place/work_dir/epoch_5.pth
03/08 15:55:18 - mmengine - INFO - Load checkpoint from /data/run01/scz0b6e/mm-lab/run_place/work_dir/epoch_5.pth
03/08 15:55:18 - mmengine - INFO - Key `message_hub` will be removed because it is not in save_keys. If you want to keep it, please set `message_hub` in published_keys
03/08 15:55:18 - mmengine - INFO - Key `optimizer` will be removed because it is not in save_keys. If you want to keep it, please set `optimizer` in published_keys
03/08 15:55:18 - mmengine - INFO - The published model is saved at /data/run01/scz0b6e/mm-lab/run_place/work_dir/epoch_5-d16194b7.pth.
Loads checkpoint by local backend from path: /data/run01/scz0b6e/mm-lab/run_place/work_dir/best_accuracy_epoch_1.pth
03/08 15:55:18 - mmengine - INFO - Load checkpoint from /data/run01/scz0b6e/mm-lab/run_place/work_dir/best_accuracy_epoch_1.pth
03/08 15:55:18 - mmengine - INFO - Key `message_hub` will be removed because it is not in save_keys. If you want to keep it, please set `message_hub` in published_keys
03/08 15:55:19 - mmengine - INFO - The published model is saved at /data/run01/scz0b6e/mm-lab/run_place/work_dir/best_accuracy_epoch_1-107ccaf7.pth.
```

Here is the resulting folder structure

```
(base) [scz0b6e@ln01 run_place]$ cd work_dir/
(base) [scz0b6e@ln01 work_dir]$ ll
total 1302396
drwxrwxr-x 3 scz0b6e scz0b6e      4096 Mar  8 15:50 20230308_155014
-rw-rw-r-- 1 scz0b6e scz0b6e         1 Mar  8 15:50 20230308_155014.py
-rw-rw-r-- 1 scz0b6e scz0b6e 102497337 Mar  8 15:55 best_accuracy_epoch_1-107ccaf7.pth
-rw-rw-r-- 1 scz0b6e scz0b6e 102670911 Mar  8 15:51 best_accuracy_epoch_1.pth
-rw-rw-r-- 1 scz0b6e scz0b6e 204935167 Mar  8 15:51 epoch_1.pth
-rw-rw-r-- 1 scz0b6e scz0b6e 205061629 Mar  8 15:52 epoch_2.pth
-rw-rw-r-- 1 scz0b6e scz0b6e 205186557 Mar  8 15:53 epoch_3.pth
-rw-rw-r-- 1 scz0b6e scz0b6e 205311485 Mar  8 15:54 epoch_4.pth
-rw-rw-r-- 1 scz0b6e scz0b6e 102497337 Mar  8 15:55 epoch_5-d16194b7.pth
-rw-rw-r-- 1 scz0b6e scz0b6e 205436221 Mar  8 15:55 epoch_5.pth
-rw-rw-r-- 1 scz0b6e scz0b6e        57 Mar  8 15:55 last_checkpoint
```

Use follow code to check and compare the keys
```
import torch
def process_checkpoint(in_file):
    print(in_file)
    checkpoint = torch.load(in_file, map_location='cpu')
    ckpt_keys = list(checkpoint.keys())
    print(ckpt_keys)
    print()

def main():
    process_checkpoint('/HOME/scz0b6e/run/mm-lab/run_place/work_dir/best_accuracy_epoch_1.pth')
    process_checkpoint('/HOME/scz0b6e/run/mm-lab/run_place/work_dir/best_accuracy_epoch_1-107ccaf7.pth')
    process_checkpoint('/HOME/scz0b6e/run/mm-lab/run_place/work_dir/epoch_5.pth')
    process_checkpoint('/HOME/scz0b6e/run/mm-lab/run_place/work_dir/epoch_5-d16194b7.pth')

if __name__ == '__main__':
    main()
```

And here is the log:
```
/HOME/scz0b6e/run/mm-lab/run_place/work_dir/best_accuracy_epoch_1.pth
['meta', 'state_dict', 'message_hub']

/HOME/scz0b6e/run/mm-lab/run_place/work_dir/best_accuracy_epoch_1-107ccaf7.pth
['meta', 'state_dict']

/HOME/scz0b6e/run/mm-lab/run_place/work_dir/epoch_5.pth
['meta', 'state_dict', 'message_hub', 'optimizer']

/HOME/scz0b6e/run/mm-lab/run_place/work_dir/epoch_5-d16194b7.pth
['meta', 'state_dict']
```
The full logs: https://github.com/KerwinKai/mmengine/blob/main/20230308_155014.log