### PR TITLE
[Feature] add auto_step flag in WandbVisBackend

### DIFF
--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -371,8 +371,9 @@ class WandbVisBackend(BaseVisBackend):
         auto_step: (bool) Whether use auto step increment built-in
             ``wandb.log`` or not. The built-in step will be reset to zero when
             the training is resumed. Default: True
-            Note that if you set False, you also should set
-            ``log_metric_by_epoch=False`` in the LoggerHook.
+
+    Note:
+        If ``auto_step`` is False, ``log_metric_by_epoch`` in :cls:`mmengine.hook.LoggerHook` needs to be set to ``False`` too.
     """
 
     def __init__(self,

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -372,10 +372,6 @@ class WandbVisBackend(BaseVisBackend):
             ``wandb.log`` or not. The built-in step will be reset to zero when
             the training is resumed. Default: True
             New in version 0.7.3
-
-    Note:
-        If ``auto_step`` is False, ``log_metric_by_epoch`` in
-        :cls:`mmengine.hook.LoggerHook` needs to be set to ``False`` too.
     """
 
     def __init__(self,
@@ -393,6 +389,7 @@ class WandbVisBackend(BaseVisBackend):
         self._log_code_name = log_code_name
         self._watch_kwargs = watch_kwargs if watch_kwargs is not None else {}
         self._auto_step = auto_step
+        self._last_step = 0
 
     def _init_env(self):
         """Setup env for wandb."""
@@ -465,6 +462,9 @@ class WandbVisBackend(BaseVisBackend):
         if self._auto_step:
             self._wandb.log({name: image}, commit=self._commit)
         else:
+            if self._last_step > step:
+                step = self._last_step + 1
+            self._last_step = step
             self._wandb.log({name: image}, commit=self._commit, step=step)
 
     @force_init_env
@@ -484,6 +484,9 @@ class WandbVisBackend(BaseVisBackend):
         if self._auto_step:
             self._wandb.log({name: value}, commit=self._commit)
         else:
+            if self._last_step > step:
+                step = self._last_step + 1
+            self._last_step = step
             self._wandb.log({name: value}, commit=self._commit, step=step)
 
     @force_init_env
@@ -505,6 +508,9 @@ class WandbVisBackend(BaseVisBackend):
         if self._auto_step:
             self._wandb.log(scalar_dict, commit=self._commit)
         else:
+            if self._last_step > step:
+                step = self._last_step + 1
+            self._last_step = step
             self._wandb.log(scalar_dict, commit=self._commit, step=step)
 
     def close(self) -> None:

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -368,8 +368,8 @@ class WandbVisBackend(BaseVisBackend):
             New in version 0.3.0.
         watch_kwargs (optional, dict): Agurments for ``wandb.watch``.
             New in version 0.4.0.
-        auto_step: (bool) Whether use auto step increment builtin
-            wandb.log or not. The built-in step will be reset to zero when
+        auto_step: (bool) Whether use auto step increment built-in
+            ``wandb.log`` or not. The built-in step will be reset to zero when
             the training is resumed. Default: True
     """
 

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -371,6 +371,8 @@ class WandbVisBackend(BaseVisBackend):
         auto_step: (bool) Whether use auto step increment built-in
             ``wandb.log`` or not. The built-in step will be reset to zero when
             the training is resumed. Default: True
+            Note that if you set False, you also should set
+            ``log_metric_by_epoch=False`` in the LoggerHook.
     """
 
     def __init__(self,

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -374,7 +374,8 @@ class WandbVisBackend(BaseVisBackend):
             New in version 0.7.3
 
     Note:
-        If ``auto_step`` is False, ``log_metric_by_epoch`` in :cls:`mmengine.hook.LoggerHook` needs to be set to ``False`` too.
+        If ``auto_step`` is False, ``log_metric_by_epoch`` in
+        :cls:`mmengine.hook.LoggerHook` needs to be set to ``False`` too.
     """
 
     def __init__(self,

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -368,9 +368,9 @@ class WandbVisBackend(BaseVisBackend):
             New in version 0.3.0.
         watch_kwargs (optional, dict): Agurments for ``wandb.watch``.
             New in version 0.4.0.
-        auto_step: (bool) Whether use auto step increment builtin wandb.log or not.
-            The built-in step will be reset to zero when the training is resumed.
-            Default: True
+        auto_step: (bool) Whether use auto step increment builtin
+            wandb.log or not. The built-in step will be reset to zero when
+            the training is resumed. Default: True
     """
 
     def __init__(self,
@@ -457,8 +457,10 @@ class WandbVisBackend(BaseVisBackend):
                 This will be ignored if auto_step is True.
         """
         image = self._wandb.Image(image)
-        step = None if self._auto_step else step
-        self._wandb.log({name: image}, commit=self._commit, step=step)
+        if self._auto_step:
+            self._wandb.log({name: image}, commit=self._commit)
+        else:
+            self._wandb.log({name: image}, commit=self._commit, step=step)
 
     @force_init_env
     def add_scalar(self,
@@ -474,8 +476,10 @@ class WandbVisBackend(BaseVisBackend):
             step (int): Global step value to record. Defaults to 0.
                 This will be ignored if auto_step is True.
         """
-        step = None if self._auto_step else step
-        self._wandb.log({name: value}, commit=self._commit, step=step)
+        if self._auto_step:
+            self._wandb.log({name: value}, commit=self._commit)
+        else:
+            self._wandb.log({name: value}, commit=self._commit, step=step)
 
     @force_init_env
     def add_scalars(self,
@@ -493,8 +497,10 @@ class WandbVisBackend(BaseVisBackend):
             file_path (str, optional): Useless parameter. Just for
                 interface unification. Defaults to None.
         """
-        step = None if self._auto_step else step
-        self._wandb.log(scalar_dict, commit=self._commit, step=step)
+        if self._auto_step:
+            self._wandb.log(scalar_dict, commit=self._commit)
+        else:
+            self._wandb.log(scalar_dict, commit=self._commit, step=step)
 
     def close(self) -> None:
         """close an opened wandb object."""

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -371,6 +371,7 @@ class WandbVisBackend(BaseVisBackend):
         auto_step: (bool) Whether use auto step increment built-in
             ``wandb.log`` or not. The built-in step will be reset to zero when
             the training is resumed. Default: True
+            New in version 0.7.3
 
     Note:
         If ``auto_step`` is False, ``log_metric_by_epoch`` in :cls:`mmengine.hook.LoggerHook` needs to be set to ``False`` too.

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -282,6 +282,25 @@ class TestWandbVisBackend:
         _, kwargs = wandb_vis_backend._wandb.log.call_args
         assert kwargs['step'] == expect
 
+        # auto_step == False and replace earlier step
+        wandb_vis_backend = WandbVisBackend('temp_dir', auto_step=False)
+        wandb_vis_backend.add_scalar('dummy', 0, step=10)
+
+        expect = 11
+        wandb_vis_backend.add_scalar(name, val, step=5)
+        _, kwargs = wandb_vis_backend._wandb.log.call_args
+        assert kwargs['step'] == expect
+
+        expect = 12
+        wandb_vis_backend.add_scalars(input_dict, step=5)
+        _, kwargs = wandb_vis_backend._wandb.log.call_args
+        assert kwargs['step'] == expect
+
+        expect = 13
+        wandb_vis_backend.add_image('img', image, step=5)
+        _, kwargs = wandb_vis_backend._wandb.log.call_args
+        assert kwargs['step'] == expect
+
         shutil.rmtree('temp_dir')
 
 

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -243,9 +243,8 @@ class TestWandbVisBackend:
         wandb_vis_backend.close()
         shutil.rmtree('temp_dir')
 
-    @pytest.mark.parametrize(
-        ["auto_step", "step", "expect"], [(True, 5, None), (False, 5, 5)]
-    )
+    @pytest.mark.parametrize(['auto_step', 'step', 'expect'], [(True, 5, None),
+                                                               (False, 5, 5)])
     def test_auto_step(self, auto_step, step, expect):
         # prepare data
         image = np.random.randint(0, 256, size=(10, 10, 3)).astype(np.uint8)
@@ -257,13 +256,13 @@ class TestWandbVisBackend:
         wandb_vis_backend = WandbVisBackend('temp_dir', auto_step=auto_step)
 
         wandb_vis_backend.add_scalar(name, val, step=step)
-        assert wandb_vis_backend._wandb.log.call_args[1]["step"] == expect
+        assert wandb_vis_backend._wandb.log.call_args[1]['step'] == expect
 
         wandb_vis_backend.add_scalars(input_dict, step=step)
-        assert wandb_vis_backend._wandb.log.call_args[1]["step"] == expect
+        assert wandb_vis_backend._wandb.log.call_args[1]['step'] == expect
 
         wandb_vis_backend.add_image('img', image, step=step)
-        assert wandb_vis_backend._wandb.log.call_args[1]["step"] == expect
+        assert wandb_vis_backend._wandb.log.call_args[1]['step'] == expect
 
         shutil.rmtree('temp_dir')
 

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -243,26 +243,44 @@ class TestWandbVisBackend:
         wandb_vis_backend.close()
         shutil.rmtree('temp_dir')
 
-    @pytest.mark.parametrize(['auto_step', 'step', 'expect'], [(True, 5, None),
-                                                               (False, 5, 5)])
-    def test_auto_step(self, auto_step, step, expect):
+    def test_auto_step(self):
         # prepare data
         image = np.random.randint(0, 256, size=(10, 10, 3)).astype(np.uint8)
         name = 'acc'
         val = 0.9
         input_dict = {name: val}
+        step = 5
 
-        # init
-        wandb_vis_backend = WandbVisBackend('temp_dir', auto_step=auto_step)
+        # auto_step == True
+        wandb_vis_backend = WandbVisBackend('temp_dir', auto_step=True)
 
         wandb_vis_backend.add_scalar(name, val, step=step)
-        assert wandb_vis_backend._wandb.log.call_args[1]['step'] == expect
+        _, kwargs = wandb_vis_backend._wandb.log.call_args
+        assert 'step' not in kwargs
 
         wandb_vis_backend.add_scalars(input_dict, step=step)
-        assert wandb_vis_backend._wandb.log.call_args[1]['step'] == expect
+        _, kwargs = wandb_vis_backend._wandb.log.call_args
+        assert 'step' not in kwargs
 
         wandb_vis_backend.add_image('img', image, step=step)
-        assert wandb_vis_backend._wandb.log.call_args[1]['step'] == expect
+        _, kwargs = wandb_vis_backend._wandb.log.call_args
+        assert 'step' not in kwargs
+
+        # auto_step == False
+        expect = 5
+        wandb_vis_backend = WandbVisBackend('temp_dir', auto_step=False)
+
+        wandb_vis_backend.add_scalar(name, val, step=step)
+        _, kwargs = wandb_vis_backend._wandb.log.call_args
+        assert kwargs['step'] == expect
+
+        wandb_vis_backend.add_scalars(input_dict, step=step)
+        _, kwargs = wandb_vis_backend._wandb.log.call_args
+        assert kwargs['step'] == expect
+
+        wandb_vis_backend.add_image('img', image, step=step)
+        _, kwargs = wandb_vis_backend._wandb.log.call_args
+        assert kwargs['step'] == expect
 
         shutil.rmtree('temp_dir')
 

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -243,6 +243,30 @@ class TestWandbVisBackend:
         wandb_vis_backend.close()
         shutil.rmtree('temp_dir')
 
+    @pytest.mark.parametrize(
+        ["auto_step", "step", "expect"], [(True, 5, None), (False, 5, 5)]
+    )
+    def test_auto_step(self, auto_step, step, expect):
+        # prepare data
+        image = np.random.randint(0, 256, size=(10, 10, 3)).astype(np.uint8)
+        name = 'acc'
+        val = 0.9
+        input_dict = {name: val}
+
+        # init
+        wandb_vis_backend = WandbVisBackend('temp_dir', auto_step=auto_step)
+
+        wandb_vis_backend.add_scalar(name, val, step=step)
+        assert wandb_vis_backend._wandb.log.call_args[1]["step"] == expect
+
+        wandb_vis_backend.add_scalars(input_dict, step=step)
+        assert wandb_vis_backend._wandb.log.call_args[1]["step"] == expect
+
+        wandb_vis_backend.add_image('img', image, step=step)
+        assert wandb_vis_backend._wandb.log.call_args[1]["step"] == expect
+
+        shutil.rmtree('temp_dir')
+
 
 class TestMLflowVisBackend:
 


### PR DESCRIPTION
## Motivation

The wandb backend uses a mechanism of the auto-increment built in the `wandb.log`.
But this step information will be reset to zero after the resumption.
So when I resume the training, I get the following discontinuous graph.

![resume_auto_step](https://user-images.githubusercontent.com/9190086/231368506-523378c7-fb5a-448b-af87-8688c93cd98e.png)

This behavior is a little confusing, I think the graphs should be continuous before and after the resumption.

![resume_manual_step](https://user-images.githubusercontent.com/9190086/231369571-1af9af80-858f-45ae-8689-b866516d1851.png)

## Modification

To fix this, I added an `auto_step` flag that allows the user to select the increment method.
- auto_step == True: Keep the current behavior (Default)
- auto_step == False: Use the step given by an argument. Note that other loggers also use this argument as the step.

## BC-breaking (Optional)

No. Default auto_step is set to True which is consistent with the current behavior.

## Use cases (Optional)

This makes wandb graph natural before and after the resumption (like the second image above).

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
