### PR TITLE
Fix Mlflow logging | Add possibility of optional calling of "after run" hooks.

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1658,7 +1658,7 @@ class Runner:
             self.load_checkpoint(self._load_from)
             self._has_loaded = True
 
-    def train(self) -> nn.Module:
+    def train(self, call_hook_after_run: bool = True) -> nn.Module:
         """Launch training.
 
         Returns:
@@ -1719,10 +1719,12 @@ class Runner:
         self._maybe_compile('train_step')
 
         model = self.train_loop.run()  # type: ignore
-        self.call_hook('after_run')
+        
+        if call_hook_after_run:
+            self.call_hook('after_run')
         return model
 
-    def val(self) -> dict:
+    def val(self, call_hook_after_run: bool = True) -> dict:
         """Launch validation.
 
         Returns:
@@ -1742,10 +1744,11 @@ class Runner:
         self.load_or_resume()
 
         metrics = self.val_loop.run()  # type: ignore
-        self.call_hook('after_run')
+        if call_hook_after_run:
+            self.call_hook('after_run')
         return metrics
 
-    def test(self) -> dict:
+    def test(self, call_hook_after_run: bool = True) -> dict:
         """Launch test.
 
         Returns:
@@ -1765,7 +1768,8 @@ class Runner:
         self.load_or_resume()
 
         metrics = self.test_loop.run()  # type: ignore
-        self.call_hook('after_run')
+        if call_hook_after_run:
+            self.call_hook('after_run')
         return metrics
 
     def call_hook(self, fn_name: str, **kwargs) -> None:

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -781,7 +781,12 @@ class MLflowVisBackend(BaseVisBackend):
         assert isinstance(scalar_dict, dict)
         assert 'step' not in scalar_dict, 'Please set it directly ' \
                                           'through the step parameter'
-        self._mlflow.log_metrics(scalar_dict, step)
+                                          
+        scalar_dict_fixed = dict()
+        for k, v in scalar_dict.items():
+            scalar_dict_fixed[k.replace('@', '_at_')] = v
+                                          
+        self._mlflow.log_metrics(scalar_dict_fixed, step)
 
     def close(self) -> None:
         """Close the mlflow."""


### PR DESCRIPTION
# Mlflow Logging

Mlflow doesn't support such characters as `@`. Pull request fixes this by replacing `@` with `_at_`.
```
MlflowLogger: Invalid metric name: 'val/AR@100'. Names may only contain alphanumerics, underscores (_), dashes (-), periods (.), spaces ( ), and slashes (/) 
```

# `after run` hooks.

Current pipeline doesn't allow to log artifacts and perform test after `train` step. This PR fixes this by adding optinal  `call_hook_after_run` to `train` and `test` methods. :
```python
    # start training
    runner.train(call_hook_after_run = False)
    
    runner.load_checkpoint(runner.message_hub.get_info('best_ckpt'))
    
    # start testing
    results = runner.test(call_hook_after_run = False)
    
    
    
    if mlflow.active_run():
        results = {k.replace('@', '_at_'): v for k, v in results.items()}
        mlflow.log_metrics(results)
        
        mlflow.log_artifact(runner.message_hub.get_info('best_ckpt'))
        mlflow.pytorch.log_model(runner.model, 'model')
        
        
    runner.call_hook('after_run')

```