### PR TITLE
[Fix] Correctly record random seed in log

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -355,6 +355,7 @@ class Runner:
         # `set_randomness`` method
         self._randomness_cfg = randomness
         self.set_randomness(**randomness)
+        self._randomness_cfg['seed'] = self._seed
 
         if experiment_name is not None:
             self._experiment_name = f'{experiment_name}_{self._timestamp}'

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -355,7 +355,6 @@ class Runner:
         # `set_randomness`` method
         self._randomness_cfg = randomness
         self.set_randomness(**randomness)
-        self._randomness_cfg['seed'] = self._seed
 
         if experiment_name is not None:
             self._experiment_name = f'{experiment_name}_{self._timestamp}'
@@ -2307,6 +2306,7 @@ class Runner:
         runtime_env = OrderedDict()
         runtime_env.update(env_cfg)
         runtime_env.update(self._randomness_cfg)
+        runtime_env['seed'] = self._seed
         runtime_env['Distributed launcher'] = self._launcher
         runtime_env['Distributed training'] = self._distributed
         runtime_env['GPU number'] = self._world_size


### PR DESCRIPTION
## Motivation

When no random seed is specified, the random seed value is recorded as None in the log

## Modification

Assign self._seed to self._randomness_cfg['seed']

