### PR TITLE
[Fix] Fix `ConfigDict.items` will be called during dump

### DIFF
--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -265,7 +265,7 @@ class ConfigDict(Dict):
             self[key] = value
 
     def __reduce_ex__(self, proto):
-        # Customize this dump related function to void `self.items` will be
+        # Override __reduce_ex__ to void `self.items` will be
         # called by CPython interpreter during pickling. See more details in
         # https://github.com/python/cpython/blob/8d61a71f9c81619e34d4a30b625922ebc83c561b/Objects/typeobject.c#L6196  # noqa: E501
         return (self.__class__, ({k: v

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -24,8 +24,9 @@ from yapf.yapflib.yapf_api import FormatCode
 
 from mmengine.fileio import dump, load
 from mmengine.logging import print_log
-from mmengine.utils import (check_file_exist, get_installed_path,
-                            import_modules_from_strings, is_installed)
+from mmengine.utils import (check_file_exist, digit_version,
+                            get_installed_path, import_modules_from_strings,
+                            is_installed)
 from .lazy import LazyAttr, LazyObject
 from .utils import (ConfigParsingError, ImportTransformer, RemoveAssignFromAST,
                     _gather_abs_import_lazyobj, _get_external_cfg_base_path,
@@ -268,9 +269,14 @@ class ConfigDict(Dict):
         # Override __reduce_ex__ to void `self.items` will be
         # called by CPython interpreter during pickling. See more details in
         # https://github.com/python/cpython/blob/8d61a71f9c81619e34d4a30b625922ebc83c561b/Objects/typeobject.c#L6196  # noqa: E501
-        return (self.__class__, ({k: v
-                                  for k, v in super().items()}, ), None, None,
-                None, None)
+        if digit_version(platform.python_version()) < digit_version('3.8'):
+            return (self.__class__, ({k: v
+                                      for k, v in super().items()}, ), None,
+                    None, None)
+        else:
+            return (self.__class__, ({k: v
+                                      for k, v in super().items()}, ), None,
+                    None, None, None)
 
     def __eq__(self, other):
         if isinstance(other, ConfigDict):

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -266,7 +266,7 @@ class ConfigDict(Dict):
             self[key] = value
 
     def __reduce_ex__(self, proto):
-        # Override __reduce_ex__ to void `self.items` will be
+        # Override __reduce_ex__ to avoid `self.items` will be
         # called by CPython interpreter during pickling. See more details in
         # https://github.com/python/cpython/blob/8d61a71f9c81619e34d4a30b625922ebc83c561b/Objects/typeobject.c#L6196  # noqa: E501
         if digit_version(platform.python_version()) < digit_version('3.8'):

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -265,7 +265,9 @@ class ConfigDict(Dict):
             self[key] = value
 
     def __reduce_ex__(self, proto):
-        #
+        # Customize this dump related function to void `self.items` will be
+        # called by CPython interpreter during pickling. See more details in
+        # https://github.com/python/cpython/blob/8d61a71f9c81619e34d4a30b625922ebc83c561b/Objects/typeobject.c#L6196  # noqa: E501
         return (self.__class__, ({k: v
                                   for k, v in super().items()}, ), None, None,
                 None, None)

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -264,15 +264,11 @@ class ConfigDict(Dict):
         for key, value in merged.items():
             self[key] = value
 
-    def __getstate__(self):
-        state = {}
-        for key, value in super().items():
-            state[key] = value
-        return state
-
-    def __setstate__(self, state):
-        for key, value in state.items():
-            self[key] = value
+    def __reduce_ex__(self, proto):
+        #
+        return (self.__class__, ({k: v
+                                  for k, v in super().items()}, ), None, None,
+                None, None)
 
     def __eq__(self, other):
         if isinstance(other, ConfigDict):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Overide __reduce_ex__ to void `self.items` will be
called by CPython interpreter during pickling. See more details in
https://github.com/python/cpython/blob/8d61a71f9c81619e34d4a30b625922ebc83c561b/Objects/typeobject.c#L6196

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
