### PR TITLE
[Fix] Correctly saves `_metadata` of `state_dict` when saving checkpoints

### DIFF
--- a/mmengine/runner/checkpoint.py
+++ b/mmengine/runner/checkpoint.py
@@ -652,10 +652,11 @@ def weights_to_cpu(state_dict):
     Returns:
         OrderedDict: Model weights on GPU.
     """
+    # stash metadata to put in state_dict later
+    metadata = getattr(state_dict, '_metadata', OrderedDict())
     state_dict = apply_to(state_dict, lambda x: hasattr(x, 'cpu'),
                           lambda x: x.cpu())
-    # Keep metadata in state_dict
-    state_dict._metadata = getattr(state_dict, '_metadata', OrderedDict())
+    state_dict._metadata = metadata
     return state_dict
 
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix #1128, where `statde_dict._metadata` of saved checkpoints becomes empty `OrderedDict`s

## Modification

modified `weights_to_cpu()` in `runner/checkpoint.py` that it stashes `_metadata` of `state_dicts` before moving weights to cpu

## BC-breaking (Optional)

N/A

## Use cases (Optional)

N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
