### PR TITLE
[Enhance] Enhance error information in build function

### DIFF
--- a/mmengine/registry/build_functions.py
+++ b/mmengine/registry/build_functions.py
@@ -111,6 +111,9 @@ def build_from_cfg(
             raise TypeError(
                 f'type must be a str or valid type, but got {type(obj_type)}')
 
+        # If `obj_cls` inherits from `ManagerMixin`, it should be
+        # instantiated by `ManagerMixin.get_instance` to ensure that it
+        # can be accessed globally.
         if inspect.isclass(obj_cls) and \
                 issubclass(obj_cls, ManagerMixin):  # type: ignore
             obj = obj_cls.get_instance(**args)  # type: ignore

--- a/mmengine/registry/build_functions.py
+++ b/mmengine/registry/build_functions.py
@@ -182,23 +182,14 @@ def build_runner_from_cfg(cfg: Union[dict, ConfigDict, Config],
             raise TypeError(
                 f'type must be a str or valid type, but got {type(obj_type)}')
 
-        try:
-            runner = runner_cls.from_cfg(args)  # type: ignore
-            print_log(
-                f'An `{runner_cls.__name__}` instance is built from '  # type: ignore # noqa: E501
-                'registry, its implementation can be found in'
-                f'{runner_cls.__module__}',  # type: ignore
-                logger='current',
-                level=logging.DEBUG)
-            return runner
-
-        except Exception as e:
-            # Normal TypeError does not print class name.
-            cls_location = '/'.join(
-                runner_cls.__module__.split('.'))  # type: ignore
-            raise type(e)(
-                f'class `{runner_cls.__name__}` in '  # type: ignore
-                f'{cls_location}.py: {e}')
+        runner = runner_cls.from_cfg(args)  # type: ignore
+        print_log(
+            f'An `{runner_cls.__name__}` instance is built from '  # type: ignore # noqa: E501
+            'registry, its implementation can be found in'
+            f'{runner_cls.__module__}',  # type: ignore
+            logger='current',
+            level=logging.DEBUG)
+        return runner
 
 
 def build_model_from_cfg(

--- a/mmengine/registry/build_functions.py
+++ b/mmengine/registry/build_functions.py
@@ -98,7 +98,7 @@ def build_from_cfg(
             obj_cls = registry.get(obj_type)
             if obj_cls is None:
                 raise KeyError(
-                    f'{obj_type} is not in the {registry.name} registry. '
+                    f'{obj_type} is not in the {registry.scope}::{registry.name} registry. '  # noqa: E501
                     f'Please check whether the value of `{obj_type}` is '
                     'correct or it was registered as expected. More details '
                     'can be found at '
@@ -117,12 +117,20 @@ def build_from_cfg(
         else:
             obj = obj_cls(**args)  # type: ignore
 
-        print_log(
-            f'An `{obj_cls.__name__}` instance is built from '  # type: ignore # noqa: E501
-            'registry, and its implementation can be found in '
-            f'{obj_cls.__module__}',  # type: ignore
-            logger='current',
-            level=logging.DEBUG)
+        if (inspect.isclass(obj_cls) or inspect.isfunction(obj_cls)
+                or inspect.ismethod(obj_cls)):
+            print_log(
+                f'An `{obj_cls.__name__}` instance is built from '  # type: ignore # noqa: E501
+                'registry, and its implementation can be found in '
+                f'{obj_cls.__module__}',  # type: ignore
+                logger='current',
+                level=logging.DEBUG)
+        else:
+            print_log(
+                'An instance is built from registry, and its constructor '
+                f'is {obj_cls}',
+                logger='current',
+                level=logging.DEBUG)
         return obj
 
 

--- a/mmengine/registry/build_functions.py
+++ b/mmengine/registry/build_functions.py
@@ -111,39 +111,19 @@ def build_from_cfg(
             raise TypeError(
                 f'type must be a str or valid type, but got {type(obj_type)}')
 
-        try:
-            # If `obj_cls` inherits from `ManagerMixin`, it should be
-            # instantiated by `ManagerMixin.get_instance` to ensure that it
-            # can be accessed globally.
-            if inspect.isclass(obj_cls) and \
-                    issubclass(obj_cls, ManagerMixin):  # type: ignore
-                obj = obj_cls.get_instance(**args)  # type: ignore
-            else:
-                obj = obj_cls(**args)  # type: ignore
+        if inspect.isclass(obj_cls) and \
+                issubclass(obj_cls, ManagerMixin):  # type: ignore
+            obj = obj_cls.get_instance(**args)  # type: ignore
+        else:
+            obj = obj_cls(**args)  # type: ignore
 
-            if (inspect.isclass(obj_cls) or inspect.isfunction(obj_cls)
-                    or inspect.ismethod(obj_cls)):
-                print_log(
-                    f'An `{obj_cls.__name__}` instance is built from '  # type: ignore # noqa: E501
-                    'registry, and its implementation can be found in '
-                    f'{obj_cls.__module__}',  # type: ignore
-                    logger='current',
-                    level=logging.DEBUG)
-            else:
-                print_log(
-                    'An instance is built from registry, and its constructor '
-                    f'is {obj_cls}',
-                    logger='current',
-                    level=logging.DEBUG)
-            return obj
-
-        except Exception as e:
-            # Normal TypeError does not print class name.
-            cls_location = '/'.join(
-                obj_cls.__module__.split('.'))  # type: ignore
-            raise type(e)(
-                f'class `{obj_cls.__name__}` in '  # type: ignore
-                f'{cls_location}.py: {e}')
+        print_log(
+            f'An `{obj_cls.__name__}` instance is built from '  # type: ignore # noqa: E501
+            'registry, and its implementation can be found in '
+            f'{obj_cls.__module__}',  # type: ignore
+            logger='current',
+            level=logging.DEBUG)
+        return obj
 
 
 def build_runner_from_cfg(cfg: Union[dict, ConfigDict, Config],

--- a/mmengine/registry/registry.py
+++ b/mmengine/registry/registry.py
@@ -610,6 +610,11 @@ class Registry:
                 existed_module = self.module_dict[name]
                 raise KeyError(f'{name} is already registered in {self.name} '
                                f'at {existed_module.__module__}')
+            if not hasattr(module, '__module__'):
+                module_name = str(inspect.getmodule(sys._getframe(2)))
+                if module_name is None:
+                    module_name = '__main__'
+                module.__module__ = module_name
             self._module_dict[name] = module
 
     def register_module(

--- a/mmengine/registry/registry.py
+++ b/mmengine/registry/registry.py
@@ -613,6 +613,10 @@ class Registry:
                 existed_module = self.module_dict[name]
                 raise KeyError(f'{name} is already registered in {self.name} '
                                f'at {existed_module.__module__}')
+            # If module is a partial function or user defined callable
+            # object, it may not have `__module__` and `__name__` attributes.
+            # We set the `__module__` and `__name__` attributes for them to
+            # provide more information.
             if not hasattr(module, '__module__'):
                 module_name = str(inspect.getmodule(sys._getframe(2)))
                 if module_name is None:

--- a/mmengine/registry/registry.py
+++ b/mmengine/registry/registry.py
@@ -602,6 +602,9 @@ class Registry:
             raise TypeError(f'module must be Callable, but got {type(module)}')
 
         if module_name is None:
+            assert hasattr(module, '__name__'), (
+                'If `name` is not provided for `register_module`, please make '
+                f'sure the {module} has the `__name__` attribute')
             module_name = module.__name__
         if isinstance(module_name, str):
             module_name = [module_name]
@@ -615,6 +618,8 @@ class Registry:
                 if module_name is None:
                     module_name = '__main__'
                 module.__module__ = module_name
+            if not hasattr(module, '__name__'):
+                module.__name__ = name
             self._module_dict[name] = module
 
     def register_module(

--- a/mmengine/registry/registry.py
+++ b/mmengine/registry/registry.py
@@ -602,9 +602,6 @@ class Registry:
             raise TypeError(f'module must be Callable, but got {type(module)}')
 
         if module_name is None:
-            assert hasattr(module, '__name__'), (
-                'If `name` is not provided for `register_module`, please make '
-                f'sure the {module} has the `__name__` attribute')
             module_name = module.__name__
         if isinstance(module_name, str):
             module_name = [module_name]
@@ -613,17 +610,6 @@ class Registry:
                 existed_module = self.module_dict[name]
                 raise KeyError(f'{name} is already registered in {self.name} '
                                f'at {existed_module.__module__}')
-            # If module is a partial function or user defined callable
-            # object, it may not have `__module__` and `__name__` attributes.
-            # We set the `__module__` and `__name__` attributes for them to
-            # provide more information.
-            if not hasattr(module, '__module__'):
-                module_name = str(inspect.getmodule(sys._getframe(2)))
-                if module_name is None:
-                    module_name = '__main__'
-                module.__module__ = module_name
-            if not hasattr(module, '__name__'):
-                module.__name__ = name
             self._module_dict[name] = module
 
     def register_module(

--- a/tests/test_registry/test_build_functions.py
+++ b/tests/test_registry/test_build_functions.py
@@ -64,7 +64,10 @@ def test_build_from_cfg(cfg_type):
     assert model.depth == 50 and model.stages == 4
 
     # non-registered class
-    with pytest.raises(KeyError, match='VGG is not in the backbone registry'):
+    with pytest.raises(
+            KeyError,
+            match='VGG is not in the test_build_functions::backbone registry',
+    ):
         cfg = cfg_type(dict(type='VGG'))
         model = build_from_cfg(cfg, BACKBONES)
 

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -578,11 +578,6 @@ def test_build_from_cfg(cfg_type):
     assert isinstance(model, ResNet)
     assert model.depth == 50 and model.stages == 4
 
-    # non-registered class
-    with pytest.raises(KeyError, match='VGG is not in the backbone registry'):
-        cfg = cfg_type(dict(type='VGG'))
-        model = build_from_cfg(cfg, BACKBONES)
-
     # `cfg` contains unexpected arguments
     with pytest.raises(TypeError):
         cfg = cfg_type(dict(type='ResNet', non_existing_arg=50))

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -162,20 +162,10 @@ class TestRegistry:
         # lambda functions can be registered
         CATS.register_module(name='unknown cat', module=lambda: 'unknown')
 
-        # name must be provided when module does not have `__name__` attribute.
-        with pytest.raises(AssertionError):
-            muchkin1 = functools.partial(muchkin, size=0)
-            CATS.register_module(module=muchkin1)
-
         assert CATS.get('muchkin0') is muchkin0
         assert 'unknown cat' in CATS
         assert 'muchkin0' in CATS
         assert len(CATS) == 11
-
-        # register duplicated name partial function
-        with pytest.raises(KeyError):
-            CATS.register_module('muchkin0', False, muchkin0)
-        CATS.register_module('muchkin0', True, muchkin0)
 
     def _build_registry(self):
         """A helper function to build a Hierarchical Registry."""

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -167,6 +167,11 @@ class TestRegistry:
         assert 'muchkin0' in CATS
         assert len(CATS) == 11
 
+        # register duplicated name partial function
+        with pytest.raises(KeyError):
+            CATS.register_module('muchkin0', False, muchkin0)
+        CATS.register_module('muchkin0', True, muchkin0)
+
     def _build_registry(self):
         """A helper function to build a Hierarchical Registry."""
         #        Hierarchical Registry

--- a/tests/test_registry/test_registry.py
+++ b/tests/test_registry/test_registry.py
@@ -162,6 +162,11 @@ class TestRegistry:
         # lambda functions can be registered
         CATS.register_module(name='unknown cat', module=lambda: 'unknown')
 
+        # name must be provided when module does not have `__name__` attribute.
+        with pytest.raises(AssertionError):
+            muchkin1 = functools.partial(muchkin, size=0)
+            CATS.register_module(module=muchkin1)
+
         assert CATS.get('muchkin0') is muchkin0
         assert 'unknown cat' in CATS
         assert 'muchkin0' in CATS


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`build_from_cfg` catches all exception when building the registered object, and raise an unfriendly error. For example, an value error will be raised during building the metric, the error raise by `build_from_cfg` will like this:

```bash
Traceback (most recent call last):
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 122, in build_from_cfg
    obj = obj_cls(**args)  # type: ignore
  File "/home/yehaochen/codebase/mmdetection/mmdet/models/dense_heads/retina_head.py", line 57, in __init__
    super(RetinaHead, self).__init__(
  File "/home/yehaochen/codebase/mmdetection/mmdet/models/dense_heads/anchor_head.py", line 84, in __init__
    self.loss_cls = MODELS.build(loss_cls)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/registry.py", line 548, in build
    return self.build_func(cfg, *args, **kwargs, registry=self)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 250, in build_model_from_cfg
    return build_from_cfg(cfg, registry, default_args)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 144, in build_from_cfg
    raise type(e)(
ValueError: class `FocalLoss` in mmdet/models/losses/focal_loss.py: real error message in FocalLoss

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 122, in build_from_cfg
    obj = obj_cls(**args)  # type: ignore
  File "/home/yehaochen/codebase/mmdetection/mmdet/models/detectors/retinanet.py", line 19, in __init__
    super().__init__(
  File "/home/yehaochen/codebase/mmdetection/mmdet/models/detectors/single_stage.py", line 35, in __init__
    self.bbox_head = MODELS.build(bbox_head)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/registry.py", line 548, in build
    return self.build_func(cfg, *args, **kwargs, registry=self)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 250, in build_model_from_cfg
    return build_from_cfg(cfg, registry, default_args)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 144, in build_from_cfg
    raise type(e)(
ValueError: class `RetinaHead` in mmdet/models/dense_heads/retina_head.py: class `FocalLoss` in mmdet/models/losses/focal_loss.py: real error message in FocalLoss

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/yehaochen/codebase/mmdetection/tools/train.py", line 133, in <module>
    main()
  File "/home/yehaochen/codebase/mmdetection/tools/train.py", line 122, in main
    runner = Runner.from_cfg(cfg)
  File "/home/yehaochen/codebase/mmengine/mmengine/runner/runner.py", line 439, in from_cfg
    runner = cls(
  File "/home/yehaochen/codebase/mmengine/mmengine/runner/runner.py", line 406, in __init__
    self.model = self.build_model(model)
  File "/home/yehaochen/codebase/mmengine/mmengine/runner/runner.py", line 813, in build_model
    model = MODELS.build(model)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/registry.py", line 548, in build
    return self.build_func(cfg, *args, **kwargs, registry=self)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 250, in build_model_from_cfg
    return build_from_cfg(cfg, registry, default_args)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 144, in build_from_cfg
    raise type(e)(
ValueError: class `RetinaNet` in mmdet/models/detectors/retinanet.py: class `RetinaHead` in mmdet/models/dense_heads/retina_head.py: class `FocalLoss` in mmdet/models/losses/focal_loss.py: real error message in FocalLoss
```
The actual error message may be buried among other messages, and users may need to scroll up to locate which lines raise this error.

This PR remove this unnecessary error catching:

```bash
Traceback (most recent call last):
  File "/home/yehaochen/codebase/mmdetection/tools/train.py", line 133, in <module>
    main()
  File "/home/yehaochen/codebase/mmdetection/tools/train.py", line 122, in main
    runner = Runner.from_cfg(cfg)
  File "/home/yehaochen/codebase/mmengine/mmengine/runner/runner.py", line 439, in from_cfg
    runner = cls(
  File "/home/yehaochen/codebase/mmengine/mmengine/runner/runner.py", line 406, in __init__
    self.model = self.build_model(model)
  File "/home/yehaochen/codebase/mmengine/mmengine/runner/runner.py", line 813, in build_model
    model = MODELS.build(model)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/registry.py", line 548, in build
    return self.build_func(cfg, *args, **kwargs, registry=self)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 221, in build_model_from_cfg
    return build_from_cfg(cfg, registry, default_args)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 118, in build_from_cfg
    obj = obj_cls(**args)  # type: ignore
  File "/home/yehaochen/codebase/mmdetection/mmdet/models/detectors/retinanet.py", line 19, in __init__
    super().__init__(
  File "/home/yehaochen/codebase/mmdetection/mmdet/models/detectors/single_stage.py", line 35, in __init__
    self.bbox_head = MODELS.build(bbox_head)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/registry.py", line 548, in build
    return self.build_func(cfg, *args, **kwargs, registry=self)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 221, in build_model_from_cfg
    return build_from_cfg(cfg, registry, default_args)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 118, in build_from_cfg
    obj = obj_cls(**args)  # type: ignore
  File "/home/yehaochen/codebase/mmdetection/mmdet/models/dense_heads/retina_head.py", line 57, in __init__
    super(RetinaHead, self).__init__(
  File "/home/yehaochen/codebase/mmdetection/mmdet/models/dense_heads/anchor_head.py", line 84, in __init__
    self.loss_cls = MODELS.build(loss_cls)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/registry.py", line 548, in build
    return self.build_func(cfg, *args, **kwargs, registry=self)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 221, in build_model_from_cfg
    return build_from_cfg(cfg, registry, default_args)
  File "/home/yehaochen/codebase/mmengine/mmengine/registry/build_functions.py", line 118, in build_from_cfg
    obj = obj_cls(**args)  # type: ignore
  File "/home/yehaochen/codebase/mmdetection/mmdet/models/losses/focal_loss.py", line 190, in __init__
    raise ValueError('real error message in FocalLoss')
ValueError: real error message in FocalLoss
```
You can simply find that line 190 in focal_loss.py raise this error.



## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
