### PR TITLE
[Enhance] Enhance the error catching in registry

### DIFF
--- a/mmengine/registry/registry.py
+++ b/mmengine/registry/registry.py
@@ -348,7 +348,6 @@ class Registry:
                     level=logging.WARNING)
                 try:
                     module = import_module(f'{self.scope}.utils')
-                    module.register_all_modules(False)  # type: ignore
                 except (ImportError, AttributeError, ModuleNotFoundError):
                     if self.scope in MODULE2PACKAGE:
                         print_log(
@@ -366,22 +365,20 @@ class Registry:
                             'have registered the module manually.',
                             logger='current',
                             level=logging.WARNING)
+                else:
+                    # The import errors triggered during the registration
+                    # may be more complex, here just throwing
+                    # the error to avoid causing more implicit registry errors
+                    # like `xxx`` not found in `yyy` registry.
+                    module.register_all_modules(False)  # type: ignore
 
             for loc in self._locations:
-                try:
-                    import_module(loc)
-                    print_log(
-                        f"Modules of {self.scope}'s {self.name} registry have "
-                        f'been automatically imported from {loc}',
-                        logger='current',
-                        level=logging.DEBUG)
-                except (ImportError, AttributeError, ModuleNotFoundError):
-                    print_log(
-                        f'Failed to import {loc}, please check the '
-                        f'location of the registry {self.name} is '
-                        'correct.',
-                        logger='current',
-                        level=logging.WARNING)
+                import_module(loc)
+                print_log(
+                    f"Modules of {self.scope}'s {self.name} registry have "
+                    f'been automatically imported from {loc}',
+                    logger='current',
+                    level=logging.DEBUG)
             self._imported = True
 
     def get(self, key: str) -> Optional[Type]:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The original implementation will catch the error raised in the registry process,  which leads to an error like `xxx not found in yyy registry` and hide the real error like "ModuleNotFoundError: No module named `pycocotools`" caused by third party. 

This PR will enhance error-catching logic. If the error is raised in registering process, it will be directly raised rather than watched by us and only throw a warning.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
