### PR TITLE
[Feature] Add support for full wandb's define_metric arguments

### DIFF
--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -201,6 +201,8 @@ class LogProcessor:
                 cur_iter_str = str(batch_idx + 1).rjust(
                     len(str(dataloader_len)))
                 log_str = (f'Iter({mode}) [{cur_iter_str}/{dataloader_len}]  ')
+        # Add global iter.
+        tag['iter'] = runner.iter + 1
         # Concatenate lr, momentum string with log header.
         log_str += f'{lr_str}  '
         # If IterTimerHook used in runner, eta, time, and data_time should be

--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -202,7 +202,10 @@ class LogProcessor:
                     len(str(dataloader_len)))
                 log_str = (f'Iter({mode}) [{cur_iter_str}/{dataloader_len}]  ')
         # Add global iter.
-        tag['iter'] = runner.iter + 1
+        if isinstance(runner._train_loop, dict) or runner._train_loop is None:
+            tag['iter'] = 0
+        else:
+            tag['iter'] = runner.iter + 1
         # Concatenate lr, momentum string with log header.
         log_str += f'{lr_str}  '
         # If IterTimerHook used in runner, eta, time, and data_time should be

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -347,15 +347,15 @@ class WandbVisBackend(BaseVisBackend):
             input parameters.
             See `wandb.init <https://docs.wandb.ai/ref/python/init>`_ for
             details. Defaults to None.
-        define_metric_cfg (dict | list[dict], optional):
+        define_metric_cfg (dict or list[dict], optional):
             When a dict is set, it is a dict of metrics and summary for
-            wandb.define_metric.
+            ``wandb.define_metric``.
             The key is metric and the value is summary.
             When a list is set, each dict should be a valid argument of
             the ``define_metric``.
-            When ``define_metric_cfg={'coco/bbox_mAP': 'max'}``,
-            The maximum value of ``coco/bbox_mAP`` is logged on wandb UI.
-            When ``define_metric_cfg=[dict(name="loss",
+            For example, ``define_metric_cfg={'coco/bbox_mAP': 'max'}``,
+            means the maximum value of ``coco/bbox_mAP`` is logged on wandb UI.
+            When ``define_metric_cfg=[dict(name='loss',
             step_metric='epoch')]``,
             the "loss” will be plotted against the epoch.
             See `wandb define_metric <https://docs.wandb.ai/ref/python/
@@ -379,7 +379,7 @@ class WandbVisBackend(BaseVisBackend):
     def __init__(self,
                  save_dir: str,
                  init_kwargs: Optional[dict] = None,
-                 define_metric_cfg: Optional[Union[dict, list]] = None,
+                 define_metric_cfg: Union[dict, list, None] = None,
                  commit: Optional[bool] = True,
                  log_code_name: Optional[str] = None,
                  watch_kwargs: Optional[dict] = None):

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -383,7 +383,7 @@ class WandbVisBackend(BaseVisBackend):
                  save_dir: str,
                  init_kwargs: Optional[dict] = None,
                  define_metric_cfg: Optional[dict] = None,
-                 define_metric_cfgs: Optional[dict] = None,
+                 define_metric_cfgs: Optional[list] = None,
                  commit: Optional[bool] = True,
                  log_code_name: Optional[str] = None,
                  watch_kwargs: Optional[dict] = None):

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -355,9 +355,12 @@ class WandbVisBackend(BaseVisBackend):
             See `wandb define_metric <https://docs.wandb.ai/ref/python/
             run#define_metric>`_ for details.
             Default: None
-        define_metric_cfgs (list, optional):
-            A list of dicts. Each dict should be valid arguments of
-            the ``define_metrics``.
+        define_metric_cfgs (list[dict], optional):
+            A list of define_metric arguments.
+            Each dict should be a valid argument of the ``define_metric``.
+            The following example changes the x-axis of the "loss" plot
+            from the default step to epoch.
+            ``define_metric_cfgs=[dict(name="loss", step_metric='epoch')]``
             See `wandb define_metric <https://docs.wandb.ai/ref/python/
             run#define_metric>`_ for details.
             New in version 0.7.4.

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -355,6 +355,12 @@ class WandbVisBackend(BaseVisBackend):
             See `wandb define_metric <https://docs.wandb.ai/ref/python/
             run#define_metric>`_ for details.
             Default: None
+        define_metric_cfgs (list, optional):
+            A list of dicts. Each dict should be valid arguments of
+            the ``define_metrics``.
+            See `wandb define_metric <https://docs.wandb.ai/ref/python/
+            run#define_metric>`_ for details.
+            New in version 0.7.4.
         commit: (bool, optional) Save the metrics dict to the wandb server
             and increment the step.  If false `wandb.log` just updates the
             current metrics dict with the row argument and metrics won't be
@@ -374,12 +380,14 @@ class WandbVisBackend(BaseVisBackend):
                  save_dir: str,
                  init_kwargs: Optional[dict] = None,
                  define_metric_cfg: Optional[dict] = None,
+                 define_metric_cfgs: Optional[dict] = None,
                  commit: Optional[bool] = True,
                  log_code_name: Optional[str] = None,
                  watch_kwargs: Optional[dict] = None):
         super().__init__(save_dir)
         self._init_kwargs = init_kwargs
         self._define_metric_cfg = define_metric_cfg
+        self._define_metric_cfgs = define_metric_cfgs
         self._commit = commit
         self._log_code_name = log_code_name
         self._watch_kwargs = watch_kwargs if watch_kwargs is not None else {}
@@ -402,6 +410,9 @@ class WandbVisBackend(BaseVisBackend):
         if self._define_metric_cfg is not None:
             for metric, summary in self._define_metric_cfg.items():
                 wandb.define_metric(metric, summary=summary)
+        if self._define_metric_cfgs is not None:
+            for metric_cfg in self._define_metric_cfgs:
+                wandb.define_metric(**metric_cfg)
         self._wandb = wandb
 
     @property  # type: ignore

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -357,7 +357,7 @@ class WandbVisBackend(BaseVisBackend):
             means the maximum value of ``coco/bbox_mAP`` is logged on wandb UI.
             When ``define_metric_cfg=[dict(name='loss',
             step_metric='epoch')]``,
-            the "loss” will be plotted against the epoch.
+            the "loss" will be plotted against the epoch.
             See `wandb define_metric <https://docs.wandb.ai/ref/python/
             run#define_metric>`_ for details.
             Default: None

--- a/tests/test_runner/test_log_processor.py
+++ b/tests/test_runner/test_log_processor.py
@@ -92,7 +92,8 @@ class TestLogProcessor(RunnerTestCase):
             train_logs = dict(time=1.0, data_time=1.0, loss_cls=1.0)
         log_processor._collect_scalars = \
             lambda *args, **kwargs: copy.deepcopy(train_logs)
-        _, out = log_processor.get_log_after_iter(self.runner, 1, mode)
+        tag, out = log_processor.get_log_after_iter(self.runner, 1, mode)
+
         # Verify that the correct context have been logged.
         cur_loop = log_processor._get_cur_loop(self.runner, mode)
         if by_epoch:
@@ -117,6 +118,9 @@ class TestLogProcessor(RunnerTestCase):
             if mode == 'train':
                 log_str += f"loss_cls: {train_logs['loss_cls']:.4f}"
             assert out == log_str
+
+            if mode in ['train', 'val']:
+                assert 'epoch' in tag
         else:
             if mode == 'train':
                 max_iters = self.runner.max_iters
@@ -143,6 +147,9 @@ class TestLogProcessor(RunnerTestCase):
             if mode == 'train':
                 log_str += f"loss_cls: {train_logs['loss_cls']:.4f}"
             assert out == log_str
+
+        # tag always has "iter" key
+        assert 'iter' in tag
 
     @parameterized.expand(
         ([True, 'val', True], [True, 'val', False], [False, 'val', True],

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -243,6 +243,21 @@ class TestWandbVisBackend:
         wandb_vis_backend.close()
         shutil.rmtree('temp_dir')
 
+    def test_define_metric_cfgs(self):
+        define_metric_cfgs = [
+            dict(name='test1', step_metric='iter'),
+            dict(name='test2', step_metric='epoch'),
+        ]
+        wandb_vis_backend = WandbVisBackend(
+            'temp_dir', define_metric_cfgs=define_metric_cfgs)
+        wandb_vis_backend._init_env()
+        wandb_vis_backend._wandb.define_metric.assert_any_call(
+            name='test1', step_metric='iter')
+        wandb_vis_backend._wandb.define_metric.assert_any_call(
+            name='test2', step_metric='epoch')
+
+        shutil.rmtree('temp_dir')
+
 
 class TestMLflowVisBackend:
 

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -243,18 +243,27 @@ class TestWandbVisBackend:
         wandb_vis_backend.close()
         shutil.rmtree('temp_dir')
 
-    def test_define_metric_cfgs(self):
-        define_metric_cfgs = [
+    def test_define_metric_cfg(self):
+        # list of dict
+        define_metric_cfg = [
             dict(name='test1', step_metric='iter'),
             dict(name='test2', step_metric='epoch'),
         ]
         wandb_vis_backend = WandbVisBackend(
-            'temp_dir', define_metric_cfgs=define_metric_cfgs)
+            'temp_dir', define_metric_cfg=define_metric_cfg)
         wandb_vis_backend._init_env()
         wandb_vis_backend._wandb.define_metric.assert_any_call(
             name='test1', step_metric='iter')
         wandb_vis_backend._wandb.define_metric.assert_any_call(
             name='test2', step_metric='epoch')
+
+        # dict
+        define_metric_cfg = dict(test3='max')
+        wandb_vis_backend = WandbVisBackend(
+            'temp_dir', define_metric_cfg=define_metric_cfg)
+        wandb_vis_backend._init_env()
+        wandb_vis_backend._wandb.define_metric.assert_any_call(
+            'test3', summary='max')
 
         shutil.rmtree('temp_dir')
 


### PR DESCRIPTION
## Motivation

In this PR, add support for other original arguments of wandb.define_metric described in: https://docs.wandb.ai/ref/python/run#define_metric
(The current `WandbVisBackend` implementation supports only the case of the `summary` metric.)

Especially the `step_metric` is helpful for defining the x-axis more flexibly.
Specifying the "iter" or "epoch" as an x-axis, we can solve the issue of resumption discussed in issue #1072. I think this PR is a better solution because this does not need additional variables like `auto_step` nor`last_step` nor extra logic and uses only the wandb's feature.

Furthermore, users can specify different x-axes depending on the metrics in the same experiment. See below:

![iter_epoch](https://user-images.githubusercontent.com/9190086/233844307-fe224925-4939-41fb-ae48-6a6bc73e5869.png)

## Modification

To allow the visualizers to use the `iter` as a step, I added an `iter` key in the tag of the log_processor. 
And I added a new argument (`define_metric_cfgs`) in the WandbVisBackend for users to configure the metric.

Since all visualizers use the same tag, this affects other non-wandb visualizers' behavior.
I think this modification would not cause any negative effect on other visualizers. 
But if it causes something bad, I will add a flag like 'add_iter' in the  log_processor for user control to include `iter` or not.

## BC-breaking (Optional)

As I described above, this PR added a new key, "iter," in the output of the log_processor.
A new plot for the "iter" might appear in some visualization, but  I think it does not cause serious problems.

## Use cases (Optional)

Expected usage is defining all the metrics used by the experiment:

```
vis_backends = [
    dict(type='LocalVisBackend'),
    dict(
        type='WandbVisBackend',        
        init_kwargs={...},
        define_metric_cfgs=[
            dict(name="lr", step_metric='iter’),
            ...
            dict(name="coco/bbox_mAP", step_metric='epoch'),
            dict(name="coco/bbox_mAP_50", step_metric='epoch'),            
        ],
    )
]
```

Providing a standard preset of the define_metric_cfgs as default (ex., `configs/_base_/wandb_metrics.py`) might be great, but I don't think it is indispensable. It is not difficult, though cumbersome, for users to define metrics individually for a particular project. And defining all possible metrics in advance is a bit difficult because the metrics would change depending on the models and tasks.

If the user missed defining some metrics, wandb would use the default step as the x-axis and loose nothing.
We can fix the X-axis later in the Web UI.

![switch_x](https://user-images.githubusercontent.com/9190086/233844548-bcbbc975-1757-4271-9839-3e970c27af67.png)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
