### PR TITLE
[Enhancement] Handle the case for Multi-Instance GPUs when using cuda_visible_devices

### DIFF
--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -376,7 +376,7 @@ def _get_device_id():
             cuda_visible_devices = list(range(num_device))
         else:
             cuda_visible_devices = cuda_visible_devices.split(',')
-        return int(cuda_visible_devices[local_rank])
+        return cuda_visible_devices[local_rank]
 
 
 def _get_host_info() -> str:

--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -376,7 +376,10 @@ def _get_device_id():
             cuda_visible_devices = list(range(num_device))
         else:
             cuda_visible_devices = cuda_visible_devices.split(',')
-        return str(cuda_visible_devices[local_rank])
+        if cuda_visible_devices[local_rank].isdigit():
+            return int(cuda_visible_devices[local_rank])
+        else:
+            return cuda_visible_devices[local_rank]
 
 
 def _get_host_info() -> str:

--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -376,9 +376,11 @@ def _get_device_id():
             cuda_visible_devices = list(range(num_device))
         else:
             cuda_visible_devices = cuda_visible_devices.split(',')
-        try:
+        if cuda_visible_devices[local_rank].isdigit():
             return int(cuda_visible_devices[local_rank])
-        except ValueError:
+        else:
+            # handle case for Multi-Instance GPUs
+            # see #1148 for details
             return cuda_visible_devices[local_rank]
 
 

--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -378,7 +378,7 @@ def _get_device_id():
             cuda_visible_devices = cuda_visible_devices.split(',')
         try:
             return int(cuda_visible_devices[local_rank])
-        except:
+        except ValueError:
             return cuda_visible_devices[local_rank]
 
 

--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -376,7 +376,7 @@ def _get_device_id():
             cuda_visible_devices = list(range(num_device))
         else:
             cuda_visible_devices = cuda_visible_devices.split(',')
-        return cuda_visible_devices[local_rank]
+        return str(cuda_visible_devices[local_rank])
 
 
 def _get_host_info() -> str:

--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -376,9 +376,9 @@ def _get_device_id():
             cuda_visible_devices = list(range(num_device))
         else:
             cuda_visible_devices = cuda_visible_devices.split(',')
-        if cuda_visible_devices[local_rank].isdigit():
+        try:
             return int(cuda_visible_devices[local_rank])
-        else:
+        except:
             return cuda_visible_devices[local_rank]
 
 

--- a/tests/test_logging/test_logger.py
+++ b/tests/test_logging/test_logger.py
@@ -231,29 +231,29 @@ def test_get_device_id():
     # cuda is not available and local_rank is not set
     with patch('torch.cuda.is_available', lambda: False), \
          patch_env(None, '0,1,2,3'):
-        assert _get_device_id() == '0'
+        assert _get_device_id() == 0
 
     # cuda is not available and local_rank is set
     with patch('torch.cuda.is_available', lambda: False), \
          patch_env('1', '0,1,2,3'):
-        assert _get_device_id() == '1'
+        assert _get_device_id() == 1
 
     # CUDA_VISIBLE_DEVICES will not influence non-cuda device
     with patch('torch.cuda.is_available', lambda: False), \
          patch_env('1', '0,100,2,3'):
-        assert _get_device_id() == '1'
+        assert _get_device_id() == 1
 
     # cuda is available and local_rank is not set
     with patch('torch.cuda.is_available', lambda: True), \
          patch_env(None, '0,1,2,3'):
-        assert _get_device_id() == '0'
+        assert _get_device_id() == 0
 
     # cuda is available and local_rank is set
     with patch('torch.cuda.is_available', lambda: True), \
          patch_env('2', '0,1,2,3'):
-        assert _get_device_id() == '2'
+        assert _get_device_id() == 2
 
     # CUDA_VISIBLE_DEVICES worked
     with patch('torch.cuda.is_available', lambda: True), \
          patch_env('2', '0,1,3,5'):
-        assert _get_device_id() == '3'
+        assert _get_device_id() == 3

--- a/tests/test_logging/test_logger.py
+++ b/tests/test_logging/test_logger.py
@@ -231,29 +231,29 @@ def test_get_device_id():
     # cuda is not available and local_rank is not set
     with patch('torch.cuda.is_available', lambda: False), \
          patch_env(None, '0,1,2,3'):
-        assert _get_device_id() == "0"
+        assert _get_device_id() == '0'
 
     # cuda is not available and local_rank is set
     with patch('torch.cuda.is_available', lambda: False), \
          patch_env('1', '0,1,2,3'):
-        assert _get_device_id() == "1"
+        assert _get_device_id() == '1'
 
     # CUDA_VISIBLE_DEVICES will not influence non-cuda device
     with patch('torch.cuda.is_available', lambda: False), \
          patch_env('1', '0,100,2,3'):
-        assert _get_device_id() == "1"
+        assert _get_device_id() == '1'
 
     # cuda is available and local_rank is not set
     with patch('torch.cuda.is_available', lambda: True), \
          patch_env(None, '0,1,2,3'):
-        assert _get_device_id() == "0"
+        assert _get_device_id() == '0'
 
     # cuda is available and local_rank is set
     with patch('torch.cuda.is_available', lambda: True), \
          patch_env('2', '0,1,2,3'):
-        assert _get_device_id() == "2"
+        assert _get_device_id() == '2'
 
     # CUDA_VISIBLE_DEVICES worked
     with patch('torch.cuda.is_available', lambda: True), \
          patch_env('2', '0,1,3,5'):
-        assert _get_device_id() == "3"
+        assert _get_device_id() == '3'

--- a/tests/test_logging/test_logger.py
+++ b/tests/test_logging/test_logger.py
@@ -231,29 +231,29 @@ def test_get_device_id():
     # cuda is not available and local_rank is not set
     with patch('torch.cuda.is_available', lambda: False), \
          patch_env(None, '0,1,2,3'):
-        assert _get_device_id() == 0
+        assert _get_device_id() == "0"
 
     # cuda is not available and local_rank is set
     with patch('torch.cuda.is_available', lambda: False), \
          patch_env('1', '0,1,2,3'):
-        assert _get_device_id() == 1
+        assert _get_device_id() == "1"
 
     # CUDA_VISIBLE_DEVICES will not influence non-cuda device
     with patch('torch.cuda.is_available', lambda: False), \
          patch_env('1', '0,100,2,3'):
-        assert _get_device_id() == 1
+        assert _get_device_id() == "1"
 
     # cuda is available and local_rank is not set
     with patch('torch.cuda.is_available', lambda: True), \
          patch_env(None, '0,1,2,3'):
-        assert _get_device_id() == 0
+        assert _get_device_id() == "0"
 
     # cuda is available and local_rank is set
     with patch('torch.cuda.is_available', lambda: True), \
          patch_env('2', '0,1,2,3'):
-        assert _get_device_id() == 2
+        assert _get_device_id() == "2"
 
     # CUDA_VISIBLE_DEVICES worked
     with patch('torch.cuda.is_available', lambda: True), \
          patch_env('2', '0,1,3,5'):
-        assert _get_device_id() == 3
+        assert _get_device_id() == "3"


### PR DESCRIPTION
## Motivation

[Issue](https://github.com/open-mmlab/mmengine/issues/1148)

## Modification

Deprecate the int() conversion in 

[mmengine/mmengine/logging/logger.py](https://github.com/open-mmlab/mmengine/blob/4bc2fe1aaec2d7d1464b11d50f6165494f62ef18/mmengine/logging/logger.py#L379)

Line 379 in [4bc2fe1](https://github.com/open-mmlab/mmengine/commit/4bc2fe1aaec2d7d1464b11d50f6165494f62ef18)
