### PR TITLE
Support multi-node distributed training with MLU backend

### DIFF
--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -101,10 +101,11 @@ def _init_dist_pytorch(backend, init_backend='torch', **kwargs) -> None:
     rank = int(os.environ['RANK'])
     if is_mlu_available():
         import torch_mlu  # noqa: F401
-        torch.mlu.set_device(rank)
+        local_rank = int(os.environ['LOCAL_RANK'])
+        torch.mlu.set_device(local_rank)
         torch_dist.init_process_group(
             backend='cncl',
-            rank=rank,
+            rank=local_rank,
             world_size=int(os.environ['WORLD_SIZE']),
             **kwargs)
     elif is_npu_available():

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -105,7 +105,7 @@ def _init_dist_pytorch(backend, init_backend='torch', **kwargs) -> None:
         torch.mlu.set_device(local_rank)
         torch_dist.init_process_group(
             backend='cncl',
-            rank=local_rank,
+            rank=rank,
             world_size=int(os.environ['WORLD_SIZE']),
             **kwargs)
     elif is_npu_available():


### PR DESCRIPTION
## Motivation

Fix the problem that multi-node distributed training would fail at initial when training with MLU.

## Modification

In `mmengine/dist/util.py`, we change rank to local rank when initializing process group with MLU.

## BC-breaking (Optional)

None

## Use cases (Optional)

None

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
