### PR TITLE
[Improve] Support registering method and partial function.

### DIFF
--- a/mmengine/registry/registry.py
+++ b/mmengine/registry/registry.py
@@ -572,7 +572,7 @@ class Registry:
             force (bool): Whether to override an existing class with the same
                 name. Defaults to False.
         """
-        if not inspect.isclass(module) and not inspect.isfunction(module):
+        if not inspect.isclass(module) and not callable(module):
             raise TypeError('module must be a class or a function, '
                             f'but got {type(module)}')
 

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import time
+from functools import partial
 
 import pytest
 
@@ -65,16 +66,18 @@ class TestRegistry:
         assert CATS.get('muchkin') is muchkin
         assert 'muchkin' in CATS
 
-        # can only decorate a class or a function
-        with pytest.raises(TypeError):
+        # decorate a class method
+        class Demo:
 
-            class Demo:
+            def some_method(self):
+                pass
 
-                def some_method(self):
-                    pass
+        method = Demo().some_method
+        CATS.register_module(name='some_method', module=method)
 
-            method = Demo().some_method
-            CATS.register_module(name='some_method', module=method)
+        # decorate a partial function
+        partial_func = partial(print, sep='')
+        CATS.register_module(name='partical_func', module=partial_func)
 
         # test `name` parameter which must be either of None, a string or a
         # sequence of string
@@ -83,7 +86,7 @@ class TestRegistry:
         class BritishShorthair:
             pass
 
-        assert len(CATS) == 2
+        assert len(CATS) == 4
         assert CATS.get('BritishShorthair') is BritishShorthair
 
         # `name` is a string
@@ -91,7 +94,7 @@ class TestRegistry:
         class Munchkin:
             pass
 
-        assert len(CATS) == 3
+        assert len(CATS) == 5
         assert CATS.get('Munchkin') is Munchkin
         assert 'Munchkin' in CATS
 
@@ -102,7 +105,7 @@ class TestRegistry:
 
         assert CATS.get('Siamese') is SiameseCat
         assert CATS.get('Siamese2') is SiameseCat
-        assert len(CATS) == 5
+        assert len(CATS) == 7
 
         # `name` is an invalid type
         with pytest.raises(
@@ -139,7 +142,7 @@ class TestRegistry:
         class BritishShorthair:
             pass
 
-        assert len(CATS) == 5
+        assert len(CATS) == 7
 
         # test `module` parameter, which is either None or a class
         # when the `register_module`` is called as a method rather than a
@@ -155,16 +158,16 @@ class TestRegistry:
 
         CATS.register_module(module=SphynxCat)
         assert CATS.get('SphynxCat') is SphynxCat
-        assert len(CATS) == 6
+        assert len(CATS) == 8
 
         CATS.register_module(name='Sphynx1', module=SphynxCat)
         assert CATS.get('Sphynx1') is SphynxCat
-        assert len(CATS) == 7
+        assert len(CATS) == 9
 
         CATS.register_module(name=['Sphynx2', 'Sphynx3'], module=SphynxCat)
         assert CATS.get('Sphynx2') is SphynxCat
         assert CATS.get('Sphynx3') is SphynxCat
-        assert len(CATS) == 9
+        assert len(CATS) == 11
 
     def _build_registry(self):
         """A helper function to build a Hierarchical Registry."""


### PR DESCRIPTION
## Motivation

The original registry doesn't accept method and partial functions.

## Modification

Use `callable` instead of `inspect.isfunction` as the condition of the registry.

## BC-breaking

No

## Use cases

For example, we want to use the factory method instead of the initialization method to build a class

```python
from transformers import AutoModelForImageClassification
from mmengine.registry import MODELS

MODELS.register_module('hf', module=AutoModelForImageClassification.from_pretrained)

resnet = MODELS.build(dict(type='hf', pretrained_model_name_or_path='microsoft/resnet-50'))
print(type(resnet))
# <class 'transformers.models.resnet.modeling_resnet.ResNetForImageClassification'>
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
