### PR TITLE
[Fix] Close MLflowVisBackend only if active (#1144)

### DIFF
--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -785,6 +785,9 @@ class MLflowVisBackend(BaseVisBackend):
 
     def close(self) -> None:
         """Close the mlflow."""
+        if not hasattr(self, '_mlflow'):
+            return
+
         file_paths = dict()
         for filename in scandir(self.cfg.work_dir, self._artifact_suffix,
                                 True):
@@ -796,8 +799,7 @@ class MLflowVisBackend(BaseVisBackend):
         for file_path, dir_path in file_paths.items():
             self._mlflow.log_artifact(file_path, dir_path)
 
-        if hasattr(self, '_mlflow'):
-            self._mlflow.end_run()
+        self._mlflow.end_run()
 
     def _flatten(self, d, parent_key='', sep='.') -> dict:
         """Flatten the dict."""


### PR DESCRIPTION
## Motivation

There is currently a bug (#1144) when running multi GPU training with MLflowVisBackend, wherein the VisBackend seemingly will try to close on multiple processes, when it can only close on one of the processes. Checking for any `self.cfg` in the `close()` method would cause the script to crash.

## Modification

The check `hasattr(self, '_mlflow')` was only done for a ending the mlflow run (`self._mlflow.end_run()`). I propose to check this at the start of the `close()` method instead.