### PR TITLE
[Fix] Fix `ProfileHook` cannot profile ddp-training

### DIFF
--- a/mmengine/hooks/profiler_hook.py
+++ b/mmengine/hooks/profiler_hook.py
@@ -136,7 +136,6 @@ class ProfilerHook(Hook):
 
         self.json_trace_path = json_trace_path
 
-    @master_only
     def before_run(self, runner):
         """Initialize the profiler.
 
@@ -212,19 +211,16 @@ class ProfilerHook(Hook):
                 f'but got {self.on_trace_ready}')
         return _on_trace_ready
 
-    @master_only
     def after_train_epoch(self, runner):
         """Determine if the content is exported."""
         if self.by_epoch and runner.epoch == self.profile_times - 1:
             self._export_chrome_trace(runner)
 
-    @master_only
     def after_train_iter(self, runner, batch_idx, data_batch, outputs):
         """Update the content according to the schedule, and determine if the
         content is exported."""
-        if self.schedule is None:
-            self.profiler.step()
         if not self.by_epoch and runner.iter == self.profile_times - 1:
+            self.profiler.step()
             self._export_chrome_trace(runner)
 
     def _export_chrome_trace(self, runner):

--- a/mmengine/hooks/profiler_hook.py
+++ b/mmengine/hooks/profiler_hook.py
@@ -150,7 +150,6 @@ class ProfilerHook(Hook):
 
         self.json_trace_path = json_trace_path
 
-    @master_only
     def before_run(self, runner):
         """Initialize the profiler.
 

--- a/mmengine/hooks/profiler_hook.py
+++ b/mmengine/hooks/profiler_hook.py
@@ -51,12 +51,12 @@ class ProfilerHook(Hook):
             Two officially recommended ways are provided:
 
             - ``schedule=dict(type='log_trace')``: Print the profiling result
-              in the terminal See more details in the `official tutorial`_.
-              The configurable arguments is the same as
+              in the terminal. See more details in the `PyTorch official tutorial`_.
+              The configurable arguments are the same as
               ``prof.key_averages().table``
             - ``scheduler=dict(type='tb_trace')``: Profile the performance
-               with tensorboard. See more details in the tutorial
-               `profile with tensorboard`_.
+              with tensorboard. See more details in the tutorial
+              `profile with tensorboard`_.
 
         record_shapes (bool): Save information about operator's input shapes.
             Defaults to False.

--- a/mmengine/hooks/profiler_hook.py
+++ b/mmengine/hooks/profiler_hook.py
@@ -229,19 +229,15 @@ class ProfilerHook(Hook):
     def after_train_epoch(self, runner):
         """Determine if the content is exported."""
         # `after_train_epoch` will also be called in IterBasedTrainLoop.
-        # Call `_export_chrome_trace` only when `self._closed` is False.
+        # Here we check `self._closed` to avoid exiting twice.
         if not self._closed:
             self._export_chrome_trace(runner)
 
     def after_train_iter(self, runner, batch_idx, data_batch, outputs):
         """Update the content according to the schedule, and determine if the
         content is exported."""
-        if self.by_epoch and runner.epoch == 0:
+        if not self._closed:
             self.profiler.step()
-
-        if not self.by_epoch and runner.iter < self.profile_times:
-            self.profiler.step()
-
         if runner.iter == self.profile_times - 1 and not self.by_epoch:
             self._export_chrome_trace(runner)
 

--- a/mmengine/hooks/profiler_hook.py
+++ b/mmengine/hooks/profiler_hook.py
@@ -54,7 +54,6 @@ class ProfilerHook(Hook):
               in the terminal See more details in the `official tutorial`_.
               The configurable arguments is the same as
               ``prof.key_averages().table``
-
             - ``scheduler=dict(type='tb_trace')``: Profile the performance
                with tensorboard. See more details in the tutorial
                `profile with tensorboard`_.

--- a/mmengine/hooks/profiler_hook.py
+++ b/mmengine/hooks/profiler_hook.py
@@ -149,6 +149,7 @@ class ProfilerHook(Hook):
         self.with_flops = with_flops
 
         self.json_trace_path = json_trace_path
+        self._closed = False
 
     def before_run(self, runner):
         """Initialize the profiler.
@@ -227,18 +228,26 @@ class ProfilerHook(Hook):
 
     def after_train_epoch(self, runner):
         """Determine if the content is exported."""
-        if self.by_epoch and runner.epoch == self.profile_times - 1:
+        # `after_train_epoch` will also be called in IterBasedTrainLoop.
+        # Call `_export_chrome_trace` only when `self._closed` is False.
+        if not self._closed:
             self._export_chrome_trace(runner)
 
     def after_train_iter(self, runner, batch_idx, data_batch, outputs):
         """Update the content according to the schedule, and determine if the
         content is exported."""
-        if not self.by_epoch and runner.iter == self.profile_times - 1:
+        if self.by_epoch and runner.epoch == 0:
             self.profiler.step()
+
+        if not self.by_epoch and runner.iter < self.profile_times:
+            self.profiler.step()
+
+        if runner.iter == self.profile_times - 1 and not self.by_epoch:
             self._export_chrome_trace(runner)
 
     def _export_chrome_trace(self, runner):
         """Exporting content."""
+        self._closed = True
         runner.logger.info('profiler may take a few minutes...')
         self.profiler.__exit__(None, None, None)
         if self.json_trace_path is not None:

--- a/mmengine/hooks/profiler_hook.py
+++ b/mmengine/hooks/profiler_hook.py
@@ -233,8 +233,7 @@ class ProfilerHook(Hook):
             self._export_chrome_trace(runner)
 
     def after_train_iter(self, runner, batch_idx, data_batch, outputs):
-        """Update the content according to the schedule, and determine if the
-        content is exported."""
+        """profiler will call `step` method if it is not closed."""
         if not self._closed:
             self.profiler.step()
         if runner.iter == self.profile_times - 1 and not self.by_epoch:

--- a/mmengine/hooks/profiler_hook.py
+++ b/mmengine/hooks/profiler_hook.py
@@ -48,8 +48,7 @@ class ProfilerHook(Hook):
             of generating handler. Defaults to None, which means profiling
             without an on_trace_ready.The Callable type needs to construct its
             own function that can handle 'torch.autograd.profiler.profile'.
-            Two officially recommended ways are provided, namely terminal
-            display or tensorboard display.
+            Two officially recommended ways are provided:
 
             - ``schedule=dict(type='log_trace')``: Print the profiling result
               in the terminal See more details in the `official tutorial`_.

--- a/tests/test_hooks/test_profiler_hook.py
+++ b/tests/test_hooks/test_profiler_hook.py
@@ -85,7 +85,7 @@ class TestProfilerHook(RunnerTestCase):
             dict(
                 type='ProfilerHook',
                 on_trace_ready=dict(
-                    type='tb_trace', dir_name='/home/baymax/RunTime/tb'))
+                    type='tb_trace', dir_name=self.temp_dir.name))
         ]
         runner = self.build_runner(self.epoch_based_cfg)
         runner.train()

--- a/tests/test_hooks/test_profiler_hook.py
+++ b/tests/test_hooks/test_profiler_hook.py
@@ -143,9 +143,6 @@ class TestProfilerHook(RunnerTestCase):
         runner.iter = 9
 
         hook = ProfilerHook(by_epoch=False, profile_times=10, schedule=None)
-        hook.before_run(runner)
-        hook.profiler.__exit__(None, None, None)
-
         hook.profiler = MagicMock()
         hook.after_train_iter(runner, 1, 1, 1)
         hook.profiler.__exit__.assert_called_once()
@@ -154,12 +151,9 @@ class TestProfilerHook(RunnerTestCase):
         hook = ProfilerHook(
             by_epoch=False,
             schedule=dict(wait=1, warmup=1, active=3, repeat=1))
-        hook.before_run(runner)
-        hook.profiler.__exit__(None, None, None)
-
         hook.profiler = MagicMock()
         hook.after_train_iter(runner, 1, 1, 1)
-        hook.profiler.step.assert_not_called()
+        hook.profiler.step.assert_called_once()
 
     def test_with_runner(self):
         self.epoch_based_cfg['custom_hooks'] = [


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

PyTorch profiler support profiling distributed program, however, the current implementation of ProfilerHook's method is decorated by `master_only`, which limits profiler capability.

Besides, If the `scheduler` is configured for the ProfilerHook, an error will be raised like this:

```bash
RuntimeError: stack.size() INTERNAL ASSERT FAILED at "../torch/csrc/autograd/profiler_python.cpp":963, please report a bug to PyTorch. Python replay stack is empty.
```

The main reason is that `self.profile.step` will not be called if scheduler is not None:

https://github.com/open-mmlab/mmengine/blob/8a0fae01f5cfdeeec4bdef4ffd175de1093edd92/mmengine/hooks/profiler_hook.py#L226-L236

which is not consistent with the [official tutorial](69b563dc3b0ea293d5c3a0a89343c75b285983fb)





## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
