### PR TITLE
fix(log): record random seed in log

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -355,6 +355,7 @@ class Runner:
         # `set_randomness`` method
         self._randomness_cfg = randomness
         self.set_randomness(**randomness)
+        self._randomness_cfg['seed'] = self._seed
 
         if experiment_name is not None:
             self._experiment_name = f'{experiment_name}_{self._timestamp}'


### PR DESCRIPTION
## Motivation
When no random seed is specified, the random seed value is recorded as `None` in the log

## Modification
Reassign self._seed to self._randomness_cfg['seed']


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
