### PR TITLE
[Enhance] Support dumping datasets to pkl file

### DIFF
--- a/mmengine/dataset/base_dataset.py
+++ b/mmengine/dataset/base_dataset.py
@@ -830,13 +830,16 @@ class BaseDataset(Dataset):
 
         return other
 
-    def load(self, pkl_file: str) -> None:
+    @classmethod
+    def load(cls, pkl_file: str) -> None:
         """Load data list from pickle file.
 
         Args:
             pkl_file (str): Pickle file path.
         """
-        self.data_list = load(pkl_file)
+        obj = cls.__new__(cls)
+        obj.__dict__.update(load(pkl_file))
+        return obj
 
     def dump(self, pkl_file: str) -> None:
         """Dump data list to pickle file.
@@ -844,4 +847,4 @@ class BaseDataset(Dataset):
         Args:
             pkl_file (str): Pickle file path.
         """
-        fileio_dump(self.data_list, pkl_file, file_format='pkl')
+        fileio_dump(self.__dict__, pkl_file, file_format='pkl')

--- a/mmengine/dataset/base_dataset.py
+++ b/mmengine/dataset/base_dataset.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 import numpy as np
 from torch.utils.data import Dataset
 
+from mmengine.fileio import dump as fileio_dump
 from mmengine.fileio import list_from_file, load
 from mmengine.logging import print_log
 from mmengine.registry import TRANSFORMS
@@ -828,3 +829,19 @@ class BaseDataset(Dataset):
                                                   copy.deepcopy(value, memo))
 
         return other
+
+    def load(self, pkl_file: str) -> None:
+        """Load data list from pickle file.
+
+        Args:
+            pkl_file (str): Pickle file path.
+        """
+        self.data_list = load(pkl_file)
+
+    def dump(self, pkl_file: str) -> None:
+        """Dump data list to pickle file.
+
+        Args:
+            pkl_file (str): Pickle file path.
+        """
+        fileio_dump(self.data_list, pkl_file, file_format='pkl')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support dumping datasets to pkl file [https://github.com/open-mmlab/mmengine/issues/896](Issue)

## Modification

add load and dump function for data_list in base_dataset.py

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
