### PR TITLE
[Fix] Fix AMP in Ascend and support using NPUJITCompile environment

### DIFF
--- a/mmengine/device/utils.py
+++ b/mmengine/device/utils.py
@@ -39,7 +39,8 @@ def is_npu_available() -> bool:
 
         # Enable operator support for dynamic shape and
         # binary operator support on the NPU.
-        torch.npu.set_compile_mode(jit_compile=False)
+        npu_jit_compile=bool(os.getenv('NPUJITCompile', False))
+        torch.npu.set_compile_mode(jit_compile=npu_jit_compile)
     except Exception:
         return False
     return hasattr(torch, 'npu') and torch.npu.is_available()

--- a/mmengine/device/utils.py
+++ b/mmengine/device/utils.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import os
 from typing import Optional
 
 import torch
@@ -39,7 +40,7 @@ def is_npu_available() -> bool:
 
         # Enable operator support for dynamic shape and
         # binary operator support on the NPU.
-        npu_jit_compile=bool(os.getenv('NPUJITCompile', False))
+        npu_jit_compile = bool(os.getenv('NPUJITCompile', False))
         torch.npu.set_compile_mode(jit_compile=npu_jit_compile)
     except Exception:
         return False

--- a/mmengine/runner/amp.py
+++ b/mmengine/runner/amp.py
@@ -126,6 +126,10 @@ def autocast(device_type: Optional[str] = None,
 
         elif device_type == 'mlu':
             pass
+
+        elif device_type == 'npu':
+            pass
+
         else:
             # Device like MPS does not support fp16 training or testing.
             # If an inappropriate device is set and fp16 is enabled, an error


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1. Support automatic mixed-precision training with pytorch version 1.10 or above.
2. Support manually set up the use of dynamic shapes and static shapes.

## Modification

1. mmengine/runner/amp.py. complements to NPU autocast.
2. mmengine/device/utils.py. supplemented with a switch to turn on static shape，dynamic shapes are used by default.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
None.

## Use cases (Optional)

Open the static shape：export  NPUJITCompile=True

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
