### PR TITLE
[Refacor] Replace 'if base' with 'with read_base' context manager

### DIFF
--- a/docs/en/advanced_tutorials/config.md
+++ b/docs/en/advanced_tutorials/config.md
@@ -819,7 +819,8 @@ The inheritance syntax of pure Python style configuration files is slightly diff
 
     .. code-tab:: python Pure Python style Inheritance
 
-        if '_base_':
+        from mmengine.config import read_base
+        with read_base():
             from .optimizer import *
 
     .. code-tab:: python Pure text style Inheritance
@@ -831,7 +832,10 @@ The inheritance syntax of pure Python style configuration files is slightly diff
 Pure Python style configuration files use import syntax to achieve inheritance. The advantage of doing this is that we can directly jump to the inherited configuration file for easy reading and jumping. The variable inheritance rule (add, delete, change, and search) is completely aligned with Python syntax. For example, if I want to modify the learning rate of the optimizer in the base configuration file:
 
 ```python
-if '_base_':
+from mmengine.config import read_base
+
+
+with read_base():
     from .optimizer import *
 
 # optimizer is a variable defined in the base configuration file
@@ -843,7 +847,10 @@ optimizer.update(
 Of course, if you are already accustomed to the inheritance rules of pure text style configuration files and the variable is of the `dict` type in the `_base_` configuration file, you can also use merge syntax to achieve the same inheritance rule as pure text style configuration files:
 
 ```python
-if '_base_':
+from mmengine.config import read_base
+
+
+with read_base():
     from .optimizer import *
 
 # optimizer is a variable defined in the base configuration file
@@ -876,7 +883,7 @@ x.update(dict(b=dict(d=4)))
 It can be seen that using the update method in the configuration file will recursively update the fields, rather than simply covering them.
 ````
 
-Compared with pure text style configuration files, the inheritance rule of pure Python style configuration files is completely aligned with the import syntax of Python, which is easier to understand and supports jumping between configuration files. You may wonder since both inheritance and module imports use import syntax, why do we need an `if '_base_'` statement for inheriting configuration files? On the one hand, this can improve the readability of configuration files, making inherited configuration files more prominent. On the other hand, it is also restricted by the rules of lazy_import, which will be explained later.
+Compared with pure text style configuration files, the inheritance rule of pure Python style configuration files is completely aligned with the import syntax of Python, which is easier to understand and supports jumping between configuration files. You may wonder since both inheritance and module imports use import syntax, why do we need an `with read_base()'` statement for inheriting configuration files? On the one hand, this can improve the readability of configuration files, making inherited configuration files more prominent. On the other hand, it is also restricted by the rules of lazy_import, which will be explained later.
 
 #### Dump the Configuration File
 
@@ -958,7 +965,7 @@ print(type(cfg['optimizer']['type']))
 
 At this point, the type accessed is the `LazyObject` type.
 
-However, we cannot adopt the lazy import strategy for the inheritance (import) of base files since we need the configuration file parsed to include the fields defined in the base configuration file, and we need to trigger the import really. Therefore, we have added a restriction on importing base files, which must be imported in the `if '_base_'` code block.
+However, we cannot adopt the lazy import strategy for the inheritance (import) of base files since we need the configuration file parsed to include the fields defined in the base configuration file, and we need to trigger the import really. Therefore, we have added a restriction on importing base files, which must be imported in the `with read_base'` context manager.
 
 ### Limitations
 

--- a/docs/en/advanced_tutorials/config.md
+++ b/docs/en/advanced_tutorials/config.md
@@ -846,7 +846,7 @@ optimizer.update(
 )
 ```
 
-Of course, if you are already accustomed to the inheritance rules of pure text style configuration files and the variable is of the `dict` type in the `_base_` configuration file, you can also use merge syntax to achieve the same inheritance rule as pure text style configuration files:
+Of course, if you are already accustomed to the inheritance rules of pure text style configuration files, you can also use merge syntax to achieve the same inheritance rule as pure text style configuration files:
 
 ```python
 from mmengine.config import read_base

--- a/docs/en/advanced_tutorials/config.md
+++ b/docs/en/advanced_tutorials/config.md
@@ -820,6 +820,8 @@ The inheritance syntax of pure Python style configuration files is slightly diff
     .. code-tab:: python Pure Python style Inheritance
 
         from mmengine.config import read_base
+
+
         with read_base():
             from .optimizer import *
 

--- a/docs/en/api/config.rst
+++ b/docs/en/api/config.rst
@@ -14,3 +14,4 @@ mmengine.config
    Config
    ConfigDict
    DictAction
+   read_base

--- a/docs/zh_cn/advanced_tutorials/config.md
+++ b/docs/zh_cn/advanced_tutorials/config.md
@@ -829,8 +829,10 @@ https://download.openmmlab.com/mmdetection/v2.0/faster_rcnn/faster_rcnn_r50_fpn_
 .. tabs::
 
     .. code-tab:: python 纯 Python 风格继承
+        from mmengine.config import read_base
 
-        if '_base_':
+
+        with read_base():
             from .optimizer import *
 
     .. code-tab:: python 纯文本风格继承
@@ -842,7 +844,10 @@ https://download.openmmlab.com/mmdetection/v2.0/faster_rcnn/faster_rcnn_r50_fpn_
 纯 Python 风格的配置文件通过 import 语法来实现继承，这样做的好处是，我们可以直接跳转到被继承的配置文件中，方便阅读和跳转。变量的继承规则（增删改查）完全对齐 Python 语法，例如我想修改 base 配置文件中 optimizer 的学习率：
 
 ```python
-if '_base_':
+from mmengine.config import read_base
+
+
+with read_base():
     from .optimizer import *
 
 # optimizer 为 base 配置文件定义的变量
@@ -854,7 +859,10 @@ optimizer.update(
 当然了，如果你已经习惯了纯文本风格的继承规则，且该变量在 _base_ 配置文件中为 `dict` 类型，也可以通过 merge 语法来实现和纯文本风格配置文件一致的继承规则：
 
 ```python
-if '_base_':
+from mmengine.config import read_base
+
+
+with read_base():
     from .optimizer import *
 
 # optimizer 为 base 配置文件定义的变量
@@ -887,7 +895,7 @@ x.update(dict(b=dict(d=4)))
 可见在配置文件中使用 update 方法会递归地去更新字段，而不是简单的覆盖。
 ````
 
-与纯文本风格的配置文件相比，纯 Python 风格的配置文件的继承规则完全对齐 import 语法，更容易理解，且支持配置文件之间的跳转。你或许会好奇既然继承和模块的导入都使用了 import 语法，为什么继承配置文件还需要额外的 `if '_base_'` 语句呢？一方面这样可以提升配置文件的可读性，可以让继承的配置文件更加突出，另一方面也是受限于 lazy_import 的规则，这个会在后面讲到。
+与纯文本风格的配置文件相比，纯 Python 风格的配置文件的继承规则完全对齐 import 语法，更容易理解，且支持配置文件之间的跳转。你或许会好奇既然继承和模块的导入都使用了 import 语法，为什么继承配置文件还需要额外的 `with read_base():`  这个上下文管理器呢？一方面这样可以提升配置文件的可读性，可以让继承的配置文件更加突出，另一方面也是受限于 lazy_import 的规则，这个会在后面讲到。
 
 #### 配置文件的导出
 
@@ -969,7 +977,7 @@ print(type(cfg['optimizer']['type']))
 
 此时得到的 type 就是 `LazyObject` 类型。
 
-然而对于 base 文件的继承（导入，import），我们不能够采取 lazy import 的策略，这是因为我们希望解析后的配置文件能够包含 base 配置文件定义的字段，需要真正的触发 import。因此我们对 base 文件的导入加了一层限制，即必须在 `if '_base_'` 的代码块中导入。
+然而对于 base 文件的继承（导入，import），我们不能够采取 lazy import 的策略，这是因为我们希望解析后的配置文件能够包含 base 配置文件定义的字段，需要真正的触发 import。因此我们对 base 文件的导入加了一层限制，即必须在 `with read_base()'` 的上下文中导入。
 
 ### 功能限制
 

--- a/docs/zh_cn/api/config.rst
+++ b/docs/zh_cn/api/config.rst
@@ -14,3 +14,4 @@ mmengine.config
    Config
    ConfigDict
    DictAction
+   read_base

--- a/mmengine/config/__init__.py
+++ b/mmengine/config/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from .config import Config, ConfigDict, DictAction
+from .config import Config, ConfigDict, DictAction, read_base
 
-__all__ = ['Config', 'ConfigDict', 'DictAction']
+__all__ = ['Config', 'ConfigDict', 'DictAction', 'read_base']

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -492,10 +492,10 @@ class Config:
                 assert isinstance(node, ast.ImportFrom), (
                     'Illegal syntax in config file! Only '
                     '`from ... import ...` could be implemented` in '
-                    '`if _base_`')
+                    'with read_base()`')
                 assert node.module is not None, (
                     'Illegal syntax in config file! Syntax like '
-                    '`from . import xxx` is not allowed in `if _base_` ')
+                    '`from . import xxx` is not allowed in `with read_base()`')
                 base_modules.append(node.level * '.' + node.module)
             return base_modules
 
@@ -526,7 +526,7 @@ class Config:
 
             # The original code:
             # ```
-            # if _base_:
+            # with read_base():
             #     from .._base_.default_runtime import *
             # ```
             # The processed code:
@@ -761,7 +761,7 @@ class Config:
                 predefined variables. Defaults to True.
 
         Returns:
-            Tuple[dict, str]: Variables dictionary and text of Config.i
+            Tuple[dict, str]: Variables dictionary and text of Config.
         """
         if Config._is_lazy_import(filename):
             raise RuntimeError(
@@ -959,7 +959,7 @@ class Config:
 
             parsed_codes = ast.parse(f.read())
             # get the names of base modules, and remove the
-            # `if '_base_:'` statement
+            # `with read_base():'` statement
             base_modules = Config._get_base_modules(parsed_codes.body)
             base_imported_names = set()
             for base_module in base_modules:

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -1731,5 +1731,15 @@ class DictAction(Action):
 
 @contextmanager
 def read_base():
-    """Context manager to mark the base config."""
+    """Context manager to mark the base config.
+
+    The pure Python-style configuration file allows you to use the import
+    syntax. However, it is important to note that you need to import the base
+    configuration file within the context of ``read_base``, and import other
+    dependencies outside of it.
+
+    You can see more usage of Python-style configuration in the `tutorial`_
+
+    .. _tutorial: https://mmengine.readthedocs.io/en/latest/advanced_tutorials/config.html#a-pure-python-style-configuration-file-beta
+    """  # noqa: E501
     yield

--- a/mmengine/config/utils.py
+++ b/mmengine/config/utils.py
@@ -43,8 +43,7 @@ PKG2PROJECT = MODULE2PACKAGE
 
 
 class ConfigParsingError(RuntimeError):
-    """Raised when there is an error when parsing pure Python style config
-    files."""
+    """Raise error when failed to parse pure Python style config files."""
 
 
 def _get_cfg_metainfo(package_path: str, cfg_path: str) -> dict:

--- a/mmengine/config/utils.py
+++ b/mmengine/config/utils.py
@@ -43,10 +43,8 @@ PKG2PROJECT = MODULE2PACKAGE
 
 
 class ConfigParsingError(RuntimeError):
-
-    def __init__(self, message: str) -> None:
-        super().__init__(message)
-        self.message = message
+    """Raised when there is an error when parsing pure Python style config
+    files."""
 
 
 def _get_cfg_metainfo(package_path: str, cfg_path: str) -> dict:

--- a/mmengine/config/utils.py
+++ b/mmengine/config/utils.py
@@ -42,6 +42,13 @@ MODULE2PACKAGE = {
 PKG2PROJECT = MODULE2PACKAGE
 
 
+class ConfigParsingError(RuntimeError):
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
 def _get_cfg_metainfo(package_path: str, cfg_path: str) -> dict:
     """Get target meta information from all 'metafile.yml' defined in `mode-
     index.yml` of external package.
@@ -236,7 +243,10 @@ class ImportTransformer(ast.NodeTransformer):
         base_dict (dict): All variables defined in base files.
 
             Examples:
-                >>> if '_base_':
+                >>> from mmengine.config import read_base
+                >>>
+                >>>
+                >>> with read_base():
                 >>>     from .._base_.default_runtime import *
                 >>>     from .._base_.datasets.coco_detection import dataset
 
@@ -334,7 +344,7 @@ class ImportTransformer(ast.NodeTransformer):
                 # fallback to import the real module and raise a warning to
                 # remind users the real module will be imported which will slow
                 # down the parsing speed.
-                raise RuntimeError(
+                raise ConfigParsingError(
                     'Illegal syntax in config! `from xxx import *` is not '
                     'allowed to appear outside the `if base:` statement')
             elif alias_node.asname is not None:
@@ -352,13 +362,12 @@ class ImportTransformer(ast.NodeTransformer):
             try:
                 nodes.append(ast.parse(code).body[0])  # type: ignore
             except Exception as e:
-                raise ImportError(
-                    f'Cannot import {alias_node} from {module}',
+                raise ConfigParsingError(
+                    f'Cannot import {alias_node} from {module}'
                     '1. Cannot import * from 3rd party lib in the config '
                     'file\n'
                     '2. Please check if the module is a base config which '
-                    'should be added to `_base_`\n',
-                ) from e
+                    'should be added to `_base_`\n') from e
         return nodes
 
     def visit_Import(self, node) -> Union[ast.Assign, ast.Import]:

--- a/tests/data/config/lazy_module_config/error_mix_using2.py
+++ b/tests/data/config/lazy_module_config/error_mix_using2.py
@@ -1,3 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-if '_base_':
+from mmengine.config import read_base
+
+with read_base():
     from ...config.py_config.test_base_variables import *

--- a/tests/data/config/lazy_module_config/load_mmdet_config.py
+++ b/tests/data/config/lazy_module_config/load_mmdet_config.py
@@ -1,5 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-if '_base_':
+from mmengine.config import read_base
+
+with read_base():
     from mmdet.configs.retinanet.retinanet_r50_caffe_fpn_1x_coco import *
     from mmdet.configs.retinanet.retinanet_r101_caffe_fpn_1x_coco import \
         model as r101

--- a/tests/data/config/lazy_module_config/toy_model.py
+++ b/tests/data/config/lazy_module_config/toy_model.py
@@ -1,10 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from mmengine.config import read_base
 from mmengine.dataset import DefaultSampler
 from mmengine.hooks import EMAHook
 from mmengine.model import MomentumAnnealingEMA
 from mmengine.testing.runner_test_case import ToyDataset, ToyMetric
 
-if '_base_':
+with read_base():
     from ._base_.base_model import *
     from ._base_.default_runtime import *
     from ._base_.scheduler import *

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -950,7 +950,12 @@ class TestConfig:
         lazy_import_cfg_path = osp.join(
             self.data_path, 'config/lazy_module_config/toy_model.py')
         cfg = Config.fromfile(lazy_import_cfg_path)
-        # Dumpe config
+        cfg_dict = cfg.to_dict()
+        assert (cfg_dict['train_dataloader']['dataset']['type'] ==
+                'mmengine.testing.runner_test_case.ToyDataset')
+        assert (
+            cfg_dict['custom_hooks'][0]['type'] == 'mmengine.hooks.EMAHook')
+        # Dumped config
         dumped_cfg_path = tmp_path / 'test_dump_lazy.py'
         cfg.dump(dumped_cfg_path)
         dumped_cfg = Config.fromfile(dumped_cfg_path)
@@ -965,12 +970,11 @@ class TestConfig:
                 for item_a, item_b in zip(a, b):
                     _compare_dict(item_a, item_b)
             else:
-                if isinstance(a, str) and a != '_module_':
-                    assert a == b
-                elif isinstance(a, LazyObject):
-                    assert str(a) == str(b)
+                assert str(a) == str(b)
 
         _compare_dict(cfg, dumped_cfg)
+
+        #
 
         # TODO reimplement this part of unit test when mmdetection adds the
         # new config.
@@ -1012,7 +1016,7 @@ error_attr = mmengine.error_attr
 
         # lazy-import and non-lazy-import should not be used mixed.
         # current text config, base lazy-import config
-        with pytest.raises(RuntimeError, match='if "_base_"'):
+        with pytest.raises(RuntimeError, match='with read_base()'):
             Config.fromfile(
                 osp.join(self.data_path,
                          'config/lazy_module_config/error_mix_using1.py'))

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -972,9 +972,7 @@ class TestConfig:
             else:
                 assert str(a) == str(b)
 
-        _compare_dict(cfg, dumped_cfg)
-
-        #
+        _compare_dict(cfg.to_dict(), dumped_cfg.to_dict())
 
         # TODO reimplement this part of unit test when mmdetection adds the
         # new config.
@@ -1030,6 +1028,17 @@ error_attr = mmengine.error_attr
 
 class TestConfigDict(TestCase):
 
+    def test_keep_custom_dict(self):
+
+        class CustomDict(dict):
+            ...
+
+        cfg_dict = ConfigDict(dict(a=CustomDict(b=1)))
+        self.assertIsInstance(cfg_dict.a, CustomDict)
+        self.assertIsInstance(cfg_dict['a'], CustomDict)
+        self.assertIsInstance(cfg_dict.values()[0], CustomDict)
+        self.assertIsInstance(cfg_dict.items()[0][1], CustomDict)
+
     def test_build_lazy(self):
         # This unit test are divide into two parts:
         # I. ConfigDict will never return a `LazyObject` instance. Only the
@@ -1045,6 +1054,12 @@ class TestConfigDict(TestCase):
         # Keep key-value the same
         raw = dict(a=1, b=dict(c=2, e=[dict(f=(2, ))]))
         cfg_dict = ConfigDict(raw)
+
+        assert len(cfg_dict) == 2
+        assert len(cfg_dict.items()) == 2
+        assert len(cfg_dict.keys()) == 2
+        assert len(cfg_dict.values()) == 2
+
         self.assertDictEqual(cfg_dict, raw)
 
         # Check `items` and `values` will only return the build object


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1. Replace 'if base' with 'with read_base'. 
2. Add ConfigParsingError
3. make Config.to_dict return string.
4. Only convert dict and OrederedDict when setitem or setattr for ConfigDict


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
6. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
7. The documentation has been modified accordingly, like docstring or example tutorials.
