### PR TITLE
[Fix] Skip testing `test_dist` in Github Action CI

### DIFF
--- a/.github/workflows/merge_stage_test.yml
+++ b/.github/workflows/merge_stage_test.yml
@@ -48,7 +48,7 @@ jobs:
           mim install 'mmcv>=2.0.0rc1'
       - name: Run unittests and generate coverage report
         run: |
-          coverage run --branch --source mmengine -m pytest tests/
+          coverage run --branch --source mmengine -m pytest tests/  --ignore tests/test_dist
           coverage xml
           coverage report -m
 
@@ -97,15 +97,11 @@ jobs:
           mim install 'mmcv>=2.0.0rc1'
       - name: Run unittests and generate coverage report
         run: |
-          if [[ ${{ matrix.torch }} == "1.13.0" ]]; then
-            coverage run --branch --source mmengine -m pytest tests/  --ignore tests/test_dist
-          else
-            coverage run --branch --source mmengine -m pytest tests/
-          fi
+          coverage run --branch --source mmengine -m pytest tests/  --ignore tests/test_dist
       # Only upload coverage report for python3.7 && pytorch1.8.1 cpu
       - name: Upload coverage to Codecov
         if: ${{matrix.torch == '1.8.1' && matrix.python-version == '3.7'}}
-        uses: codecov/codecov-action@v1.0.14
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           flags: unittests
@@ -148,7 +144,7 @@ jobs:
           mim install 'mmcv>=2.0.0rc1'
       - name: Run unittests and generate coverage report
         run: |
-          coverage run --branch --source mmengine -m pytest tests/
+          coverage run --branch --source mmengine -m pytest tests/ --ignore tests/test_dist
           coverage xml
           coverage report -m
 
@@ -292,7 +288,7 @@ jobs:
           pip install openmim
           mim install 'mmcv>=2.0.0rc1'
       - name: Run CPU unittests
-        run: pytest tests/
+        run: pytest tests/  --ignore tests/test_dist
         if: ${{ matrix.platform == 'cpu' }}
       - name: Run GPU unittests
         # Skip testing distributed related unit tests since the memory of windows CI is limited

--- a/.github/workflows/pr_stage_test.yml
+++ b/.github/workflows/pr_stage_test.yml
@@ -45,12 +45,12 @@ jobs:
           mim install 'mmcv>=2.0.0rc1'
       - name: Run unittests and generate coverage report
         run: |
-          coverage run --branch --source mmengine -m pytest tests/
+          coverage run --branch --source mmengine -m pytest tests/  --ignore tests/test_dist
           coverage xml
           coverage report -m
       # Upload coverage report for python3.7 && pytorch1.8.1 cpu
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.14
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           flags: unittests
@@ -90,7 +90,7 @@ jobs:
           mim install 'mmcv>=2.0.0rc1'
       - name: Run unittests and generate coverage report
         run: |
-          coverage run --branch --source mmengine -m pytest tests/
+          coverage run --branch --source mmengine -m pytest tests/  --ignore tests/test_dist
           coverage xml
           coverage report -m
 
@@ -161,7 +161,7 @@ jobs:
           pip install openmim
           mim install 'mmcv>=2.0.0rc1'
       - name: Run CPU unittests
-        run: pytest tests/
+        run: pytest tests/  --ignore tests/test_dist
         if: ${{ matrix.platform == 'cpu' }}
       - name: Run GPU unittests
         # Skip testing distributed related unit tests since the memory of windows CI is limited


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Github Action CI could throw errors randomly when testing `test_dist` due to machine's capability. This PR skip testing `test_dist` in all Github Action CI, and only test `test_dist` in circle CI.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
