### PR TITLE
Add allow_config_update option

### DIFF
--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -347,6 +347,10 @@ class WandbVisBackend(BaseVisBackend):
             input parameters.
             See `wandb.init <https://docs.wandb.ai/ref/python/init>`_ for
             details. Defaults to None.
+        allow_config_update (bool, optional): Uses this value for
+            `allow_val_change` in the call to `wandb.config.update`. One may
+            wish to set this to `True` if the are resuming runs and have any
+            changes to the MMDetection config.
         define_metric_cfg (dict or list[dict], optional):
             When a dict is set, it is a dict of metrics and summary for
             ``wandb.define_metric``.
@@ -379,12 +383,14 @@ class WandbVisBackend(BaseVisBackend):
     def __init__(self,
                  save_dir: str,
                  init_kwargs: Optional[dict] = None,
+                 allow_config_update: Optional[bool] = None,
                  define_metric_cfg: Union[dict, list, None] = None,
                  commit: Optional[bool] = True,
                  log_code_name: Optional[str] = None,
                  watch_kwargs: Optional[dict] = None):
         super().__init__(save_dir)
         self._init_kwargs = init_kwargs
+        self._allow_config_update = allow_config_update
         self._define_metric_cfg = define_metric_cfg
         self._commit = commit
         self._log_code_name = log_code_name
@@ -434,7 +440,7 @@ class WandbVisBackend(BaseVisBackend):
         Args:
             config (Config): The Config object
         """
-        self._wandb.config.update(dict(config))
+        self._wandb.config.update(dict(config), self._allow_config_update)
         self._wandb.run.log_code(name=self._log_code_name)
 
     @force_init_env

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -349,8 +349,8 @@ class WandbVisBackend(BaseVisBackend):
             details. Defaults to None.
         allow_config_update (bool, optional): Uses this value for
             `allow_val_change` in the call to `wandb.config.update`. One may
-            wish to set this to `True` if the are resuming runs and have any
-            changes to the MMDetection config.
+            wish to set this to `True` if they are resuming a run and have
+            any changes to the MMDetection config.
         define_metric_cfg (dict or list[dict], optional):
             When a dict is set, it is a dict of metrics and summary for
             ``wandb.define_metric``.


### PR DESCRIPTION
## Motivation

Sometimes one wishes to resume runs with WandB enabled. But for resuming runs sometimes it is necessary to change some parameters in the MMDetection config. For example, on first attempting a run, one might set `load_from`. But then when resuming the run, `load_from` should be set to `None` to let the resumer pick the latest checkpoint. `wandb.config.update` then raises a `ConfigError` because we are attempting to pass in a different config key. WandB offers a `allow_val_change` option but this is not exposed by the MMDetection API. (note: it's possible to pass `allow_val_change` as `init_kwargs` for WandB but this is a **different** parameter to the one used in `wandb.config.update`)

## Modification

Adds and option to `WandbVisBackend` called `allow_config_update`. Adds a private attribute `_allow_config_update`. Passes `_allow_config_update` to `wandb.config.update`.

## BC-breaking (Optional)

Not BC-breaking.
