### PR TITLE
[Fix] No training log when the num of iterations is smaller than the default interval

### DIFF
--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -167,7 +167,8 @@ class LoggerHook(Hook):
             tag, log_str = runner.log_processor.get_log_after_iter(
                 runner, batch_idx, 'train')
         elif (self.end_of_epoch(runner.train_dataloader, batch_idx)
-              and not self.ignore_last):
+              and (not self.ignore_last
+                   or len(runner.train_dataloader) < self.interval)):
             # `runner.max_iters` may not be divisible by `self.interval`. if
             # `self.ignore_last==True`, the log of remaining iterations will
             # be recorded (Epoch [4][1000/1007], the logs of 998-1007

--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -168,7 +168,7 @@ class LoggerHook(Hook):
                 runner, batch_idx, 'train')
         elif (self.end_of_epoch(runner.train_dataloader, batch_idx)
               and (not self.ignore_last
-                   or len(runner.train_dataloader) < self.interval)):
+                   or len(runner.train_dataloader) <= self.interval)):
             # `runner.max_iters` may not be divisible by `self.interval`. if
             # `self.ignore_last==True`, the log of remaining iterations will
             # be recorded (Epoch [4][1000/1007], the logs of 998-1007

--- a/tests/test_hooks/test_logger_hook.py
+++ b/tests/test_hooks/test_logger_hook.py
@@ -127,6 +127,15 @@ class TestLoggerHook:
         logger_hook.after_train_iter(runner, batch_idx=999)
         runner.logger.info.assert_called()
 
+        # Test print training log when the num of iterations is smaller than the default interval
+        runner = MagicMock()
+        runner.log_processor.get_log_after_iter = MagicMock(
+            return_value=(dict(), 'log_str'))
+        runner.train_dataloader = [0] * 9
+        logger_hook = LoggerHook()
+        logger_hook.after_train_iter(runner, batch_idx=8)
+        runner.log_processor.get_log_after_iter.assert_called()
+
     def test_after_val_epoch(self):
         logger_hook = LoggerHook()
         runner = MagicMock()

--- a/tests/test_hooks/test_logger_hook.py
+++ b/tests/test_hooks/test_logger_hook.py
@@ -127,7 +127,8 @@ class TestLoggerHook:
         logger_hook.after_train_iter(runner, batch_idx=999)
         runner.logger.info.assert_called()
 
-        # Test print training log when the num of iterations is smaller than the default interval
+        # Test print training log when the num of
+        # iterations is smaller than the default interval
         runner = MagicMock()
         runner.log_processor.get_log_after_iter = MagicMock(
             return_value=(dict(), 'log_str'))

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -1727,12 +1727,16 @@ class TestRunner(TestCase):
         with self.assertRaisesRegex(AssertionError, 'If you want to validate'):
             runner.train()
 
-        # 13 Test the logs will be output when the length of
-        # the train dataloader is smaller than the log interval
+        # 13 Test the logs will be printed when the length of
+        # train_dataloader is smaller than the interval set in LoggerHook
         cfg = copy.deepcopy(self.epoch_based_cfg)
         cfg.experiment_name = 'test_train13'
+        cfg.default_hooks = dict(logger=dict(type='LoggerHook', interval=5))
         runner = Runner.from_cfg(cfg)
         runner.train()
+        with open(runner.logger._log_file, 'r') as f:
+            log = f.read()
+        self.assertIn('Epoch(train) [1][4/4]', log)
 
     @skipIf(
         SKIP_TEST_COMPILE,

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -1727,6 +1727,13 @@ class TestRunner(TestCase):
         with self.assertRaisesRegex(AssertionError, 'If you want to validate'):
             runner.train()
 
+        # 13 Test the logs will be output when the length of
+        # the train dataloader is smaller than the log interval
+        cfg = copy.deepcopy(self.epoch_based_cfg)
+        cfg.experiment_name = 'test_train13'
+        runner = Runner.from_cfg(cfg)
+        runner.train()
+
     @skipIf(
         SKIP_TEST_COMPILE,
         reason='torch.compile is not valid, please install PyTorch>=2.0.0')

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -1734,7 +1734,7 @@ class TestRunner(TestCase):
         cfg.default_hooks = dict(logger=dict(type='LoggerHook', interval=5))
         runner = Runner.from_cfg(cfg)
         runner.train()
-        with open(runner.logger._log_file, 'r') as f:
+        with open(runner.logger._log_file) as f:
             log = f.read()
         self.assertIn('Epoch(train) [1][4/4]', log)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

No training log when the num of iterations is smaller than the default interval. [https://github.com/open-mmlab/mmengine/issues/935](Issue)

## Modification

Add judgement in  function ```after_train_iter``` of class ```LoggerHook```.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
