### PR TITLE
[Fix] Fix the resuming error caused by HistoryBuffer

### DIFF
--- a/examples/distributed_training.py
+++ b/examples/distributed_training.py
@@ -92,7 +92,6 @@ def main():
         val_dataloader=val_dataloader,
         val_cfg=dict(),
         val_evaluator=dict(type=Accuracy),
-        resume=True,
         launcher=args.launcher,
     )
     runner.train()

--- a/examples/distributed_training.py
+++ b/examples/distributed_training.py
@@ -92,6 +92,7 @@ def main():
         val_dataloader=val_dataloader,
         val_cfg=dict(),
         val_evaluator=dict(type=Accuracy),
+        resume=True,
         launcher=args.launcher,
     )
     runner.train()

--- a/mmengine/logging/history_buffer.py
+++ b/mmengine/logging/history_buffer.py
@@ -224,5 +224,6 @@ class HistoryBuffer:
             state (dict): State dict.
         """
         statistics_methods = state.pop('statistics_methods', {})
+        self._set_default_statistics()
         self._statistics_methods.update(statistics_methods)
         self.__dict__.update(state)

--- a/mmengine/logging/history_buffer.py
+++ b/mmengine/logging/history_buffer.py
@@ -207,3 +207,22 @@ class HistoryBuffer:
             raise ValueError('HistoryBuffer._log_history is an empty array! '
                              'please call update first')
         return self._log_history[-1]
+
+    def __getstate__(self) -> dict:
+        """Make ``_statistics_methods`` can be resumed.
+
+        Returns:
+            dict: State dict including statistics_methods.
+        """
+        self.__dict__.update(statistics_methods=self._statistics_methods)
+        return self.__dict__
+
+    def __setstate__(self, state):
+        """Try to load ``_statistics_methods`` from state.
+
+        Args:
+            state (dict): State dict.
+        """
+        statistics_methods = state.pop('statistics_methods', {})
+        self._statistics_methods.update(statistics_methods)
+        self.__dict__.update(state)

--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
 import datetime
+import re
 from collections import OrderedDict
 from itertools import chain
 from typing import List, Optional, Tuple
@@ -59,6 +60,9 @@ class LogProcessor:
             ``train/loss``, and accuracy will be saved as ``val/accuracy``.
             Defaults to False.
             `New in version 0.7.0.`
+        mean_pattern (str): This is a regular expression used to match the log
+            that need to be included in the smoothing statistics.
+            `New in version 0.7.3.`
 
     Examples:
         >>> # `log_name` is defined, `loss_large_window` will be an additional
@@ -106,12 +110,14 @@ class LogProcessor:
                  by_epoch=True,
                  custom_cfg: Optional[List[dict]] = None,
                  num_digits: int = 4,
-                 log_with_hierarchy: bool = False):
+                 log_with_hierarchy: bool = False,
+                 mean_pattern=r'.*(loss|time|data_time|grad_norm).*'):
         self.window_size = window_size
         self.by_epoch = by_epoch
         self.custom_cfg = custom_cfg if custom_cfg else []
         self.num_digits = num_digits
         self.log_with_hierarchy = log_with_hierarchy
+        self.mean_pattern = re.compile(mean_pattern)
         self._check_custom_cfg()
 
     def get_log_after_iter(self, runner, batch_idx: int,
@@ -280,14 +286,11 @@ class LogProcessor:
         # Count the averaged time and data_time by epoch
         if 'time' not in custom_keys:
             custom_cfg_copy.append(
-                dict(
-                    data_src=f'{mode}/time',
-                    window_size='epoch',
-                    method_name='mean'))
+                dict(data_src='time', window_size='epoch', method_name='mean'))
         if 'data_time' not in custom_keys:
             custom_cfg_copy.append(
                 dict(
-                    data_src=f'{mode}/data_time',
+                    data_src='data_time',
                     window_size='epoch',
                     method_name='mean'))
         parsed_cfg = self._parse_windows_size(runner, batch_idx,
@@ -357,18 +360,19 @@ class LogProcessor:
                 mode_history_scalars[key] = log_buffer
         for key in mode_history_scalars:
             # Update the latest learning rate and smoothed time logs.
-            if 'loss' in key or key in ('time', 'data_time', 'grad_norm'):
+            if re.search(self.mean_pattern, key) is not None:
                 tag[key] = mode_history_scalars[key].mean(self.window_size)
             else:
                 # Default statistic method is current.
                 tag[key] = mode_history_scalars[key].current()
         # Update custom keys.
         for log_cfg in custom_cfg:
-            data_src = log_cfg.pop('data_src')
-            if 'log_name' in log_cfg:
-                log_name = log_cfg.pop('log_name')
+            if not reserve_prefix:
+                data_src = log_cfg.pop('data_src')
+                log_name = f"{log_cfg.pop('log_name', data_src)}"
             else:
-                log_name = data_src
+                data_src = f"{mode}/{log_cfg.pop('data_src')}"
+                log_name = f"{mode}/{log_cfg.pop('log_name', data_src)}"
             # log item in custom_cfg could only exist in train or val
             # mode.
             if data_src in mode_history_scalars:

--- a/tests/test_logging/test_history_buffer.py
+++ b/tests/test_logging/test_history_buffer.py
@@ -13,6 +13,11 @@ else:
     array_method.append(torch.tensor)
 
 
+@HistoryBuffer.register_statistics
+def custom_statistics(self):
+    return -1
+
+
 class TestLoggerBuffer:
 
     def test_init(self):
@@ -112,10 +117,5 @@ class TestLoggerBuffer:
             log_buffer.statistics('unknown')
 
     def test_register_statistics(self):
-
-        @HistoryBuffer.register_statistics
-        def custom_statistics(self):
-            return -1
-
         log_buffer = HistoryBuffer()
         assert log_buffer.statistics('custom_statistics') == -1


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

After PR #972, `HistoryBuffer.statistics` will be called with the [custom_keys_copy](https://github.com/open-mmlab/mmengine/pull/972/files#diff-75746b50b571a33d63b68111136d0aa29ac6ac5d788aff12b02a7f329f640728R286). However, the class attributed [`HistoryBuffer._statistics_methods`](https://github.com/HAOCHENYE/mmengine/blob/d132e41a974f6f6e99ca6bdcb9eb56b7d9d2d653/mmengine/logging/history_buffer.py#L32) will not be dumped during saving the checkpoint.  It means the resumed `HistoryBuffer`s can not call the `statistic` methods since they have an empty `_statistic_methods`

This error can be trigger follow these steps:

1. set `log_with_hierarchy=True` for the `log_processor` and start training
2. Stop the training until the next checkpoint has been saved after the prior validation. At this time, All `HistoryBuffer`s including `val/time` and `val/data_time` will be dumped without `_statistics_methods`.
3. Resume the training. The `HistoryBuffer`s will be loaded without `_statistics_methods`.
4. During validation, the `HistoryBuffer` of `val/data_time` and `val/time` will call `statistics` method without `_statistics_methods`, and an error will be raised.

## Modification

1. Make `HistoryBuffer` Dump the `_statistics_methods`.
2. Refine the logic of `log_processor`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
5. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
6. The documentation has been modified accordingly, like docstring or example tutorials.
