### PR TITLE
use graph transform to deal with more general cases for efficient_conv_bn_eval

### DIFF
--- a/tests/test_model/test_efficient_conv_bn_eval.py
+++ b/tests/test_model/test_efficient_conv_bn_eval.py
@@ -37,8 +37,8 @@ class BackboneModel(nn.Module):
             x = self.mod1(x)
         # this conv-bn pair can use efficient_conv_bn_eval feature
         x = self.bn1(self.conv1(x))
-        # this conv-bn pair cannot use efficient_conv_bn_eval feature
-        # because `self.conv2` is used twice
+        # this conv-bn pair can use efficient_conv_bn_eval feature
+        # only for the second `self.conv2` call.
         x = self.bn2(self.conv2(self.conv2(x)))
         # this conv-bn pair can use efficient_conv_bn_eval feature
         # just for the first forward of the `self.bn3`


### PR DESCRIPTION
## Motivation

Prior to this PR, `efficient_conv_bn_eval` operates in module level. It modifies the `forward` function of `conv` and `bn` modules. Therefore, it cannot deal with multiple usage of `conv`.

This PR improves the `efficient_conv_bn_eval` feature to operate in **computation** level. We fuse each computation of `conv` and `bn`. No changes in `state_dict`, no constraints for the network architecture. As long as there are `conv` + `bn` in `eval` computation patterns, this PR works.

See the updated test for example.

## BC-breaking (Optional)

No. It just changes the implementation of `efficient_conv_bn_eval`.