### PR TITLE
Refine the error message when auto_scale_lr is not set correctly

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1978,11 +1978,10 @@ class Runner:
                 if (self.auto_scale_lr is None
                         or self.auto_scale_lr.get('enable', False)):
                     raise RuntimeError(
-                        'Number of GPU used for current experiment is not '
-                        'consistent with resuming from checkpoint, '
-                        'which may result in poor performance due to the '
-                        'learning rate. If you want the learning rate to '
-                        'be automatically adjusted, set the '
+                        'Number of GPUs used for current experiment is not '
+                        'consistent with the checkpoint being resumed from. '
+                        'This will result in poor performance due to the '
+                        'learning rate. You must set the '
                         '`auto_scale_lr` parameter for Runner and make '
                         '`auto_scale_lr["enable"]=True`.')
                 else:

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1975,16 +1975,22 @@ class Runner:
             if (previous_gpu_ids is not None and len(previous_gpu_ids) > 0
                     and len(previous_gpu_ids) != self._world_size):
                 # TODO, should we modify the iteration?
-                self.logger.info(
-                    'Number of GPU used for current experiment is not '
-                    'consistent with resuming from checkpoint')
                 if (self.auto_scale_lr is None
                         or self.auto_scale_lr.get('enable', False)):
                     raise RuntimeError(
-                        'Cannot automatically rescale lr in resuming. Please '
-                        'make sure the number of GPU is consistent with the '
-                        'previous training state resuming from the checkpoint '
-                        'or set `enable` in `auto_scale_lr` to False.')
+                         'Number of GPU used for current experiment is not '
+                         'consistent with resuming from checkpoint, '
+                         'which may result in poor performance due to the '
+                         'learning rate. If you want the learning rate to '
+                         'be automatically adjusted, set the '
+                         '`auto_scale_lr` parameter for Runner and make '
+                         '`auto_scale_lr["enable"]=True`.')
+               else:
+                   self.logger.info(
+                     'Number of GPU used for current experiment is not '
+                     'consistent with resuming from checkpoint but the
+                     'leaning rate will be adjusted according to the '
+                     f'setting in auto_scale_lr={self.auto_scale_lr}')
 
         # resume random seed
         resumed_seed = checkpoint['meta'].get('seed', None)

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1978,19 +1978,19 @@ class Runner:
                 if (self.auto_scale_lr is None
                         or self.auto_scale_lr.get('enable', False)):
                     raise RuntimeError(
-                         'Number of GPU used for current experiment is not '
-                         'consistent with resuming from checkpoint, '
-                         'which may result in poor performance due to the '
-                         'learning rate. If you want the learning rate to '
-                         'be automatically adjusted, set the '
-                         '`auto_scale_lr` parameter for Runner and make '
-                         '`auto_scale_lr["enable"]=True`.')
-               else:
-                   self.logger.info(
-                     'Number of GPU used for current experiment is not '
-                     'consistent with resuming from checkpoint but the
-                     'leaning rate will be adjusted according to the '
-                     f'setting in auto_scale_lr={self.auto_scale_lr}')
+                        'Number of GPU used for current experiment is not '
+                        'consistent with resuming from checkpoint, '
+                        'which may result in poor performance due to the '
+                        'learning rate. If you want the learning rate to '
+                        'be automatically adjusted, set the '
+                        '`auto_scale_lr` parameter for Runner and make '
+                        '`auto_scale_lr["enable"]=True`.')
+                else:
+                    self.logger.info(
+                        'Number of GPU used for current experiment is not '
+                        'consistent with resuming from checkpoint but the '
+                        'leaning rate will be adjusted according to the '
+                        f'setting in auto_scale_lr={self.auto_scale_lr}')
 
         # resume random seed
         resumed_seed = checkpoint['meta'].get('seed', None)

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1979,12 +1979,12 @@ class Runner:
                     'Number of GPU used for current experiment is not '
                     'consistent with resuming from checkpoint')
                 if (self.auto_scale_lr is None
-                        or not self.auto_scale_lr.get('enable', False)):
+                        or self.auto_scale_lr.get('enable', False)):
                     raise RuntimeError(
                         'Cannot automatically rescale lr in resuming. Please '
                         'make sure the number of GPU is consistent with the '
                         'previous training state resuming from the checkpoint '
-                        'or set `enable` in `auto_scale_lr to False.')
+                        'or set `enable` in `auto_scale_lr` to False.')
 
         # resume random seed
         resumed_seed = checkpoint['meta'].get('seed', None)

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -1976,7 +1976,7 @@ class Runner:
                     and len(previous_gpu_ids) != self._world_size):
                 # TODO, should we modify the iteration?
                 if (self.auto_scale_lr is None
-                        or self.auto_scale_lr.get('enable', False)):
+                        or not self.auto_scale_lr.get('enable', False)):
                     raise RuntimeError(
                         'Number of GPUs used for current experiment is not '
                         'consistent with the checkpoint being resumed from. '


### PR DESCRIPTION
## Motivation

RuntimeError when attempting to resume a run. It seems the logic for triggering the runtime error is incorrect (or the error message is incorrect, but this PR is based on the assumption that the error message is correct).

## Modification

Remove a `not` to fix the logic. This makes the RuntimeError trigger if `self.auto_scale_lr` has a key called "enable" and that key is `True`. This is the desired logic if we consider the error message which asks the user to set "enable" to `False` to avoid the error.

## Checklist

I did this in 30 seconds so admittedly I haven't followed the checklist. I'd be happy to file an issue and allow a core maintainer to carry on from here. Please let me know.
