### PR TITLE
[Fix] Update the best_ckpt of checkpoint if the current epoch has the best performance

### DIFF
--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -145,7 +145,6 @@ class CheckpointHook(Hook):
         self.save_param_scheduler = save_param_scheduler
         self.out_dir = out_dir  # type: ignore
         self.max_keep_ckpts = max_keep_ckpts
-
         self.save_last = save_last
         self.args = kwargs
 
@@ -417,7 +416,6 @@ class CheckpointHook(Hook):
                 current_ckpt = runner.epoch + 1
             else:
                 current_ckpt = runner.iter + 1
-
             redundant_ckpts = range(
                 current_ckpt - self.max_keep_ckpts * self.interval, 0,
                 -self.interval)

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -428,8 +428,6 @@ class CheckpointHook(Hook):
                     self.out_dir, self.filename_tmpl.format(step))
                 if self.file_backend.isfile(ckpt_path):
                     self.file_backend.remove(ckpt_path)
-                else:
-                    break
 
             self.keep_ckpt_ids.append(current_ckpt)
 

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -404,7 +404,8 @@ class CheckpointHook(Hook):
         # remove other checkpoints before save checkpoint to make the
         # self.keep_ckpt_ids are saved as expected
         if self.max_keep_ckpts > 0:
-            # _save_checkpoint may be called multiple times in one epoch
+            # _save_checkpoint and _save_best_checkpoint may call this
+            # _save_checkpoint_with_step in one epoch
             if len(self.keep_ckpt_ids) > 0 and self.keep_ckpt_ids[-1] == step:
                 pass
             else:

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -550,8 +550,7 @@ class CheckpointHook(Hook):
         # or `after_train_iter` stage only keep the previous best checkpoint
         # not the current best checkpoint which causes the current best
         # checkpoint can not be removed when resuming training.
-        if (best_ckpt_updated and self.last_ckpt is not None
-                and is_main_process()):
+        if best_ckpt_updated and self.last_ckpt is not None:
             self._save_checkpoint_with_step(runner, cur_time, meta)
 
     def _init_rule(self, rules, key_indicators) -> None:

--- a/mmengine/hooks/checkpoint_hook.py
+++ b/mmengine/hooks/checkpoint_hook.py
@@ -409,7 +409,7 @@ class CheckpointHook(Hook):
             if len(self.keep_ckpt_ids) > 0 and self.keep_ckpt_ids[-1] == step:
                 pass
             else:
-                if len(self.keep_ckpt_ids) >= self.max_keep_ckpts:
+                if len(self.keep_ckpt_ids) == self.max_keep_ckpts:
                     _step = self.keep_ckpt_ids.popleft()
                     if is_main_process():
                         ckpt_path = self.file_backend.join_path(

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -2090,7 +2090,7 @@ class Runner:
         file_client_args: Optional[dict] = None,
         save_optimizer: bool = True,
         save_param_scheduler: bool = True,
-        meta: dict = None,
+        meta: Optional[dict] = None,
         by_epoch: bool = True,
         backend_args: Optional[dict] = None,
     ):
@@ -2112,8 +2112,8 @@ class Runner:
                 to the checkpoint. Defaults to True.
             meta (dict, optional): The meta information to be saved in the
                 checkpoint. Defaults to None.
-            by_epoch (bool): Whether the scheduled momentum is updated by
-                epochs. Defaults to True.
+            by_epoch (bool): Decide the number of epoch or iteration saved in
+                checkpoint. Defaults to True.
             backend_args (dict, optional): Arguments to instantiate the
                 prefix of uri corresponding backend. Defaults to None.
                 New in v0.2.0.
@@ -2129,9 +2129,11 @@ class Runner:
             # `self.call_hook('after_train_epoch)` but `save_checkpoint` is
             # called by `after_train_epoch`` method of `CheckpointHook` so
             # `epoch` should be `self.epoch + 1`
-            meta.update(epoch=self.epoch + 1, iter=self.iter)
+            meta.setdefault('epoch', self.epoch + 1)
+            meta.setdefault('iter', self.iter)
         else:
-            meta.update(epoch=self.epoch, iter=self.iter + 1)
+            meta.setdefault('epoch', self.epoch)
+            meta.setdefault('iter', self.iter + 1)
 
         if file_client_args is not None:
             warnings.warn(

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -499,11 +499,13 @@ class TestCheckpointHook(RunnerTestCase):
         runner = self.build_runner(cfg)
         runner.train()
         self.assertTrue(
-            osp.isfile(osp.join(cfg.work_dir, f'{training_type}_10.pth')))
+            osp.isfile(osp.join(cfg.work_dir, f'{training_type}_11.pth')))
 
-        for i in range(10):
+        for i in range(11):
             self.assertFalse(
                 osp.isfile(osp.join(cfg.work_dir, f'{training_type}_{i}.pth')))
+
+        cfg.default_hooks.checkpoint.max_keep_ckpts = -1
 
         # Test filename_tmpl
         cfg.default_hooks.checkpoint.filename_tmpl = 'test_{}.pth'
@@ -517,8 +519,12 @@ class TestCheckpointHook(RunnerTestCase):
         cfg.train_cfg.val_interval = 1
         runner = self.build_runner(cfg)
         runner.train()
-        self.assertTrue(
-            osp.isfile(osp.join(cfg.work_dir, 'best_test_acc_test_5.pth')))
+        best_ckpt = osp.join(cfg.work_dir, 'best_test_acc_test_5.pth')
+        self.assertTrue(osp.isfile(best_ckpt))
+
+        ckpt = torch.load(osp.join(cfg.work_dir, 'test_5.pth'))
+        self.assertEqual(best_ckpt,
+                         ckpt['message_hub']['runtime_info']['best_ckpt'])
 
         # test save published keys
         cfg.default_hooks.checkpoint.published_keys = ['meta', 'state_dict']

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -534,7 +534,8 @@ class TestCheckpointHook(RunnerTestCase):
         cfg.train_cfg.val_interval = 1
         runner = self.build_runner(cfg)
         runner.train()
-        best_ckpt = osp.join(cfg.work_dir, 'best_test_acc_iter_5.pth')
+        best_ckpt = osp.join(cfg.work_dir,
+                             f'best_test_acc_{training_type}_5.pth')
         self.assertTrue(osp.isfile(best_ckpt))
 
         ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_5.pth'))

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -572,20 +572,24 @@ class TestCheckpointHook(RunnerTestCase):
         cfg.train_cfg.val_interval = 1
         runner = self.build_runner(cfg)
         runner.train()
-        best_ckpt = osp.join(cfg.work_dir,
-                             f'best_test_acc_{training_type}_5.pth')
-        self.assertTrue(osp.isfile(best_ckpt))
+        best_ckpt_path = osp.join(cfg.work_dir,
+                                  f'best_test_acc_{training_type}_5.pth')
+        best_ckpt = torch.load(best_ckpt_path)
 
         ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_5.pth'))
-        self.assertEqual(best_ckpt,
+        self.assertEqual(best_ckpt_path,
                          ckpt['message_hub']['runtime_info']['best_ckpt'])
 
         if training_type == 'epoch':
             self.assertEqual(ckpt['meta']['epoch'], 5)
             self.assertEqual(ckpt['meta']['iter'], 20)
+            self.assertEqual(best_ckpt['meta']['epoch'], 5)
+            self.assertEqual(best_ckpt['meta']['iter'], 20)
         else:
             self.assertEqual(ckpt['meta']['epoch'], 0)
             self.assertEqual(ckpt['meta']['iter'], 5)
+            self.assertEqual(best_ckpt['meta']['epoch'], 0)
+            self.assertEqual(best_ckpt['meta']['iter'], 5)
 
         self.clear_work_dir()
 
@@ -597,24 +601,26 @@ class TestCheckpointHook(RunnerTestCase):
         cfg.train_cfg.val_interval = 1
         runner = self.build_runner(cfg)
         runner.train()
-        best_ckpt = osp.join(cfg.work_dir,
-                             f'best_test_acc_{training_type}_5.pth')
-        self.assertTrue(osp.isfile(best_ckpt))
+        best_ckpt_path = osp.join(cfg.work_dir,
+                                  f'best_test_acc_{training_type}_5.pth')
+        best_ckpt = torch.load(best_ckpt_path)
 
         # if the current ckpt is the best, the interval will be ignored the
         # the ckpt will also be saved
-        path = osp.join(cfg.work_dir, f'{training_type}_5.pth')
-        self.assertTrue(osp.isfile(path))
-        ckpt = torch.load(path)
-        self.assertEqual(best_ckpt,
+        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_5.pth'))
+        self.assertEqual(best_ckpt_path,
                          ckpt['message_hub']['runtime_info']['best_ckpt'])
 
         if training_type == 'epoch':
             self.assertEqual(ckpt['meta']['epoch'], 5)
             self.assertEqual(ckpt['meta']['iter'], 20)
+            self.assertEqual(best_ckpt['meta']['epoch'], 5)
+            self.assertEqual(best_ckpt['meta']['iter'], 20)
         else:
             self.assertEqual(ckpt['meta']['epoch'], 0)
             self.assertEqual(ckpt['meta']['iter'], 5)
+            self.assertEqual(best_ckpt['meta']['epoch'], 0)
+            self.assertEqual(best_ckpt['meta']['iter'], 5)
 
         # test save published keys
         cfg = copy.deepcopy(common_cfg)

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -429,34 +429,37 @@ class TestCheckpointHook(RunnerTestCase):
 
     @parameterized.expand([['iter'], ['epoch']])
     def test_with_runner(self, training_type):
-        # Test interval in epoch based training
-        save_iterval = 2
-        cfg = copy.deepcopy(getattr(self, f'{training_type}_based_cfg'))
-        setattr(cfg.train_cfg, f'max_{training_type}s', 11)
+        common_cfg = getattr(self, f'{training_type}_based_cfg')
+        setattr(common_cfg.train_cfg, f'max_{training_type}s', 11)
         checkpoint_cfg = dict(
             type='CheckpointHook',
-            interval=save_iterval,
+            interval=2,
             by_epoch=training_type == 'epoch')
-        cfg.default_hooks = dict(checkpoint=checkpoint_cfg)
+        common_cfg.default_hooks = dict(checkpoint=checkpoint_cfg)
+
+        # Test interval in epoch based training
+        cfg = copy.deepcopy(common_cfg)
         runner = self.build_runner(cfg)
         runner.train()
 
         for i in range(1, 11):
-            if i == 0:
-                self.assertFalse(
-                    osp.isfile(
-                        osp.join(cfg.work_dir, f'{training_type}_{i}.pth')))
-            if i % 2 == 0:
-                self.assertTrue(
-                    osp.isfile(
-                        osp.join(cfg.work_dir, f'{training_type}_{i}.pth')))
+            self.assertEqual(
+                osp.isfile(osp.join(cfg.work_dir, f'{training_type}_{i}.pth')),
+                i % 2 == 0)
 
+        # save_last=True
         self.assertTrue(
             osp.isfile(osp.join(cfg.work_dir, f'{training_type}_11.pth')))
 
+        self.clear_work_dir()
+
         # Test save_optimizer=False
+        cfg = copy.deepcopy(common_cfg)
+        runner = self.build_runner(cfg)
+        runner.train()
         ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
         self.assertIn('optimizer', ckpt)
+
         cfg.default_hooks.checkpoint.save_optimizer = False
         runner = self.build_runner(cfg)
         runner.train()
@@ -464,6 +467,7 @@ class TestCheckpointHook(RunnerTestCase):
         self.assertNotIn('optimizer', ckpt)
 
         # Test save_param_scheduler=False
+        cfg = copy.deepcopy(common_cfg)
         cfg.param_scheduler = [
             dict(
                 type='LinearLR',
@@ -483,7 +487,10 @@ class TestCheckpointHook(RunnerTestCase):
         ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
         self.assertNotIn('param_schedulers', ckpt)
 
+        self.clear_work_dir()
+
         # Test out_dir
+        cfg = copy.deepcopy(common_cfg)
         out_dir = osp.join(self.temp_dir.name, 'out_dir')
         cfg.default_hooks.checkpoint.out_dir = out_dir
         runner = self.build_runner(cfg)
@@ -493,8 +500,10 @@ class TestCheckpointHook(RunnerTestCase):
                 osp.join(out_dir, osp.basename(cfg.work_dir),
                          f'{training_type}_11.pth')))
 
-        # Test max_keep_ckpts.
-        del cfg.default_hooks.checkpoint.out_dir
+        self.clear_work_dir()
+
+        # Test max_keep_ckpts
+        cfg = copy.deepcopy(common_cfg)
         cfg.default_hooks.checkpoint.max_keep_ckpts = 1
         runner = self.build_runner(cfg)
         runner.train()
@@ -505,31 +514,41 @@ class TestCheckpointHook(RunnerTestCase):
             self.assertFalse(
                 osp.isfile(osp.join(cfg.work_dir, f'{training_type}_{i}.pth')))
 
-        cfg.default_hooks.checkpoint.max_keep_ckpts = -1
+        self.clear_work_dir()
 
         # Test filename_tmpl
+        cfg = copy.deepcopy(common_cfg)
         cfg.default_hooks.checkpoint.filename_tmpl = 'test_{}.pth'
         runner = self.build_runner(cfg)
         runner.train()
-        self.assertTrue(osp.isfile(osp.join(cfg.work_dir, 'test_10.pth')))
+        self.assertTrue(osp.isfile(osp.join(cfg.work_dir, 'test_11.pth')))
+
+        self.clear_work_dir()
 
         # Test save_best
+        cfg = copy.deepcopy(common_cfg)
+        cfg.default_hooks.checkpoint.interval = 1
         cfg.default_hooks.checkpoint.save_best = 'test/acc'
         cfg.val_evaluator = dict(type='TriangleMetric', length=11)
         cfg.train_cfg.val_interval = 1
         runner = self.build_runner(cfg)
         runner.train()
-        best_ckpt = osp.join(cfg.work_dir, 'best_test_acc_test_5.pth')
+        best_ckpt = osp.join(cfg.work_dir, 'best_test_acc_iter_5.pth')
         self.assertTrue(osp.isfile(best_ckpt))
 
-        ckpt = torch.load(osp.join(cfg.work_dir, 'test_5.pth'))
+        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_5.pth'))
         self.assertEqual(best_ckpt,
                          ckpt['message_hub']['runtime_info']['best_ckpt'])
 
+        self.clear_work_dir()
+
         # test save published keys
+        cfg = copy.deepcopy(common_cfg)
         cfg.default_hooks.checkpoint.published_keys = ['meta', 'state_dict']
         runner = self.build_runner(cfg)
         runner.train()
         ckpt_files = os.listdir(runner.work_dir)
         self.assertTrue(
             any(re.findall(r'-[\d\w]{8}\.pth', file) for file in ckpt_files))
+
+        self.clear_work_dir()

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -433,12 +433,13 @@ class TestCheckpointHook(RunnerTestCase):
         setattr(common_cfg.train_cfg, f'max_{training_type}s', 11)
         checkpoint_cfg = dict(
             type='CheckpointHook',
-            interval=2,
+            interval=1,
             by_epoch=training_type == 'epoch')
         common_cfg.default_hooks = dict(checkpoint=checkpoint_cfg)
 
         # Test interval in epoch based training
         cfg = copy.deepcopy(common_cfg)
+        cfg.default_hooks.checkpoint.interval = 2
         runner = self.build_runner(cfg)
         runner.train()
 
@@ -528,7 +529,6 @@ class TestCheckpointHook(RunnerTestCase):
 
         # Test save_best
         cfg = copy.deepcopy(common_cfg)
-        cfg.default_hooks.checkpoint.interval = 1
         cfg.default_hooks.checkpoint.save_best = 'test/acc'
         cfg.val_evaluator = dict(type='TriangleMetric', length=11)
         cfg.train_cfg.val_interval = 1


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

save checkpoint again to update the best_score and best_ckpt stored in message_hub because the checkpoint saved in `after_train_epoch` or `after_train_iter` stage only keeps the previous best checkpoint not the current best checkpoint which causes the current best checkpoint can not to be removed when resuming training.

## Modification

- save checkpoint again to update best_ckpt of ckpt

- If the current checkpoint is the best checkpoint, it will be saved without the effect of interval.

  For example, if interval=2 and the current epoch is 5, only one model weight without optimizer state will be saved, but now the checkpoint with optimizer state will also be saved.

- update the logic to remove outdated checkpoints

  For the same reason as above, these checkpoints that will be deleted are somewhat different from the previous behaviour (before this PR). For example, if interval=2 and the 5th epcoh is the best checkpoint, epoch_2.pth, epoch_4.pth will be kept, and now there will be one more epoch_5.pth. Supposing max_keep_ckpts=1, only epoch_4.pth will be kept before, and now only epoch_4.pth will be kept. I think this is an acceptable change.

- save keep_ckpt_ids to ckpt for resuming training

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
