### PR TITLE
[Enhance] Complement type hint of get_model_complexity_info()

### DIFF
--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -675,7 +675,7 @@ def complexity_stats_table(
 
 def get_model_complexity_info(
     model: nn.Module,
-    input_shape: tuple = None,
+    input_shape: Optional[tuple] = None,
     inputs: Union[torch.Tensor, Tuple[torch.Tensor, ...], None] = None,
     show_table: bool = True,
     show_arch: bool = True,
@@ -684,10 +684,13 @@ def get_model_complexity_info(
 
     Args:
         model (nn.Module): The model to analyze.
-        input_shape (tuple): The input shape of the model.
-        inputs (Union[torch.Tensor, tuple[torch.Tensor, ...], None]):\
+        input_shape (tuple, optional): The input shape of the model.
+            If inputs is not specified, the input_shape should be set.
+            Defaults to None.
+        inputs (torch.Tensor or tuple[torch.Tensor, ...], optional]):
             The input tensor(s) of the model. If not given the input tensor
             will be generated automatically with the given input_shape.
+            Defaults to None.
         show_table (bool): Whether to show the complexity table.
             Defaults to True.
         show_arch (bool): Whether to show the complexity arch.

--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -4,7 +4,7 @@
 # https://github.com/facebookresearch/fvcore/blob/main/fvcore/nn/print_model_statistics.py
 
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import torch
 from rich import box
@@ -676,7 +676,7 @@ def complexity_stats_table(
 def get_model_complexity_info(
     model: nn.Module,
     input_shape: tuple = None,
-    inputs: Optional[torch.Tensor] = None,
+    inputs: Union[torch.Tensor, Tuple[torch.Tensor, ...], None] = None,
     show_table: bool = True,
     show_arch: bool = True,
 ):
@@ -685,9 +685,9 @@ def get_model_complexity_info(
     Args:
         model (nn.Module): The model to analyze.
         input_shape (tuple): The input shape of the model.
-        inputs (torch.Tensor, optional): The input tensor of the model.
-            If not given the input tensor will be generated automatically
-            with the given input_shape.
+        inputs (Union[torch.Tensor, tuple[torch.Tensor, ...], None]):\
+            The input tensor(s) of the model. If not given the input tensor
+            will be generated automatically with the given input_shape.
         show_table (bool): Whether to show the complexity table.
             Defaults to True.
         show_arch (bool): Whether to show the complexity arch.


### PR DESCRIPTION
The type of `inputs` should be one of `torch.Tensor`, `tuple[torch.Tensor, ...]` and `None`.

## Motivation

The type hint of arg `inputs` in `get_model_complexity_info()` should match `class FlopAnalyzer` 
https://github.com/open-mmlab/mmengine/blob/5e1ed7aaf0166f3913c84bef830456cd25c4a497/mmengine/analysis/complexity_analysis.py#L121
and `class ActivationAnalyzer`,
https://github.com/open-mmlab/mmengine/blob/5e1ed7aaf0166f3913c84bef830456cd25c4a497/mmengine/analysis/complexity_analysis.py#L192
since the argument `inputs` is finally fed into these two classes.

Otherwise, a user may be confused about what if a custom model requires more than one tensors as inputs.

## Modification

Change current type hint of `inputs` in `get_model_complexity_info()` from 

```python
Optional[torch.Tensor]
```

to

```python
Union[torch.Tensor, Tuple[torch.Tensor, ...], None]
```

## BC-breaking (Optional)

Not applicable.

## Use cases (Optional)

Not applicable.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
