### PR TITLE
[Feature] `input_shape` of `get_model_complexity_info()` for multiple tensors

### DIFF
--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -694,11 +694,11 @@ def get_model_complexity_info(
 
     Examples:
         >>> # the forward of model accepts only one input
-        >>> input_shapes = (3, 224, 224)
-        >>> get_model_complexity_info(model, input_shapes)
+        >>> input_shape = (3, 224, 224)
+        >>> get_model_complexity_info(model, input_shape=input_shape)
         >>> # the forward of model accepts two or more inputs
-        >>> input_shapes = ((3, 224, 224), (3, 10))
-        >>> get_model_complexity_info(model, input_shapes)
+        >>> input_shape = ((3, 224, 224), (3, 10))
+        >>> get_model_complexity_info(model, input_shape=input_shape)
 
     Args:
         model (nn.Module): The model to analyze.

--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -677,7 +677,8 @@ def complexity_stats_table(
 def get_model_complexity_info(
     model: nn.Module,
     input_shape: Union[Tuple[int, ...], Tuple[Tuple[int, ...]], None] = None,
-    inputs: Union[torch.Tensor, Tuple[torch.Tensor, ...], None] = None,
+    inputs: Union[torch.Tensor, Tuple[torch.Tensor, ...], Tuple[Any, ...],
+                  None] = None,
     show_table: bool = True,
     show_arch: bool = True,
 ):
@@ -707,7 +708,8 @@ def get_model_complexity_info(
             The input shape of the model.
             If "inputs" is not specified, the "input_shape" should be set.
             Defaults to None.
-        inputs (torch.Tensor or tuple[torch.Tensor, ...], optional]):
+        inputs (torch.Tensor, tuple[torch.Tensor, ...] or Tuple[Any, ...],\
+            optional]):
             The input tensor(s) of the model. If not given the input tensor
             will be generated automatically with the given input_shape.
             Defaults to None.

--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -683,18 +683,29 @@ def get_model_complexity_info(
 ):
     """Interface to get the complexity of a model.
 
+    The parameter `inputs` are fed to the forward method of model.
+    If `input` is not specified, the `input_shape` is required and
+    it will be used to construct the dummy input fed to model.
+    If the forward of model requires two or more inputs, the `inputs`
+    should be a tuple of tensor or the `input_shape` should be a tuple
+    of tuple which each element will be constructed into a dumpy input.
+
+    Examples:
+        >>> # the forward of model accepts only one input
+        >>> input_shapes = (3, 224, 224)
+        >>> # the following tuple of one tensor will be constructed
+        >>> inputs = tuple(torch.randn(1, 3, 224, 224),)
+        >>>
+        >>> # the forward of model accepts two or more inputs
+        >>> input_shapes = ((3, 224, 224), (3, 10))
+        >>> # the following tuple of tensors will be constructed
+        >>> inputs = tuple(torch.randn(1, 3, 224, 224), torch.randn(1, 3, 10))
+
     Args:
         model (nn.Module): The model to analyze.
         input_shape (Union[Tuple[int, ...], Tuple[Tuple[int, ...]], None]):
             The input shape of the model.
             If "inputs" is not specified, the "input_shape" should be set.
-            If the input_shape is a "tuple of int", one tensor will be
-            constructed. If the input_shape is a "tuple of tuple of int",
-            multiple tensors will be constructed. For example, assume
-                >>> input_shape = ((5,6), (7,8))
-            a "inputs" tuple consists of two tensors
-                >>> inputs = (torch.randn(1, 5, 6), torch.randn(1, 7, 8))
-            will be constructed and fed into the model.
             Defaults to None.
         inputs (torch.Tensor or tuple[torch.Tensor, ...], optional]):
             The input tensor(s) of the model. If not given the input tensor

--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -732,11 +732,11 @@ def get_model_complexity_info(
             inputs = (torch.randn(1, *input_shape), )
         elif is_tuple_of(input_shape, tuple) and all([
                 is_tuple_of(one_input_shape, int)
-                for one_input_shape in input_shape
+                for one_input_shape in input_shape  # type: ignore
         ]):  # tuple of tuple of int, construct multiple tensors
             inputs = tuple([
                 torch.randn(1, *one_input_shape)
-                for one_input_shape in input_shape
+                for one_input_shape in input_shape  # type: ignore
             ])
         else:
             raise ValueError(

--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from rich.table import Table
 from torch import nn
 
+from ..utils import is_tuple_of
 from .complexity_analysis import (ActivationAnalyzer, FlopAnalyzer,
                                   parameter_count)
 
@@ -713,14 +714,12 @@ def get_model_complexity_info(
         raise ValueError('"input_shape" and "inputs" cannot be both set.')
 
     if inputs is None:
-        if isinstance(input_shape, tuple) and all(
-                isinstance(item, int)
-                for item in input_shape):  # tuple of int, construct one tensor
+        if is_tuple_of(input_shape, int):  # tuple of int, construct one tensor
             inputs = (torch.randn(1, *input_shape), )
-        elif isinstance(input_shape, tuple) and all(
-                isinstance(item, tuple) and all(
-                    isinstance(i, int) for i in item) for item in input_shape
-        ):  # tuple of tuple of int, construct multiple tensors
+        elif is_tuple_of(input_shape, tuple) and all([
+                is_tuple_of(one_input_shape, int)
+                for one_input_shape in input_shape
+        ]):  # tuple of tuple of int, construct multiple tensors
             inputs = tuple([
                 torch.randn(1, *one_input_shape)
                 for one_input_shape in input_shape

--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -727,9 +727,9 @@ def get_model_complexity_info(
             ])
         else:
             raise ValueError(
-                '"input_shape" should be either a `tuple of int` (to construct\
-                one input tensor) or a `tuple of tuple of int` (to construct\
-                multiple input tensors).')
+                '"input_shape" should be either a `tuple of int` (to construct'
+                'one input tensor) or a `tuple of tuple of int` (to construct'
+                'multiple input tensors).')
 
     flop_handler = FlopAnalyzer(model, inputs)
     activation_handler = ActivationAnalyzer(model, inputs)

--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -676,7 +676,8 @@ def complexity_stats_table(
 
 def get_model_complexity_info(
     model: nn.Module,
-    input_shape: Union[Tuple[int, ...], Tuple[Tuple[int, ...]], None] = None,
+    input_shape: Union[Tuple[int, ...], Tuple[Tuple[int, ...], ...],
+                       None] = None,
     inputs: Union[torch.Tensor, Tuple[torch.Tensor, ...], Tuple[Any, ...],
                   None] = None,
     show_table: bool = True,

--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -686,7 +686,7 @@ def get_model_complexity_info(
     """Interface to get the complexity of a model.
 
     The parameter `inputs` are fed to the forward method of model.
-    If `input` is not specified, the `input_shape` is required and
+    If `inputs` is not specified, the `input_shape` is required and
     it will be used to construct the dummy input fed to model.
     If the forward of model requires two or more inputs, the `inputs`
     should be a tuple of tensor or the `input_shape` should be a tuple
@@ -695,13 +695,10 @@ def get_model_complexity_info(
     Examples:
         >>> # the forward of model accepts only one input
         >>> input_shapes = (3, 224, 224)
-        >>> # the following tuple of one tensor will be constructed
-        >>> inputs = tuple(torch.randn(1, 3, 224, 224),)
-        >>>
+        >>> get_model_complexity_info(model, input_shapes)
         >>> # the forward of model accepts two or more inputs
         >>> input_shapes = ((3, 224, 224), (3, 10))
-        >>> # the following tuple of tensors will be constructed
-        >>> inputs = tuple(torch.randn(1, 3, 224, 224), torch.randn(1, 3, 10))
+        >>> get_model_complexity_info(model, input_shapes)
 
     Args:
         model (nn.Module): The model to analyze.

--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -12,7 +12,7 @@ from rich.console import Console
 from rich.table import Table
 from torch import nn
 
-from ..utils import is_tuple_of
+from mmengine.utils import is_tuple_of
 from .complexity_analysis import (ActivationAnalyzer, FlopAnalyzer,
                                   parameter_count)
 

--- a/tests/test_analysis/test_print_helper.py
+++ b/tests/test_analysis/test_print_helper.py
@@ -51,7 +51,7 @@ def test_get_model_complexity_info():
     input2 = torch.randn(1, 9, 7)
     input_shape2 = (9, 7)
     scalar = 0.3
-    
+
     # test a network that accepts one tensor as input
     model = NetAcceptOneTensor()
     complexity_info = get_model_complexity_info(model=model, inputs=input1)
@@ -59,37 +59,37 @@ def test_get_model_complexity_info():
     params = parameter_count(model=model)['']
     assert complexity_info['flops'] == flops
     assert complexity_info['params'] == params
-    
-    complexity_info = get_model_complexity_info(model=model,
-                                                input_shap=input_shape1)
-    flops = FlopAnalyzer(model=model,
-                         inputs=(torch.randn(1, *input_shape), )).total()
+
+    complexity_info = get_model_complexity_info(
+        model=model, input_shape=input_shape1)
+    flops = FlopAnalyzer(
+        model=model, inputs=(torch.randn(1, *input_shape1), )).total()
     assert complexity_info['flops'] == flops
 
     # test a network that accepts two tensors as input
     model = NetAcceptTwoTensors()
-    complexity_info = get_model_complexity_info(model=model,
-                                                inputs=(input1, input2))
-    flops = FlopAnalyzer(model=model,
-                         inputs=(input1, input2)).total()
+    complexity_info = get_model_complexity_info(
+        model=model, inputs=(input1, input2))
+    flops = FlopAnalyzer(model=model, inputs=(input1, input2)).total()
     params = parameter_count(model=model)['']
     assert complexity_info['flops'] == flops
     assert complexity_info['params'] == params
-    
+
     complexity_info = get_model_complexity_info(
         model=model, input_shape=(input_shape1, input_shape2))
     inputs = (torch.randn(1, *input_shape1), torch.randn(1, *input_shape2))
     flops = FlopAnalyzer(model=model, inputs=inputs).total()
     assert complexity_info['flops'] == flops
-    
+
     # test a network that accepts one tensor and one scalar as input
     model = NetAcceptOneTensorAndOneScalar()
     # For pytorch<1.9, a scalar input is not acceptable for torch.jit,
     # wrap it to `torch.tensor`. See https://github.com/pytorch/pytorch/blob/cd9dd653e98534b5d3a9f2576df2feda40916f1d/torch/csrc/jit/python/python_arg_flatten.cpp#L90. # noqa: E501
-    scalar = torch.tensor([scalar]) if digit_version(
-        TORCH_VERSION) < digit_version('1.9.0') else scalar
-    complexity_info = get_model_complexity_info(model=model,
-                                                inputs=(input1, scalar))
+    scalar = torch.tensor([
+        scalar
+    ]) if digit_version(TORCH_VERSION) < digit_version('1.9.0') else scalar
+    complexity_info = get_model_complexity_info(
+        model=model, inputs=(input1, scalar))
     flops = FlopAnalyzer(model=model, inputs=(input1, scalar)).total()
     params = parameter_count(model=model)['']
     assert complexity_info['flops'] == flops
@@ -99,9 +99,10 @@ def test_get_model_complexity_info():
     # when neithor `inputs` nor `input_shape` is specified
     with pytest.raises(ValueError, match='should be set'):
         get_model_complexity_info(model)
-    
+
     # `get_model_complexity_info()` should throw `ValueError`
     # when both `inputs` and `input_shape` are specified
     model = NetAcceptOneTensor()
     with pytest.raises(ValueError, match='cannot be both set'):
-        get_model_complexity_info(model, inputs=input1, input_shape=input_shapes)
+        get_model_complexity_info(
+            model, inputs=input1, input_shape=input_shape1)

--- a/tests/test_analysis/test_print_helper.py
+++ b/tests/test_analysis/test_print_helper.py
@@ -1,0 +1,136 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import unittest
+
+import torch
+import torch.nn as nn
+
+from mmengine.analysis.complexity_analysis import FlopAnalyzer, parameter_count
+from mmengine.analysis.print_helper import get_model_complexity_info
+
+
+class NetAcceptOneTensor(nn.Module):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.l1 = nn.Linear(in_features=5, out_features=6)
+
+    def forward(self, x) -> None:
+        out = self.l1(x)
+        return out
+
+
+class NetAcceptTwoTensors(nn.Module):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.l1 = nn.Linear(in_features=5, out_features=6)
+        self.l2 = nn.Linear(in_features=7, out_features=6)
+
+    def forward(self, x1, x2) -> None:
+        out = self.l1(x1) + self.l2(x2)
+        return out
+
+
+class NetAcceptOneTensorNOneScalar(nn.Module):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.l1 = nn.Linear(in_features=5, out_features=6)
+        self.l2 = nn.Linear(in_features=5, out_features=6)
+
+    def forward(self, x1, r) -> None:
+        out = r * self.l1(x1) + (1 - r) * self.l2(x1)
+        return out
+
+
+class TestGetModelCompexityInfo(unittest.TestCase):
+    """Unittest for function get_model_complexity_info()
+
+    Test use cases of variant `input_shape` and `input` combinations.
+    """
+
+    def setUp(self) -> None:
+        """Create test elements (tensors, scalars, etc.) once for all."""
+        self.t1 = torch.randn(1, 9, 5)
+        self.shape1 = (9, 5)
+        self.t2 = torch.randn(1, 9, 7)
+        self.shape2 = (9, 7)
+        self.scalar = 0.3
+
+    def test_oneTensor(self) -> None:
+        """Test a network that accept one tensor as input."""
+        model = NetAcceptOneTensor()
+        input = self.t1
+        dict_complexity = get_model_complexity_info(model=model, inputs=input)
+        self.assertEqual(dict_complexity['flops'],
+                         FlopAnalyzer(model=model, inputs=input).total())
+        self.assertEqual(dict_complexity['params'],
+                         parameter_count(model=model)[''])
+
+    def test_oneShape(self) -> None:
+        """Test a network that accept one tensor as input."""
+        model = NetAcceptOneTensor()
+        input_shape = self.shape1
+        dict_complexity = get_model_complexity_info(
+            model=model, input_shape=input_shape)
+        self.assertEqual(
+            dict_complexity['flops'],
+            FlopAnalyzer(model=model,
+                         inputs=(torch.randn(1, *input_shape), )).total())
+        self.assertEqual(dict_complexity['params'],
+                         parameter_count(model=model)[''])
+
+    def test_twoTensors(self) -> None:
+        """Test a network that accept two tensors as input."""
+        model = NetAcceptTwoTensors()
+        input1 = self.t1
+        input2 = self.t2
+        dict_complexity = get_model_complexity_info(
+            model=model, inputs=(input1, input2))
+        self.assertEqual(
+            dict_complexity['flops'],
+            FlopAnalyzer(model=model, inputs=(input1, input2)).total())
+        self.assertEqual(dict_complexity['params'],
+                         parameter_count(model=model)[''])
+
+    def test_twoShapes(self) -> None:
+        """Test a network that accept two tensors as input."""
+        model = NetAcceptTwoTensors()
+        input_shape1 = self.shape1
+        input_shape2 = self.shape2
+        dict_complexity = get_model_complexity_info(
+            model=model, input_shape=(input_shape1, input_shape2))
+        self.assertEqual(
+            dict_complexity['flops'],
+            FlopAnalyzer(
+                model=model,
+                inputs=(torch.randn(1, *input_shape1),
+                        torch.randn(1, *input_shape2))).total())
+        self.assertEqual(dict_complexity['params'],
+                         parameter_count(model=model)[''])
+
+    def test_oneTensorNOneScalar(self) -> None:
+        """Test a network that accept one tensor and one scalar as input."""
+        model = NetAcceptOneTensorNOneScalar()
+        input = self.t1
+        scalar = self.scalar
+        dict_complexity = get_model_complexity_info(
+            model=model, inputs=(input, scalar))
+        self.assertEqual(
+            dict_complexity['flops'],
+            FlopAnalyzer(model=model, inputs=(input, scalar)).total())
+        self.assertEqual(dict_complexity['params'],
+                         parameter_count(model=model)[''])
+
+    def test_provideBothInputsNInputshape(self) -> None:
+        """The function `get_model_complexity_info()` should throw `ValueError`
+        when both `inputs` and `input_shape` are specified."""
+        model = NetAcceptOneTensor()
+        input = self.t1
+        input_shape = self.shape1
+        self.assertRaises(
+            ValueError,
+            get_model_complexity_info,
+            model=model,
+            inputs=input,
+            input_shape=input_shape)

--- a/tests/test_analysis/test_print_helper.py
+++ b/tests/test_analysis/test_print_helper.py
@@ -14,7 +14,7 @@ class NetAcceptOneTensor(nn.Module):
         super().__init__()
         self.l1 = nn.Linear(in_features=5, out_features=6)
 
-    def forward(self, x) -> None:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         out = self.l1(x)
         return out
 
@@ -26,7 +26,7 @@ class NetAcceptTwoTensors(nn.Module):
         self.l1 = nn.Linear(in_features=5, out_features=6)
         self.l2 = nn.Linear(in_features=7, out_features=6)
 
-    def forward(self, x1, x2) -> None:
+    def forward(self, x1: torch.Tensor, x2: torch.Tensor) -> torch.Tensor:
         out = self.l1(x1) + self.l2(x2)
         return out
 
@@ -38,7 +38,7 @@ class NetAcceptOneTensorNOneScalar(nn.Module):
         self.l1 = nn.Linear(in_features=5, out_features=6)
         self.l2 = nn.Linear(in_features=5, out_features=6)
 
-    def forward(self, x1, r) -> None:
+    def forward(self, x1: torch.Tensor, r) -> torch.Tensor:
         out = r * self.l1(x1) + (1 - r) * self.l2(x1)
         return out
 

--- a/tests/test_analysis/test_print_helper.py
+++ b/tests/test_analysis/test_print_helper.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import unittest
 
+import pytest
 import torch
 import torch.nn as nn
 
@@ -45,103 +45,63 @@ class NetAcceptOneTensorAndOneScalar(nn.Module):
         return out
 
 
-class TestGetModelCompexityInfo(unittest.TestCase):
-    """Unittest for function get_model_complexity_info()
+def test_get_model_complexity_info():
+    input1 = torch.randn(1, 9, 5)
+    input_shape1 = (9, 5)
+    input2 = torch.randn(1, 9, 7)
+    input_shape2 = (9, 7)
+    scalar = 0.3
+    
+    # test a network that accepts one tensor as input
+    model = NetAcceptOneTensor()
+    complexity_info = get_model_complexity_info(model=model, inputs=input1)
+    flops = FlopAnalyzer(model=model, inputs=input1).total()
+    params = parameter_count(model=model)['']
+    assert complexity_info['flops'] == flops
+    assert complexity_info['params'] == params
+    
+    complexity_info = get_model_complexity_info(model=model,
+                                                input_shap=input_shape1)
+    flops = FlopAnalyzer(model=model,
+                         inputs=(torch.randn(1, *input_shape), )).total()
+    assert complexity_info['flops'] == flops
 
-    Test use cases of variant `input_shape` and `input` combinations.
-    """
+    # test a network that accepts two tensors as input
+    model = NetAcceptTwoTensors()
+    complexity_info = get_model_complexity_info(model=model,
+                                                inputs=(input1, input2))
+    flops = FlopAnalyzer(model=model,
+                         inputs=(input1, input2)).total()
+    params = parameter_count(model=model)['']
+    assert complexity_info['flops'] == flops
+    assert complexity_info['params'] == params
+    
+    complexity_info = get_model_complexity_info(
+        model=model, input_shape=(input_shape1, input_shape2))
+    inputs = (torch.randn(1, *input_shape1), torch.randn(1, *input_shape2))
+    flops = FlopAnalyzer(model=model, inputs=inputs).total()
+    assert complexity_info['flops'] == flops
+    
+    # test a network that accepts one tensor and one scalar as input
+    model = NetAcceptOneTensorAndOneScalar()
+    # For pytorch<1.9, a scalar input is not acceptable for torch.jit,
+    # wrap it to `torch.tensor`. See https://github.com/pytorch/pytorch/blob/cd9dd653e98534b5d3a9f2576df2feda40916f1d/torch/csrc/jit/python/python_arg_flatten.cpp#L90. # noqa: E501
+    scalar = torch.tensor([scalar]) if digit_version(
+        TORCH_VERSION) < digit_version('1.9.0') else scalar
+    complexity_info = get_model_complexity_info(model=model,
+                                                inputs=(input1, scalar))
+    flops = FlopAnalyzer(model=model, inputs=(input1, scalar)).total()
+    params = parameter_count(model=model)['']
+    assert complexity_info['flops'] == flops
+    assert complexity_info['params'] == params
 
-    def setUp(self) -> None:
-        """Create test elements (tensors, scalars, etc.) once for all."""
-        self.t1 = torch.randn(1, 9, 5)
-        self.shape1 = (9, 5)
-        self.t2 = torch.randn(1, 9, 7)
-        self.shape2 = (9, 7)
-        self.scalar = 0.3
-
-    def test_oneTensor(self) -> None:
-        """Test a network that accept one tensor as input."""
-        model = NetAcceptOneTensor()
-        input = self.t1
-        dict_complexity = get_model_complexity_info(model=model, inputs=input)
-        self.assertEqual(dict_complexity['flops'],
-                         FlopAnalyzer(model=model, inputs=input).total())
-        self.assertEqual(dict_complexity['params'],
-                         parameter_count(model=model)[''])
-
-    def test_oneShape(self) -> None:
-        """Test a network that accept one tensor as input."""
-        model = NetAcceptOneTensor()
-        input_shape = self.shape1
-        dict_complexity = get_model_complexity_info(
-            model=model, input_shape=input_shape)
-        self.assertEqual(
-            dict_complexity['flops'],
-            FlopAnalyzer(model=model,
-                         inputs=(torch.randn(1, *input_shape), )).total())
-        self.assertEqual(dict_complexity['params'],
-                         parameter_count(model=model)[''])
-
-    def test_twoTensors(self) -> None:
-        """Test a network that accept two tensors as input."""
-        model = NetAcceptTwoTensors()
-        input1 = self.t1
-        input2 = self.t2
-        dict_complexity = get_model_complexity_info(
-            model=model, inputs=(input1, input2))
-        self.assertEqual(
-            dict_complexity['flops'],
-            FlopAnalyzer(model=model, inputs=(input1, input2)).total())
-        self.assertEqual(dict_complexity['params'],
-                         parameter_count(model=model)[''])
-
-    def test_twoShapes(self) -> None:
-        """Test a network that accept two tensors as input."""
-        model = NetAcceptTwoTensors()
-        input_shape1 = self.shape1
-        input_shape2 = self.shape2
-        dict_complexity = get_model_complexity_info(
-            model=model, input_shape=(input_shape1, input_shape2))
-        self.assertEqual(
-            dict_complexity['flops'],
-            FlopAnalyzer(
-                model=model,
-                inputs=(torch.randn(1, *input_shape1),
-                        torch.randn(1, *input_shape2))).total())
-        self.assertEqual(dict_complexity['params'],
-                         parameter_count(model=model)[''])
-
-    def test_oneTensorNOneScalar(self) -> None:
-        """Test a network that accept one tensor and one scalar as input."""
-        model = NetAcceptOneTensorAndOneScalar()
-        input = self.t1
-        # For pytorch<1.9, a scalar input is not acceptable for torch.jit,
-        # wrap it to `torch.tensor`. See https://github.com/pytorch/pytorch/blob/cd9dd653e98534b5d3a9f2576df2feda40916f1d/torch/csrc/jit/python/python_arg_flatten.cpp#L90. # noqa: E501
-        scalar = torch.tensor([self.scalar]) if digit_version(
-            TORCH_VERSION) < digit_version('1.9.0') else self.scalar
-        dict_complexity = get_model_complexity_info(
-            model=model, inputs=(input, scalar))
-        self.assertEqual(
-            dict_complexity['flops'],
-            FlopAnalyzer(model=model, inputs=(input, scalar)).total())
-        self.assertEqual(dict_complexity['params'],
-                         parameter_count(model=model)[''])
-
-    def test_provideBothInputsNInputshape(self) -> None:
-        """The function `get_model_complexity_info()` should throw `ValueError`
-        when both `inputs` and `input_shape` are specified."""
-        model = NetAcceptOneTensor()
-        input = self.t1
-        input_shape = self.shape1
-        self.assertRaises(
-            ValueError,
-            get_model_complexity_info,
-            model=model,
-            inputs=input,
-            input_shape=input_shape)
-
-    def test_provideNoneOfInputsNInputshape(self) -> None:
-        """The function `get_model_complexity_info()` should throw `ValueError`
-        when neithor `inputs` nor `input_shape` is specified."""
-        model = NetAcceptOneTensor()
-        self.assertRaises(ValueError, get_model_complexity_info, model=model)
+    # `get_model_complexity_info()` should throw `ValueError`
+    # when neithor `inputs` nor `input_shape` is specified
+    with pytest.raises(ValueError, match='should be set'):
+        get_model_complexity_info(model)
+    
+    # `get_model_complexity_info()` should throw `ValueError`
+    # when both `inputs` and `input_shape` are specified
+    model = NetAcceptOneTensor()
+    with pytest.raises(ValueError, match='cannot be both set'):
+        get_model_complexity_info(model, inputs=input1, input_shape=input_shapes)

--- a/tests/test_analysis/test_print_helper.py
+++ b/tests/test_analysis/test_print_helper.py
@@ -33,7 +33,7 @@ class NetAcceptTwoTensors(nn.Module):
         return out
 
 
-class NetAcceptOneTensorNOneScalar(nn.Module):
+class NetAcceptOneTensorAndOneScalar(nn.Module):
 
     def __init__(self) -> None:
         super().__init__()
@@ -113,7 +113,7 @@ class TestGetModelCompexityInfo(unittest.TestCase):
 
     def test_oneTensorNOneScalar(self) -> None:
         """Test a network that accept one tensor and one scalar as input."""
-        model = NetAcceptOneTensorNOneScalar()
+        model = NetAcceptOneTensorAndOneScalar()
         input = self.t1
         # For pytorch<1.9, a scalar input is not acceptable for torch.jit,
         # wrap it to `torch.tensor`. See https://github.com/pytorch/pytorch/blob/cd9dd653e98534b5d3a9f2576df2feda40916f1d/torch/csrc/jit/python/python_arg_flatten.cpp#L90. # noqa: E501

--- a/tests/test_analysis/test_print_helper.py
+++ b/tests/test_analysis/test_print_helper.py
@@ -134,3 +134,9 @@ class TestGetModelCompexityInfo(unittest.TestCase):
             model=model,
             inputs=input,
             input_shape=input_shape)
+
+    def test_provideNoneOfInputsNInputshape(self) -> None:
+        """The function `get_model_complexity_info()` should throw `ValueError`
+        when neithor `inputs` nor `input_shape` is specified."""
+        model = NetAcceptOneTensor()
+        self.assertRaises(ValueError, get_model_complexity_info, model=model)


### PR DESCRIPTION
## Motivation

Previously, the arg `input_shape` of get_model_complexity_info() is used to construct only one input tensor.
https://github.com/open-mmlab/mmengine/blob/5da24ed1021c7ebd17a5d7c89999089f15a5d4cf/mmengine/analysis/print_helper.py#L707-L708
It is inconvenient if a custom model requires more than one inputs. Such as

```python
class mymodel(nn.Module):
    def __init__(self) -> None:
        super().__init__()
        self.l1=nn.Linear(in_features=5,out_features=6)
        self.l2=nn.Linear(in_features=7,out_features=6)
        
    def forward(self, x1, x2):
        out=self.l1(x1)+self.l2(x2)
        return out
```

This PR add support of using `input_shape` to construct multiple input tensors.

## Modification

If `inputs` is `None`, check `input_shape`. 
If `input_shape` is a tuple of int, one input tensor will be constructed as before.
If `input_shape` is a tuple of tuple of int, multiple input tensors will be constructed. For example,

```python
input_shape = ((5,6), (7,8))
```
a tuple of tensors

```python
inputs = (torch.randn(1, 5, 6), torch.randn(1, 7, 8))
```

will be constructed and fed into the model.

## BC-breaking (Optional)

For better literacy of the code, I would also like to change the variable name from `input_shape` to `input_shapes` (this change has not been applied yet), since it now supports multiple tensors. But this definitely requires modification of some downstream repos. 
Thus, I require discussion with reviewers about this.

## Use cases (Optional)

Below is a code snippet that utilized the added feature.

```python
import torch
import torch.nn as nn
from mmengine.analysis import get_model_complexity_info

class mymodel(nn.Module):
    def __init__(self) -> None:
        super().__init__()
        self.l1=nn.Linear(in_features=5,out_features=6)
        self.l2=nn.Linear(in_features=7,out_features=6)
        
    def forward(self, x1, x2):
        out=self.l1(x1)+self.l2(x2)
        return out

def main():
    model=mymodel()
    complexity=get_model_complexity_info(model=model, input_shape=((66,5), (66,7))) # two tuples of int to construct to tensors
    print(complexity['flops'])
    print(complexity['params'])

if __name__=="__main__":
    main()
```

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
