### PR TITLE
[Fix] Fix the incorrect device of inputs in get_model_complexity_info

### DIFF
--- a/mmengine/analysis/print_helper.py
+++ b/mmengine/analysis/print_helper.py
@@ -725,14 +725,15 @@ def get_model_complexity_info(
         raise ValueError('"input_shape" and "inputs" cannot be both set.')
 
     if inputs is None:
+        device = next(model.parameters()).device
         if is_tuple_of(input_shape, int):  # tuple of int, construct one tensor
-            inputs = (torch.randn(1, *input_shape), )
+            inputs = (torch.randn(1, *input_shape).to(device), )
         elif is_tuple_of(input_shape, tuple) and all([
                 is_tuple_of(one_input_shape, int)
                 for one_input_shape in input_shape  # type: ignore
         ]):  # tuple of tuple of int, construct multiple tensors
             inputs = tuple([
-                torch.randn(1, *one_input_shape)
+                torch.randn(1, *one_input_shape).to(device)
                 for one_input_shape in input_shape  # type: ignore
             ])
         else:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Resolve #1092.

## Modification

In `get_model_complexity_info`, when `inputs` is `None` and model is not in cpu, generate random inputs in the device of model.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
