### PR TITLE
[Refactor] `get_device` and `is_npu_available`

### DIFF
--- a/mmengine/device/utils.py
+++ b/mmengine/device/utils.py
@@ -4,6 +4,17 @@ from typing import Optional
 
 import torch
 
+try:
+    import torch_npu  # noqa: F401
+
+    # Enable operator support for dynamic shape and
+    # binary operator support on the NPU.
+    npu_jit_compile = bool(os.getenv('NPUJITCompile', False))
+    torch.npu.set_compile_mode(jit_compile=npu_jit_compile)
+    IS_NPU_AVAILABLE = hasattr(torch, 'npu') and torch.npu.is_available()
+except Exception:
+    IS_NPU_AVAILABLE = False
+
 
 def get_max_cuda_memory(device: Optional[torch.device] = None) -> int:
     """Returns the maximum GPU memory occupied by tensors in megabytes (MB) for
@@ -35,16 +46,7 @@ def is_cuda_available() -> bool:
 
 def is_npu_available() -> bool:
     """Returns True if Ascend PyTorch and npu devices exist."""
-    try:
-        import torch_npu  # noqa: F401
-
-        # Enable operator support for dynamic shape and
-        # binary operator support on the NPU.
-        npu_jit_compile = bool(os.getenv('NPUJITCompile', False))
-        torch.npu.set_compile_mode(jit_compile=npu_jit_compile)
-    except Exception:
-        return False
-    return hasattr(torch, 'npu') and torch.npu.is_available()
+    return IS_NPU_AVAILABLE
 
 
 def is_mlu_available() -> bool:
@@ -60,19 +62,23 @@ def is_mps_available() -> bool:
     return hasattr(torch.backends, 'mps') and torch.backends.mps.is_available()
 
 
+DEVICE = 'none'
+if is_npu_available():
+    DEVICE = 'npu'
+elif is_cuda_available():
+    DEVICE = 'cuda'
+elif is_mlu_available():
+    DEVICE = 'mlu'
+elif is_mps_available():
+    DEVICE = 'mps'
+else:
+    DEVICE = 'cpu'
+
+
 def get_device() -> str:
     """Returns the currently existing device type.
 
     Returns:
         str: cuda | npu | mlu | mps | cpu.
     """
-    if is_npu_available():
-        return 'npu'
-    elif is_cuda_available():
-        return 'cuda'
-    elif is_mlu_available():
-        return 'mlu'
-    elif is_mps_available():
-        return 'mps'
-    else:
-        return 'cpu'
+    return DEVICE

--- a/mmengine/device/utils.py
+++ b/mmengine/device/utils.py
@@ -62,7 +62,7 @@ def is_mps_available() -> bool:
     return hasattr(torch.backends, 'mps') and torch.backends.mps.is_available()
 
 
-DEVICE = 'none'
+DEVICE = 'cpu'
 if is_npu_available():
     DEVICE = 'npu'
 elif is_cuda_available():
@@ -71,8 +71,6 @@ elif is_mlu_available():
     DEVICE = 'mlu'
 elif is_mps_available():
     DEVICE = 'mps'
-else:
-    DEVICE = 'cpu'
 
 
 def get_device() -> str:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Determine devices on initialization instead of whenever `get_device` is called.

Determine the availability of NPU devices on initialization instead of whenever `is_npu_available` is called.

## Modification

Add new variables `IS_NPU_AVAILABLE` and `DEVICE`

## BC-breaking (Optional)

No

## Use cases (Optional)

Not changed

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
