### PR TITLE
[Fix] Update the ClassBalancedDataset logic

### DIFF
--- a/mmengine/dataset/dataset_wrapper.py
+++ b/mmengine/dataset/dataset_wrapper.py
@@ -429,12 +429,16 @@ class ClassBalancedDataset:
         #    r(I) = max_{c in L(I)} r(c)
         repeat_factors = []
         for idx in range(num_images):
+            # the length of `repeat_factors` need equal to the length of
+            # dataset. Hence, if the `cat_ids` is empty,
+            # the repeat_factor should be 1.
+            repeat_factor: float = 1.
             cat_ids = set(self.dataset.get_cat_ids(idx))
             if len(cat_ids) != 0:
                 repeat_factor = max(
                     {category_repeat[cat_id]
                      for cat_id in cat_ids})
-                repeat_factors.append(repeat_factor)
+            repeat_factors.append(repeat_factor)
 
         return repeat_factors
 


### PR DESCRIPTION
Related PR: https://github.com/open-mmlab/mmdetection/pull/10038

## Description of the problem

Right now, if the `cat_ids` is empty, the operation will be skipped. And the length of the repeat_factors will not equal to len(self.dataset). 
https://github.com/open-mmlab/mmengine/blob/093068e4ffdb0bb6ab0b95c45d9616835e930ce0/mmengine/dataset/dataset_wrapper.py#L430-L437

The index of the image without any label will be replaced by the next image, and this will cause error.
https://github.com/open-mmlab/mmengine/blob/093068e4ffdb0bb6ab0b95c45d9616835e930ce0/mmengine/dataset/dataset_wrapper.py#L383-L391

Hence, if the image label is empty, it should add`1.0` in `repeat_factors` to keep the length same.


## Results of LVIS

### Before fix this error
```
 Epoch(val) [12][2477/2477]  
lvis/bbox_AP: 0.2160  lvis/bbox_AP50: 0.3520  lvis/bbox_AP75: 0.2290  lvis/bbox_APs: 0.1660  lvis/bbox_APm: 0.2860  lvis/bbox_APl: 0.3350  lvis/bbox_APr: 0.0630  lvis/bbox_APc: 0.2000  lvis/bbox_APf: 0.3020 
lvis/segm_AP: 0.2080  lvis/segm_AP50: 0.3290  lvis/segm_AP75: 0.2210  lvis/segm_APs: 0.1510  lvis/segm_APm: 0.2830  lvis/segm_APl: 0.3390  lvis/segm_APr: 0.0660  lvis/segm_APc: 0.2010  lvis/segm_APf: 0.2790
```

### After fix this error

```
 Epoch(val) [12][2477/2477]  
lvis/bbox_AP: 0.2300  lvis/bbox_AP50: 0.3770  lvis/bbox_AP75: 0.2430  lvis/bbox_APs: 0.1730  lvis/bbox_APm: 0.3030  lvis/bbox_APl: 0.3460  lvis/bbox_APr: 0.1000  lvis/bbox_APc: 0.2170  lvis/bbox_APf: 0.3010  
lvis/segm_AP: 0.2240  lvis/segm_AP50: 0.3520  lvis/segm_AP75: 0.2380  lvis/segm_APs: 0.1590  lvis/segm_APm: 0.3000  lvis/segm_APl: 0.3520  lvis/segm_APr: 0.1180  lvis/segm_APc: 0.2160  lvis/segm_APf: 0.2790
```

### Released result in mmdet

```
{"mode": "val", "epoch": 12, "iter": 7674, "lr": 0.0002,
 "bbox_AP": 0.225, "bbox_AP50": 0.369, "bbox_AP75": 0.238, "bbox_APs": 0.168, "bbox_APm": 0.297, "bbox_APl": 0.35, "bbox_APr": 0.091, "bbox_APc": 0.211, "bbox_APf": 0.301, 
 "bbox_mAP_copypaste": "AP:0.225 AP50:0.369 AP75:0.238 APs:0.168 APm:0.297 APl:0.350 APr:0.091 APc:0.211 APf:0.301", 
 "segm_AP": 0.217, "segm_AP50": 0.343, "segm_AP75": 0.23, "segm_APs": 0.152, "segm_APm": 0.294, "segm_APl": 0.351, "segm_APr": 0.096, "segm_APc": 0.21, "segm_APf": 0.278, 
 "segm_mAP_copypaste": "AP:0.217 AP50:0.343 AP75:0.230 APs:0.152 APm:0.294 APl:0.351 APr:0.096 APc:0.210 APf:0.278"}
```