### PR TITLE
[Enhance] Enhance error message during custom import

### DIFF
--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -5,6 +5,7 @@ import os
 import os.path as osp
 import platform
 import shutil
+import sys
 import tempfile
 import types
 import uuid
@@ -180,7 +181,15 @@ class Config:
             try:
                 import_modules_from_strings(**cfg_dict['custom_imports'])
             except ImportError as e:
-                raise ImportError('Failed to custom import!') from e
+                err_msg = (
+                    'Failed to import custom modules from '
+                    f"{cfg_dict['custom_imports']}, the current sys.path is: ")
+                for p in sys.path:
+                    err_msg += f'\n    {p}'
+                err_msg += (
+                    '\nYou should set `PYTHONPATH` to make `sys.path` include '
+                    'the directory which contains your custom module')
+                raise ImportError(err_msg) from e
         return Config(
             cfg_dict,
             cfg_text=cfg_text,

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -65,8 +65,14 @@ class TestConfig:
         # If import successfully, os.environ[''TEST_VALUE''] will be
         # set to 'test'
         assert os.environ.pop('TEST_VALUE') == 'test'
+        sys.path.pop()
+
         Config.fromfile(cfg_file, import_custom_modules=False)
         assert 'TEST_VALUE' not in os.environ
+        sys.modules.pop('test_custom_import_module')
+        with pytest.raises(
+                ImportError, match='Failed to import custom modules from'):
+            Config.fromfile(cfg_file, import_custom_modules=True)
 
     @pytest.mark.parametrize('file_format', ['py', 'json', 'yaml'])
     def test_fromstring(self, file_format):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Enhance the error message raised by custom import:

```bash
ImportError: Failed to import custom modules from {'imports': ['test_custom_import_module'], 'allow_failed_imports': False}, the current sys.path is: 
    /home/yehaochen/anaconda3/bin
    /home/yehaochen/anaconda3/lib/python39.zip
    /home/yehaochen/anaconda3/lib/python3.9
    /home/yehaochen/anaconda3/lib/python3.9/lib-dynload
    
    /home/yehaochen/.local/lib/python3.9/site-packages
    /home/yehaochen/anaconda3/lib/python3.9/site-packages
    /home/yehaochen/codebase/mmengine
You should set `PYTHONPATH` to make `sys.path` include the directory which contains your custom module
```

User can get more information about how to resolve the error

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
