### PR TITLE
Add cv2 graphics / headless extras to setup.py

### DIFF
--- a/requirements/cv2-graphics.txt
+++ b/requirements/cv2-graphics.txt
@@ -1,0 +1,6 @@
+opencv-python>=4.5.5.64  ; python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
+opencv-python>=4.5.4.58  ; python_version < '3.11' and python_version >= '3.10'    # Python 3.10
+opencv-python>=3.4.15.55  ; python_version < '3.10' and python_version >= '3.9'    # Python 3.9
+opencv-python>=3.4.15.55  ; python_version < '3.9' and python_version >= '3.8'    # Python 3.8
+opencv-python>=3.4.15.55  ; python_version < '3.8' and python_version >= '3.7'    # Python 3.7
+opencv-python>=3.4.13.47  ; python_version < '3.7' and python_version >= '3.6'    # Python 3.6

--- a/requirements/cv2-headless.txt
+++ b/requirements/cv2-headless.txt
@@ -1,0 +1,6 @@
+opencv-python-headless>=4.5.5.64  ; python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
+opencv-python-headless>=4.5.4.58  ; python_version < '3.11' and python_version >= '3.10'    # Python 3.10
+opencv-python-headless>=3.4.15.55  ; python_version < '3.10' and python_version >= '3.9'    # Python 3.9
+opencv-python-headless>=3.4.15.55  ; python_version < '3.9' and python_version >= '3.8'    # Python 3.8
+opencv-python-headless>=3.4.15.55  ; python_version < '3.8' and python_version >= '3.7'    # Python 3.7
+opencv-python-headless>=3.4.13.47  ; python_version < '3.7' and python_version >= '3.6'    # Python 3.6

--- a/setup.py
+++ b/setup.py
@@ -31,13 +31,15 @@ def get_version():
     return locals()['__version__']
 
 
-def parse_requirements(fname='requirements/runtime.txt', with_version=True):
+def parse_requirements(fname='requirements.txt', versions=False):
     """Parse the package dependencies listed in a requirements file but strips
     specific versioning information.
 
     Args:
         fname (str): path to requirements file
-        with_version (bool, default=False): if True include version specs
+        versions (bool | str, default=False):
+            If true include version specs.
+            If strict, then pin to the minimum version.
 
     Returns:
         List[str]: list of requirements items
@@ -45,60 +47,85 @@ def parse_requirements(fname='requirements/runtime.txt', with_version=True):
     CommandLine:
         python -c "import setup; print(setup.parse_requirements())"
     """
-    import re
     import sys
-    from os.path import exists
+    from os.path import dirname, exists, join
     require_fpath = fname
 
-    def parse_line(line):
-        """Parse information from a line in a requirements text file."""
+    def parse_line(line, dpath=''):
+        """Parse information from a line in a requirements text file.
+
+        line = 'git+https://a.com/somedep@sometag#egg=SomeDep'
+        line = '-e git+https://a.com/somedep@sometag#egg=SomeDep'
+        """
+        # Remove inline comments
+        comment_pos = line.find(' #')
+        if comment_pos > -1:
+            line = line[:comment_pos]
+
         if line.startswith('-r '):
             # Allow specifying requirements in other files
-            target = line.split(' ')[1]
+            target = join(dpath, line.split(' ')[1])
             for info in parse_require_file(target):
                 yield info
         else:
+            # See: https://www.python.org/dev/peps/pep-0508/
             info = {'line': line}
             if line.startswith('-e '):
                 info['package'] = line.split('#egg=')[1]
             else:
+                if '--find-links' in line:
+                    # setuptools does not seem to handle find links
+                    line = line.split('--find-links')[0]
+                if ';' in line:
+                    pkgpart, platpart = line.split(';')
+                    # Handle platform specific dependencies
+                    # setuptools.readthedocs.io/en/latest/setuptools.html
+                    # #declaring-platform-specific-dependencies
+                    plat_deps = platpart.strip()
+                    info['platform_deps'] = plat_deps
+                else:
+                    pkgpart = line
+                    platpart = None
+
                 # Remove versioning from the package
                 pat = '(' + '|'.join(['>=', '==', '>']) + ')'
-                parts = re.split(pat, line, maxsplit=1)
+                parts = re.split(pat, pkgpart, maxsplit=1)
                 parts = [p.strip() for p in parts]
 
                 info['package'] = parts[0]
                 if len(parts) > 1:
                     op, rest = parts[1:]
-                    if ';' in rest:
-                        # Handle platform specific dependencies
-                        # http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies
-                        version, platform_deps = map(str.strip,
-                                                     rest.split(';'))
-                        info['platform_deps'] = platform_deps
-                    else:
-                        version = rest  # NOQA
+                    version = rest  # NOQA
                     info['version'] = (op, version)
             yield info
 
     def parse_require_file(fpath):
+        dpath = dirname(fpath)
         with open(fpath) as f:
             for line in f.readlines():
                 line = line.strip()
                 if line and not line.startswith('#'):
-                    yield from parse_line(line)
+                    yield from parse_line(line, dpath=dpath)
 
     def gen_packages_items():
         if exists(require_fpath):
             for info in parse_require_file(require_fpath):
                 parts = [info['package']]
-                if with_version and 'version' in info:
-                    parts.extend(info['version'])
+                if versions and 'version' in info:
+                    if versions == 'strict':
+                        # In strict mode, we pin to the minimum version
+                        if info['version']:
+                            # Only replace the first >= instance
+                            verstr = ''.join(info['version']).replace(
+                                '>=', '==', 1)
+                            parts.append(verstr)
+                    else:
+                        parts.extend(info['version'])
                 if not sys.version.startswith('3.4'):
                     # apparently package_deps are broken in 3.4
-                    platform_deps = info.get('platform_deps')
-                    if platform_deps is not None:
-                        parts.append(';' + platform_deps)
+                    plat_deps = info.get('platform_deps')
+                    if plat_deps is not None:
+                        parts.append(';' + plat_deps)
                 item = ''.join(parts)
                 yield item
 
@@ -106,7 +133,8 @@ def parse_requirements(fname='requirements/runtime.txt', with_version=True):
     return packages
 
 
-install_requires = parse_requirements()
+install_requires = parse_requirements('requirements/runtime.txt')
+
 try:
     # OpenCV installed via conda.
     import cv2  # NOQA: F401
@@ -148,5 +176,7 @@ setup(
     extras_require={
         'all': parse_requirements('requirements.txt'),
         'tests': parse_requirements('requirements/tests.txt'),
+        'cv2-headless': parse_requirements('requirements/cv2-headless'),
+        'cv2-graphics': parse_requirements('requirements/cv2-graphics'),
     },
 )


### PR DESCRIPTION
This PR is related to a similar one for mmcv: https://github.com/open-mmlab/mmcv/pull/2775

I've copy/pasted the body of that PR but `s/mmcv/mmengine/g`

## Motivation

The mmengine library requires the cv2 module, but there are two flavors of the module that different users may want in different circumstances, either opencv-python or opencv-python-headless. These libraries are incompatible with each other, and if you incorrectly install the wrong one it becomes a pain to clean them up and install the right one.

This PR introduces a way for the user to specify which one of these they want at install time.


## Modification

I've added two new files in `requirements`. `cv2-headless.txt` and `cv2-graphics.txt` which specify reasonable minimum versions of opencv based on the version of Python the user is on.  These are registered as new `extras_require` options. So the new usage would be either:

```bash
pip install mmengine[cv2-headless]

OR

pip install mmengine[cv2-graphics]
```

This means you no longer have to install cv2 before / after mmengine, and you can be sure you have the right one for your use case based on the install command you use. I've been using this construct in [kwimage](https://gitlab.kitware.com/computer-vision/kwimage) and other cv repos for a while now with good success. 

This also makes a modification to the `parse_requirements` function in setup.py. I was the original author of this construct and I figured I would update it to the lastest version I'm using in my [cookiecutter repo](https://github.com/Erotemic/xcookie/blob/a80785354a2d8547ec4483c22aa7d19b86ce4c3b/setup.py#L67) while I was here. I don't think it matters to parse the new extra reqs, but it does support more cases that could exist in the future. That could be reverted if needbe. 

## Notes

I think to finialize this PR there will need to be documentation modification and maybe this section:

```python
try:
    # OpenCV installed via conda.
    import cv2  # NOQA: F401
    major, minor, *rest = cv2.__version__.split('.')
    if int(major) < 3:
        raise RuntimeError(
            f'OpenCV >=3 is required but {cv2.__version__} is installed')
except ImportError:
    # If first not installed install second package
    CHOOSE_INSTALL_REQUIRES = [('opencv-python-headless>=3',
                                'opencv-python>=3')]
    for main, secondary in CHOOSE_INSTALL_REQUIRES:
        install_requires.append(choose_requirement(main, secondary))
```

In the setup.py needs to change? Looking for maintainer feedback about this detail.