### PR TITLE
[Suggest] enable explicit error for deepspeed not installed

### DIFF
--- a/mmengine/_strategy/__init__.py
+++ b/mmengine/_strategy/__init__.py
@@ -6,7 +6,9 @@ from .deepspeed import DeepSpeedStrategy
 from .distributed import DDPStrategy
 from .single_device import SingleDeviceStrategy
 
-__all__ = ['BaseStrategy', 'DDPStrategy', 'SingleDeviceStrategy', 'DeepSpeedStrategy']
+__all__ = [
+    'BaseStrategy', 'DDPStrategy', 'SingleDeviceStrategy', 'DeepSpeedStrategy'
+]
 
 
 if digit_version(TORCH_VERSION) >= digit_version('2.0.0'):

--- a/mmengine/_strategy/__init__.py
+++ b/mmengine/_strategy/__init__.py
@@ -1,15 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from mmengine.utils import digit_version, is_installed
+from mmengine.utils import digit_version
 from mmengine.utils.dl_utils import TORCH_VERSION
 from .base import BaseStrategy
+from .deepspeed import DeepSpeedStrategy
 from .distributed import DDPStrategy
 from .single_device import SingleDeviceStrategy
 
 __all__ = ['BaseStrategy', 'DDPStrategy', 'SingleDeviceStrategy']
 
-if is_installed('deepspeed'):
-    from .deepspeed import DeepSpeedStrategy  # noqa: F401
-    __all__.append('DeepSpeedStrategy')
 
 if digit_version(TORCH_VERSION) >= digit_version('2.0.0'):
     try:

--- a/mmengine/_strategy/__init__.py
+++ b/mmengine/_strategy/__init__.py
@@ -6,7 +6,7 @@ from .deepspeed import DeepSpeedStrategy
 from .distributed import DDPStrategy
 from .single_device import SingleDeviceStrategy
 
-__all__ = ['BaseStrategy', 'DDPStrategy', 'SingleDeviceStrategy']
+__all__ = ['BaseStrategy', 'DDPStrategy', 'SingleDeviceStrategy', 'DeepSpeedStrategy']
 
 
 if digit_version(TORCH_VERSION) >= digit_version('2.0.0'):

--- a/mmengine/_strategy/__init__.py
+++ b/mmengine/_strategy/__init__.py
@@ -10,7 +10,6 @@ __all__ = [
     'BaseStrategy', 'DDPStrategy', 'SingleDeviceStrategy', 'DeepSpeedStrategy'
 ]
 
-
 if digit_version(TORCH_VERSION) >= digit_version('2.0.0'):
     try:
         from .fsdp import FSDPStrategy  # noqa:F401

--- a/mmengine/_strategy/deepspeed.py
+++ b/mmengine/_strategy/deepspeed.py
@@ -4,7 +4,11 @@ import os.path as osp
 import time
 from typing import Callable, Dict, List, Optional, Union
 
-import deepspeed
+try:
+    import deepspeed
+except ImportError:
+    deepspeed = None
+
 import torch.nn as nn
 
 import mmengine
@@ -71,6 +75,10 @@ class DeepSpeedStrategy(BaseStrategy):
         # the following args are for BaseStrategy
         **kwargs,
     ):
+        assert deepspeed is not None, \
+            'DeepSpeed is not installed. Please check ' \
+            'https://github.com/microsoft/DeepSpeed#installation.'
+        
         super().__init__(**kwargs)
 
         self.config = self._parse_config(config)

--- a/mmengine/_strategy/deepspeed.py
+++ b/mmengine/_strategy/deepspeed.py
@@ -78,7 +78,7 @@ class DeepSpeedStrategy(BaseStrategy):
         assert deepspeed is not None, \
             'DeepSpeed is not installed. Please check ' \
             'https://github.com/microsoft/DeepSpeed#installation.'
-        
+
         super().__init__(**kwargs)
 
         self.config = self._parse_config(config)

--- a/mmengine/model/wrappers/_deepspeed.py
+++ b/mmengine/model/wrappers/_deepspeed.py
@@ -2,10 +2,14 @@
 from typing import Any, Dict, List, Optional, Union
 
 import torch
-from deepspeed.runtime.engine import DeepSpeedEngine
 
 from mmengine.optim.optimizer._deepspeed import DeepSpeedOptimWrapper
 from mmengine.registry import MODEL_WRAPPERS
+
+try:
+    from deepspeed.runtime.engine import DeepSpeedEngine
+except:
+    DeepSpeedEngine = None
 
 
 @MODEL_WRAPPERS.register_module()

--- a/mmengine/model/wrappers/_deepspeed.py
+++ b/mmengine/model/wrappers/_deepspeed.py
@@ -8,7 +8,7 @@ from mmengine.registry import MODEL_WRAPPERS
 
 try:
     from deepspeed.runtime.engine import DeepSpeedEngine
-except:
+except ImportError:
     DeepSpeedEngine = None
 
 

--- a/mmengine/optim/__init__.py
+++ b/mmengine/optim/__init__.py
@@ -1,9 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from mmengine.utils import is_installed
 from .optimizer import (OPTIM_WRAPPER_CONSTRUCTORS, OPTIMIZERS,
                         AmpOptimWrapper, ApexOptimWrapper, BaseOptimWrapper,
-                        DeepSpeedOptimWrapper, DefaultOptimWrapperConstructor, 
-                        OptimWrapper, OptimWrapperDict, 
+                        DeepSpeedOptimWrapper, DefaultOptimWrapperConstructor,
+                        OptimWrapper, OptimWrapperDict,
                         ZeroRedundancyOptimizer, build_optim_wrapper)
 # yapf: disable
 from .scheduler import (ConstantLR, ConstantMomentum, ConstantParamScheduler,

--- a/mmengine/optim/__init__.py
+++ b/mmengine/optim/__init__.py
@@ -2,9 +2,9 @@
 from mmengine.utils import is_installed
 from .optimizer import (OPTIM_WRAPPER_CONSTRUCTORS, OPTIMIZERS,
                         AmpOptimWrapper, ApexOptimWrapper, BaseOptimWrapper,
-                        DefaultOptimWrapperConstructor, OptimWrapper,
-                        OptimWrapperDict, ZeroRedundancyOptimizer,
-                        build_optim_wrapper)
+                        DeepSpeedOptimWrapper, DefaultOptimWrapperConstructor, 
+                        OptimWrapper, OptimWrapperDict, 
+                        ZeroRedundancyOptimizer, build_optim_wrapper)
 # yapf: disable
 from .scheduler import (ConstantLR, ConstantMomentum, ConstantParamScheduler,
                         CosineAnnealingLR, CosineAnnealingMomentum,
@@ -32,9 +32,5 @@ __all__ = [
     'OptimWrapperDict', 'OneCycleParamScheduler', 'OneCycleLR', 'PolyLR',
     'PolyMomentum', 'PolyParamScheduler', 'ReduceOnPlateauLR',
     'ReduceOnPlateauMomentum', 'ReduceOnPlateauParamScheduler',
-    'ZeroRedundancyOptimizer', 'BaseOptimWrapper'
+    'ZeroRedundancyOptimizer', 'BaseOptimWrapper', 'DeepSpeedOptimWrapper'
 ]
-
-if is_installed('deepspeed'):
-    from .optimizer import DeepSpeedOptimWrapper  # noqa:F401
-    __all__.append('DeepSpeedOptimWrapper')

--- a/mmengine/optim/optimizer/__init__.py
+++ b/mmengine/optim/optimizer/__init__.py
@@ -9,14 +9,11 @@ from .default_constructor import DefaultOptimWrapperConstructor
 from .optimizer_wrapper import OptimWrapper
 from .optimizer_wrapper_dict import OptimWrapperDict
 from .zero_optimizer import ZeroRedundancyOptimizer
+from ._deepspeed import DeepSpeedOptimWrapper
 
 __all__ = [
     'OPTIM_WRAPPER_CONSTRUCTORS', 'OPTIMIZERS',
     'DefaultOptimWrapperConstructor', 'build_optim_wrapper', 'OptimWrapper',
     'AmpOptimWrapper', 'ApexOptimWrapper', 'OptimWrapperDict',
-    'ZeroRedundancyOptimizer', 'BaseOptimWrapper'
+    'ZeroRedundancyOptimizer', 'BaseOptimWrapper', 'DeepSpeedOptimWrapper'
 ]
-
-if is_installed('deepspeed'):
-    from ._deepspeed import DeepSpeedOptimWrapper  # noqa:F401
-    __all__.append('DeepSpeedOptimWrapper')

--- a/mmengine/optim/optimizer/__init__.py
+++ b/mmengine/optim/optimizer/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from ._deepspeed import DeepSpeedOptimWrapper
 from .amp_optimizer_wrapper import AmpOptimWrapper
 from .apex_optimizer_wrapper import ApexOptimWrapper
 from .base import BaseOptimWrapper
@@ -8,7 +9,6 @@ from .default_constructor import DefaultOptimWrapperConstructor
 from .optimizer_wrapper import OptimWrapper
 from .optimizer_wrapper_dict import OptimWrapperDict
 from .zero_optimizer import ZeroRedundancyOptimizer
-from ._deepspeed import DeepSpeedOptimWrapper
 
 __all__ = [
     'OPTIM_WRAPPER_CONSTRUCTORS', 'OPTIMIZERS',

--- a/mmengine/optim/optimizer/__init__.py
+++ b/mmengine/optim/optimizer/__init__.py
@@ -1,5 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from mmengine.utils import is_installed
 from .amp_optimizer_wrapper import AmpOptimWrapper
 from .apex_optimizer_wrapper import ApexOptimWrapper
 from .base import BaseOptimWrapper

--- a/mmengine/runner/_flexible_runner.py
+++ b/mmengine/runner/_flexible_runner.py
@@ -23,7 +23,7 @@ from mmengine.optim import OptimWrapper, OptimWrapperDict, _ParamScheduler
 from mmengine.registry import (DATA_SAMPLERS, DATASETS, EVALUATOR, FUNCTIONS,
                                HOOKS, LOG_PROCESSORS, LOOPS, RUNNERS,
                                STRATEGIES, VISUALIZERS, DefaultScope)
-from mmengine.utils import digit_version, is_installed
+from mmengine.utils import digit_version
 from mmengine.utils.dl_utils import TORCH_VERSION
 from mmengine.visualization import Visualizer
 from .base_loop import BaseLoop
@@ -641,9 +641,6 @@ class FlexibleRunner:
             else:
                 strategy_name = strategy['type'].__name__
             if strategy_name == 'DeepSpeedStrategy':
-                if not is_installed('deepspeed'):
-                    raise RuntimeWarning('Please install deepspeed with `pip install deepspeed`.')
-              
                 if self._train_dataloader is None:
                     strategy['train_micro_batch_size_per_gpu'] = 1
                 else:

--- a/mmengine/runner/_flexible_runner.py
+++ b/mmengine/runner/_flexible_runner.py
@@ -23,7 +23,7 @@ from mmengine.optim import OptimWrapper, OptimWrapperDict, _ParamScheduler
 from mmengine.registry import (DATA_SAMPLERS, DATASETS, EVALUATOR, FUNCTIONS,
                                HOOKS, LOG_PROCESSORS, LOOPS, RUNNERS,
                                STRATEGIES, VISUALIZERS, DefaultScope)
-from mmengine.utils import digit_version
+from mmengine.utils import digit_version, is_installed
 from mmengine.utils.dl_utils import TORCH_VERSION
 from mmengine.visualization import Visualizer
 from .base_loop import BaseLoop
@@ -641,6 +641,9 @@ class FlexibleRunner:
             else:
                 strategy_name = strategy['type'].__name__
             if strategy_name == 'DeepSpeedStrategy':
+                if not is_installed('deepspeed'):
+                    raise RuntimeWarning('Please install deepspeed with `pip install deepspeed`.')
+              
                 if self._train_dataloader is None:
                     strategy['train_micro_batch_size_per_gpu'] = 1
                 else:


### PR DESCRIPTION
If the user has not installed deepspeed and use deepspeed strategy, an implicit error of DeepSpeedStrategy not in REGISTRY will be raised.
Because of [here](https://github.com/open-mmlab/mmengine/blob/b2295a258c4af3cdeb1a55fa5e49cddbd1c6c0bf/mmengine/_strategy/__init__.py#L10C13-L10C13)