### PR TITLE
[Fix] Limit urllib3 version for docs building

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,3 +7,4 @@ sphinx-copybutton
 sphinx_markdown_tables
 torch
 torchvision
+urllib3<2.0.0


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

As the [issue](https://github.com/urllib3/urllib3/issues/2168) says, surllib3 2.0 has deprecated the support of OpenSSL<=1.1.1.

However, the environment for building the docs only has OpenSSL  v1.0.0, and an error will be raised like this:

```bash
sphinx.errors.ExtensionError: Could not import extension sphinx.builders.linkcheck (exception: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168)
```

 According to the discussion [here](https://github.com/psf/requests/issues/6432), the easiest way to avoid the problem is to limit the urllib3 version < 2.0.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
