### PR TITLE
[Enhance] Make the parameters of get_model_complexity_info() friendly

### DIFF
--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -3,7 +3,6 @@
 # Modified from
 # https://github.com/facebookresearch/fvcore/blob/main/fvcore/nn/print_model_statistics.py
 
-import warnings
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
@@ -697,12 +696,10 @@ def get_model_complexity_info(
     Returns:
         dict: The complexity information of the model.
     """
-    assert (input_shape is not None) or (
-        inputs
-        is not None), '"input_shape" and "inputs" cannot both be "None".'
-    if (input_shape is not None) and (inputs is not None):
-        warnings.warn('Both "input_shape" and "inputs" are provided.\
-            "inputs" will be used.')
+    if input_shape is None and inputs is None:
+        raise ValueError('One of "input_shape" and "inputs" should be set.')
+    elif input_shape is not None and inputs is not None:
+        raise ValueError('"input_shape" and "inputs" cannot be both set.')
 
     if inputs is None:
         inputs = (torch.randn(1, *input_shape), )

--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -3,6 +3,7 @@
 # Modified from
 # https://github.com/facebookresearch/fvcore/blob/main/fvcore/nn/print_model_statistics.py
 
+import warnings
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
@@ -675,7 +676,7 @@ def complexity_stats_table(
 
 def get_model_complexity_info(
     model: nn.Module,
-    input_shape: tuple,
+    input_shape: tuple = None,
     inputs: Optional[torch.Tensor] = None,
     show_table: bool = True,
     show_arch: bool = True,
@@ -696,6 +697,13 @@ def get_model_complexity_info(
     Returns:
         dict: The complexity information of the model.
     """
+    assert (input_shape is not None) or (
+        inputs
+        is not None), '"input_shape" and "inputs" cannot both be "None".'
+    if (input_shape is not None) and (inputs is not None):
+        warnings.warn('Both "input_shape" and "inputs" are provided.\
+            "inputs" will be used.')
+
     if inputs is None:
         inputs = (torch.randn(1, *input_shape), )
 


### PR DESCRIPTION
## Motivation

Optimize the flexibility of function `get_model_complexity_info()`. #1055

## Modification

1. Set default value of `input_shape` to `None`.
2. `assert` does not allow both `input_shape` and `inputs` are `None`.
3. If both `input_shape` and `inputs` are provided, print a warning.

## BC-breaking (Optional)

It the downstream repo calls the function `get_model_complexity_info()` like [this line](https://github.com/open-mmlab/mmdetection/blob/ecac3a77becc63f23d9f6980b2a36f86acd00a8a/tools/analysis_tools/get_flops.py#L99) (It seems that the downstream repos have to call this function like the linked line.), not change has to be performed on the existing repos to fit this modification. 

## Use cases (Optional)

Not applicable.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
