### PR TITLE
[Fix] Fix there is no space between data_time metric

### DIFF
--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -307,7 +307,8 @@ class LogProcessor:
                 tag[key] = value
         # Log other messages.
         log_items = []
-        for name, val in chain(tag.items(), non_scalar_tag.items()):
+        for name, val in chain(tag.items(), non_scalar_tag.items(),
+                               time_tag.items()):
             if isinstance(val, float):
                 val = f'{val:.{self.num_digits}f}'
             if isinstance(val, (torch.Tensor, np.ndarray)):
@@ -315,9 +316,6 @@ class LogProcessor:
                 val = f'\n{val}\n'
             log_items.append(f'{name}: {val}')
         log_str += '  '.join(log_items)
-
-        for name, val in time_tag.items():
-            log_str += f'{name}: {val:.{self.num_digits}f}  '
 
         if with_non_scalar:
             tag.update(non_scalar_tag)

--- a/tests/test_runner/test_log_processor.py
+++ b/tests/test_runner/test_log_processor.py
@@ -161,7 +161,7 @@ class TestLogProcessor:
             return_value=non_scalar_logs)
         _, out = log_processor.get_log_after_epoch(self.runner, 2, mode)
         expect_metric_str = ("accuracy: 0.9000  recall: {'cat': 1, 'dog': 0}  "
-                             'cm: \ntensor([1, 2, 3])\ndata_time: 1.0000  ')
+                             'cm: \ntensor([1, 2, 3])\n  data_time: 1.0000')
         if by_epoch:
             if mode == 'test':
                 assert out == 'Epoch(test) [5/5]  ' + expect_metric_str


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Resolve #1016 .

before:
```bash
03/28 18:54:17 - mmengine - INFO - Epoch(val) [1][157/157]  accuracy: 28.8200data_time: 0.0049  time: 0.0101
```

after:
```bash
03/28 18:53:03 - mmengine - INFO - Epoch(val) [1][157/157]  accuracy: 29.1400  data_time: 0.0050  time: 0.0101
```
## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
