### PR TITLE
[Fix] Fix build unnecessary loop during train/test/val

### DIFF
--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -253,7 +253,10 @@ class LoggerHook(Hook):
             runner, len(runner.val_dataloader), 'val')
         runner.logger.info(log_str)
         if self.log_metric_by_epoch:
-            # Avoid to build train_loop during validation
+            # Accessing the epoch attribute of the runner will trigger
+            # the construction of the train_loop. Therefore, to avoid
+            # triggering the construction of the train_loop during
+            # validation, check before accessing the epoch.
             if isinstance(runner._train_loop, (dict, type(None))):
                 epoch = 0
             else:

--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -253,11 +253,20 @@ class LoggerHook(Hook):
             runner, len(runner.val_dataloader), 'val')
         runner.logger.info(log_str)
         if self.log_metric_by_epoch:
+            # Avoid to build train_loop during validation
+            if isinstance(runner._train_loop, dict):
+                epoch = 0
+            else:
+                epoch = runner.epoch
             runner.visualizer.add_scalars(
-                tag, step=runner.epoch, file_path=self.json_log_path)
+                tag, step=epoch, file_path=self.json_log_path)
         else:
+            if isinstance(runner._train_loop, dict):
+                iter = 0
+            else:
+                iter = runner.iter
             runner.visualizer.add_scalars(
-                tag, step=runner.iter, file_path=self.json_log_path)
+                tag, step=iter, file_path=self.json_log_path)
 
     def after_test_epoch(self,
                          runner,

--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -254,14 +254,14 @@ class LoggerHook(Hook):
         runner.logger.info(log_str)
         if self.log_metric_by_epoch:
             # Avoid to build train_loop during validation
-            if isinstance(runner._train_loop, dict):
+            if isinstance(runner._train_loop, (dict, type(None))):
                 epoch = 0
             else:
                 epoch = runner.epoch
             runner.visualizer.add_scalars(
                 tag, step=epoch, file_path=self.json_log_path)
         else:
-            if isinstance(runner._train_loop, dict):
+            if isinstance(runner._train_loop, (dict, type(None))):
                 iter = 0
             else:
                 iter = runner.iter

--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -257,14 +257,16 @@ class LoggerHook(Hook):
             # the construction of the train_loop. Therefore, to avoid
             # triggering the construction of the train_loop during
             # validation, check before accessing the epoch.
-            if isinstance(runner._train_loop, (dict, type(None))):
+            if (isinstance(runner._train_loop, dict)
+                    or runner._train_loop is None):
                 epoch = 0
             else:
                 epoch = runner.epoch
             runner.visualizer.add_scalars(
                 tag, step=epoch, file_path=self.json_log_path)
         else:
-            if isinstance(runner._train_loop, (dict, type(None))):
+            if (isinstance(runner._train_loop, dict)
+                    or runner._train_loop is None):
                 iter = 0
             else:
                 iter = runner.iter

--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -135,7 +135,6 @@ class LogProcessor:
             recorded by :obj:`runner.message_hub` and :obj:`runner.visualizer`.
         """
         assert mode in ['train', 'test', 'val']
-        cur_iter = self._get_iter(runner, batch_idx=batch_idx)
         # Overwrite ``window_size`` defined in ``custom_cfg`` to int value.
         parsed_cfg = self._parse_windows_size(runner, batch_idx,
                                               self.custom_cfg)
@@ -172,19 +171,22 @@ class LogProcessor:
             # ...                 ||| |||
             # Epoch(train)  [ 10][100/270]
             dataloader_len = self._get_dataloader_size(runner, mode)
+            cur_iter = self._get_iter(runner, batch_idx)
             cur_iter_str = str(cur_iter).rjust(len(str(dataloader_len)))
-
             if mode in ['train', 'val']:
-                # Right Align the epoch log:
-                # Epoch(train)   [9][100/270]
-                # ...             ||
-                # Epoch(train) [100][100/270]
                 cur_epoch = self._get_epoch(runner, mode)
-                max_epochs = runner.max_epochs
-                # 3 means the three characters: "[", "]", and " " occupied in
-                # " [{max_epochs}]"
-                cur_epoch_str = f'[{cur_epoch}]'.rjust(
-                    len(str(max_epochs)) + 3, ' ')
+                if not isinstance(runner._train_loop, dict):
+                    # Right Align the epoch log:
+                    # Epoch(train)   [9][100/270]
+                    # ...             ||
+                    # Epoch(train) [100][100/270]
+                    max_epochs = runner.max_epochs
+                    # 3 means the three characters: "[", "]", and " " occupied
+                    # in " [{max_epochs}]"
+                    cur_epoch_str = f'[{cur_epoch}]'.rjust(
+                        len(str(max_epochs)) + 3, ' ')
+                else:
+                    cur_epoch_str = f'[{cur_epoch}]'
                 tag['epoch'] = cur_epoch
                 log_str = (f'Epoch({mode}){cur_epoch_str}'
                            f'[{cur_iter_str}/{dataloader_len}]  ')
@@ -193,6 +195,7 @@ class LogProcessor:
                            f'[{cur_iter_str}/{dataloader_len}]  ')
         else:
             if mode == 'train':
+                cur_iter = self._get_iter(runner, batch_idx)
                 cur_iter_str = str(cur_iter).rjust(len(str(runner.max_iters)))
                 log_str = (f'Iter({mode}) '
                            f'[{cur_iter_str}/{runner.max_iters}]  ')
@@ -492,19 +495,19 @@ class LogProcessor:
         device = getattr(runner.model, 'output_device', None)
         return get_max_cuda_memory(device)
 
-    def _get_iter(self, runner, batch_idx: int = None) -> int:
+    def _get_iter(self, runner, batch_idx: int) -> int:
         """Get current iteration index.
 
         Args:
             runner (Runner): The runner of the training/testing/validation
                 process.
-            batch_idx (int, optional): The iteration index of current
+            batch_idx (int): The iteration index of current
                 dataloader. Defaults to None.
 
         Returns:
             int: The current global iter or inner iter.
         """
-        if self.by_epoch and batch_idx is not None:
+        if self.by_epoch:
             current_iter = batch_idx + 1
         else:
             current_iter = runner.iter + 1
@@ -524,9 +527,12 @@ class LogProcessor:
         if mode == 'train':
             epoch = runner.epoch + 1
         elif mode == 'val':
-            # normal val mode
-            # runner.epoch += 1 has been done before validation
-            epoch = runner.epoch
+            if isinstance(runner._train_loop, dict):
+                epoch = 0
+            else:
+                # normal val mode
+                # runner.epoch += 1 has been done before validation
+                epoch = runner.epoch
         else:
             raise ValueError(
                 f"runner mode should be 'train' or 'val', but got {mode}")

--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -175,7 +175,8 @@ class LogProcessor:
             cur_iter_str = str(cur_iter).rjust(len(str(dataloader_len)))
             if mode in ['train', 'val']:
                 cur_epoch = self._get_epoch(runner, mode)
-                if not isinstance(runner._train_loop, (dict, type(None))):
+                if not (isinstance(runner._train_loop, dict)
+                        or runner._train_loop is None):
                     # Right Align the epoch log:
                     # Epoch(train)   [9][100/270]
                     # ...             ||
@@ -527,7 +528,8 @@ class LogProcessor:
         if mode == 'train':
             epoch = runner.epoch + 1
         elif mode == 'val':
-            if isinstance(runner._train_loop, (dict, type(None))):
+            if (isinstance(runner._train_loop, dict)
+                    or runner._train_loop is None):
                 epoch = 0
             else:
                 # normal val mode

--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -175,7 +175,7 @@ class LogProcessor:
             cur_iter_str = str(cur_iter).rjust(len(str(dataloader_len)))
             if mode in ['train', 'val']:
                 cur_epoch = self._get_epoch(runner, mode)
-                if not isinstance(runner._train_loop, dict):
+                if not isinstance(runner._train_loop, (dict, type(None))):
                     # Right Align the epoch log:
                     # Epoch(train)   [9][100/270]
                     # ...             ||
@@ -527,7 +527,7 @@ class LogProcessor:
         if mode == 'train':
             epoch = runner.epoch + 1
         elif mode == 'val':
-            if isinstance(runner._train_loop, dict):
+            if isinstance(runner._train_loop, (dict, type(None))):
                 epoch = 0
             else:
                 # normal val mode

--- a/tests/test_runner/test_log_processor.py
+++ b/tests/test_runner/test_log_processor.py
@@ -8,7 +8,7 @@ import torch
 from parameterized import parameterized
 
 from mmengine.logging import HistoryBuffer, MessageHub, MMLogger
-from mmengine.runner import LogProcessor
+from mmengine.runner import BaseLoop, LogProcessor
 from mmengine.testing import RunnerTestCase
 
 
@@ -253,19 +253,6 @@ class TestLogProcessor(RunnerTestCase):
         torch.cuda.max_memory_allocated.assert_called()
         torch.cuda.reset_peak_memory_stats.assert_called()
 
-    def test_get_iter(self):
-        log_processor = LogProcessor()
-        # Get global iter when `inner_iter=False`
-        iter = log_processor._get_iter(self.runner)
-        assert iter == 11
-        # Get inner iter
-        iter = log_processor._get_iter(self.runner, 1)
-        assert iter == 2
-        # Still get global iter when `logger_hook.by_epoch==False`
-        log_processor.by_epoch = False
-        iter = log_processor._get_iter(self.runner, 1)
-        assert iter == 11
-
     def test_get_epoch(self):
         log_processor = LogProcessor()
         epoch = log_processor._get_epoch(self.runner, 'train')
@@ -338,3 +325,22 @@ class TestLogProcessor(RunnerTestCase):
         runner.train()
         runner.val()
         runner.test()
+
+        # Unnecessary loop will not be built
+        for cfg in (self.epoch_based_cfg, self.iter_based_cfg):
+            cfg = copy.deepcopy(cfg)
+            runner = self.build_runner(cfg)
+            runner.train()
+            self.assertIsInstance(runner._train_loop, BaseLoop)
+            self.assertIsInstance(runner._val_loop, BaseLoop)
+            self.assertIsInstance(runner._test_loop, dict)
+
+            runner = self.build_runner(cfg)
+            runner.val()
+            self.assertIsInstance(runner._train_loop, dict)
+            self.assertIsInstance(runner._test_loop, dict)
+
+            runner = self.build_runner(cfg)
+            runner.test()
+            self.assertIsInstance(runner._train_loop, dict)
+            self.assertIsInstance(runner._val_loop, dict)

--- a/tests/test_runner/test_log_processor.py
+++ b/tests/test_runner/test_log_processor.py
@@ -253,6 +253,19 @@ class TestLogProcessor(RunnerTestCase):
         torch.cuda.max_memory_allocated.assert_called()
         torch.cuda.reset_peak_memory_stats.assert_called()
 
+    def test_get_iter(self):
+        log_processor = LogProcessor()
+        # Get global iter when `inner_iter=False`
+        iter = log_processor._get_iter(self.runner)
+        assert iter == 11
+        # Get inner iter
+        iter = log_processor._get_iter(self.runner, 1)
+        assert iter == 2
+        # Still get global iter when `logger_hook.by_epoch==False`
+        log_processor.by_epoch = False
+        iter = log_processor._get_iter(self.runner, 1)
+        assert iter == 11
+
     def test_get_epoch(self):
         log_processor = LogProcessor()
         epoch = log_processor._get_epoch(self.runner, 'train')

--- a/tests/test_runner/test_log_processor.py
+++ b/tests/test_runner/test_log_processor.py
@@ -8,7 +8,7 @@ import torch
 from parameterized import parameterized
 
 from mmengine.logging import HistoryBuffer, MessageHub, MMLogger
-from mmengine.runner import BaseLoop, LogProcessor
+from mmengine.runner import LogProcessor
 from mmengine.testing import RunnerTestCase
 
 
@@ -325,22 +325,3 @@ class TestLogProcessor(RunnerTestCase):
         runner.train()
         runner.val()
         runner.test()
-
-        # Unnecessary loop will not be built
-        for cfg in (self.epoch_based_cfg, self.iter_based_cfg):
-            cfg = copy.deepcopy(cfg)
-            runner = self.build_runner(cfg)
-            runner.train()
-            self.assertIsInstance(runner._train_loop, BaseLoop)
-            self.assertIsInstance(runner._val_loop, BaseLoop)
-            self.assertIsInstance(runner._test_loop, dict)
-
-            runner = self.build_runner(cfg)
-            runner.val()
-            self.assertIsInstance(runner._train_loop, dict)
-            self.assertIsInstance(runner._test_loop, dict)
-
-            runner = self.build_runner(cfg)
-            runner.test()
-            self.assertIsInstance(runner._train_loop, dict)
-            self.assertIsInstance(runner._val_loop, dict)

--- a/tests/test_runner/test_log_processor.py
+++ b/tests/test_runner/test_log_processor.py
@@ -255,10 +255,7 @@ class TestLogProcessor(RunnerTestCase):
 
     def test_get_iter(self):
         log_processor = LogProcessor()
-        # Get global iter when `inner_iter=False`
-        iter = log_processor._get_iter(self.runner)
-        assert iter == 11
-        # Get inner iter
+        # Get batch_idx
         iter = log_processor._get_iter(self.runner, 1)
         assert iter == 2
         # Still get global iter when `logger_hook.by_epoch==False`

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -1764,6 +1764,16 @@ class TestRunner(TestCase):
             log = f.read()
         self.assertIn('Epoch(train) [1][4/4]', log)
 
+        # 14. test_loop will not be built
+        for cfg in (self.epoch_based_cfg, self.iter_based_cfg):
+            cfg = copy.deepcopy(cfg)
+            cfg.experiment_name = 'test_train14'
+            runner = Runner.from_cfg(cfg)
+            runner.train()
+            self.assertIsInstance(runner._train_loop, BaseLoop)
+            self.assertIsInstance(runner._val_loop, BaseLoop)
+            self.assertIsInstance(runner._test_loop, dict)
+
     @skipIf(
         SKIP_TEST_COMPILE,
         reason='torch.compile is not valid, please install PyTorch>=2.0.0')
@@ -1842,6 +1852,15 @@ class TestRunner(TestCase):
             self.assertIn(predictions[0].dtype,
                           (torch.float16, torch.bfloat16))
 
+        # train_loop and test_loop will not be built
+        for cfg in (self.epoch_based_cfg, self.iter_based_cfg):
+            cfg = copy.deepcopy(cfg)
+            cfg.experiment_name = 'test_val4'
+            runner = Runner.from_cfg(cfg)
+            runner.val()
+            self.assertIsInstance(runner._train_loop, dict)
+            self.assertIsInstance(runner._test_loop, dict)
+
     @skipIf(
         SKIP_TEST_COMPILE,
         reason='torch.compile is not valid, please install PyTorch>=2.0.0')
@@ -1901,7 +1920,7 @@ class TestRunner(TestCase):
         predictions.clear()
 
         # Test fp16 `autocast` context.
-        cfg.experiment_name = 'test_val3'
+        cfg.experiment_name = 'test_test3'
         cfg.test_cfg = dict(fp16=True)
         runner = Runner.from_cfg(cfg)
         runner.model.register_forward_hook(get_outputs_callback)
@@ -1913,6 +1932,14 @@ class TestRunner(TestCase):
             runner.test()
             self.assertIn(predictions[0].dtype,
                           (torch.float16, torch.bfloat16))
+        # train_loop and val_loop will not be built
+        for cfg in (self.epoch_based_cfg, self.iter_based_cfg):
+            cfg = copy.deepcopy(cfg)
+            cfg.experiment_name = 'test_test4'
+            runner = Runner.from_cfg(cfg)
+            runner.test()
+            self.assertIsInstance(runner._train_loop, dict)
+            self.assertIsInstance(runner._val_loop, dict)
 
     @skipIf(
         SKIP_TEST_COMPILE,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`Runner` will build train_loop automatically when the `epoch`, `iter`, `max_epoch` attributes are accessed. This feature cause that the `log_processor` and `LoggerHook` will trigger the building of `train_loop` during `testing` and `validating`. This PR fix this and update the unit test to make sure unnecessary loops will not be built.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
