### PR TITLE
Fix scalar check in RuntimeInfoHook

### DIFF
--- a/mmengine/hooks/runtime_info_hook.py
+++ b/mmengine/hooks/runtime_info_hook.py
@@ -23,7 +23,7 @@ def _is_scalar(value: Any) -> bool:
     """
     if isinstance(value, np.ndarray):
         return value.size == 1
-    elif isinstance(value, (int, float, np.floating, np.integer)):
+    elif isinstance(value, (int, float, np.number)):
         return True
     elif isinstance(value, torch.Tensor):
         return value.numel() == 1

--- a/mmengine/hooks/runtime_info_hook.py
+++ b/mmengine/hooks/runtime_info_hook.py
@@ -23,7 +23,7 @@ def _is_scalar(value: Any) -> bool:
     """
     if isinstance(value, np.ndarray):
         return value.size == 1
-    elif isinstance(value, (int, float)):
+    elif isinstance(value, (int, float, np.floating, np.integer)):
         return True
     elif isinstance(value, torch.Tensor):
         return value.numel() == 1

--- a/tests/test_hooks/test_runtime_info_hook.py
+++ b/tests/test_hooks/test_runtime_info_hook.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
 from unittest.mock import Mock
+
 import numpy as np
 import torch
 import torch.nn as nn
@@ -132,12 +133,14 @@ class TestRuntimeInfoHook(RunnerTestCase):
 
         # check other scalar dtypes
         val = np.mean([5])  # this is not ndarray but dtype is np.float64.
-        hook.after_val_epoch(runner, metrics={
-            'acc_f32': val.astype(np.float32),
-            'acc_i32': val.astype(np.int32),
-            'acc_u8': val.astype(np.uint8),
-            'acc_ndarray': np.array([5]),
-        })
+        hook.after_val_epoch(
+            runner,
+            metrics={
+                'acc_f32': val.astype(np.float32),
+                'acc_i32': val.astype(np.int32),
+                'acc_u8': val.astype(np.uint8),
+                'acc_ndarray': np.array([5]),
+            })
         self.assertEqual(
             runner.message_hub.get_scalar('val/acc_f32').current(), 5)
         self.assertEqual(
@@ -148,11 +151,13 @@ class TestRuntimeInfoHook(RunnerTestCase):
             runner.message_hub.get_scalar('val/acc_ndarray').current(), 5)
 
         val = torch.tensor([5.0]).mean()
-        hook.after_val_epoch(runner, metrics={
-            'acc_f32': val.float(),
-            'acc_i64': val.long(),
-            'acc_tensor': torch.tensor([5]),
-        })
+        hook.after_val_epoch(
+            runner,
+            metrics={
+                'acc_f32': val.float(),
+                'acc_i64': val.long(),
+                'acc_tensor': torch.tensor([5]),
+            })
         self.assertEqual(
             runner.message_hub.get_scalar('val/acc_f32').current(), 5)
         self.assertEqual(

--- a/tests/test_hooks/test_runtime_info_hook.py
+++ b/tests/test_hooks/test_runtime_info_hook.py
@@ -125,7 +125,7 @@ class TestRuntimeInfoHook(RunnerTestCase):
         self.assertEqual(
             runner.message_hub.get_scalar('test/acc').current(), 0.8)
 
-    def test_scalar_chech(self):
+    def test_scalar_check(self):
         cfg = copy.deepcopy(self.epoch_based_cfg)
         runner = self.build_runner(cfg)
         hook = self._get_runtime_info_hook(runner)


### PR DESCRIPTION
## Motivation

Some numpy scalars (float32, float16, ...) are misclassified as non-scalar values inRuntimeInfoHook.

See:

```
from mmengine.hooks.runtime_info_hook import _is_scalar
v = np.mean([0.5])
print(_is_scalar(v.astype(np.float16)))  # => False
print(_is_scalar(v.astype(np.float32)))  # => False
print(_is_scalar(v.astype(np.float64)))  # => True
```

This causes problems when the custom metrics are calculated in numpy because the log_processor looks to collect only scalar values as metrics to give the visualizer them.

## Modification

Added np.floating and np.integer as valid scalar types.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

I encountered this problem when I defined custom metrics where I calculated metrics in tensor and converted the result to numpy. (ex. metrics.detach().cpu().numpy() --> np.float32)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
