### PR TITLE
[Feature] Fix Visualizer that built vis_backends will not be used when save_dir is None

### DIFF
--- a/mmengine/visualization/visualizer.py
+++ b/mmengine/visualization/visualizer.py
@@ -164,9 +164,7 @@ class Visualizer(ManagerMixin):
 
         if vis_backends is not None:
             assert len(vis_backends) > 0, 'empty list'
-            names = [
-                vis_backend.get('name', None) for vis_backend in vis_backends
-            ]
+            names = [vis_backend.get('name') for vis_backend in vis_backends]
             if None in names:
                 if len(set(names)) > 1:
                     raise RuntimeError(
@@ -189,13 +187,7 @@ class Visualizer(ManagerMixin):
                 save_dir = osp.join(save_dir, 'vis_data')
             for vis_backend in vis_backends:
                 name = vis_backend.pop('name', vis_backend['type'])
-                if 'save_dir' not in vis_backend:
-                    if save_dir is not None:
-                        vis_backend['save_dir'] = save_dir
-                    else:
-                        raise ValueError(
-                            f'save_dir should be specified in {vis_backend} '
-                            f'or {self.__class__.__name__}')
+                vis_backend.setdefault('save_dir', save_dir)
                 self._vis_backends[name] = VISBACKENDS.build(vis_backend)
 
         self.fig_save = None

--- a/mmengine/visualization/visualizer.py
+++ b/mmengine/visualization/visualizer.py
@@ -198,6 +198,7 @@ class Visualizer(ManagerMixin):
                             f'or {self.__class__.__name__}')
                 self._vis_backends[name] = VISBACKENDS.build(vis_backend)
 
+        self.fig_save = None
         self.fig_save_cfg = fig_save_cfg
         self.fig_show_cfg = fig_show_cfg
 

--- a/mmengine/visualization/visualizer.py
+++ b/mmengine/visualization/visualizer.py
@@ -189,23 +189,18 @@ class Visualizer(ManagerMixin):
                 raise RuntimeError('The name fields cannot be the same')
 
             # check if vis_backends are initialized
-            if save_dir is None:
-                for vis_backend in vis_backends:
-                    if vis_backend.get('save_dir') is None:
-                        print_log(
-                            '`Visualizer` backend is not initialized '
-                            'because save_dir is None '
-                            'and at least one vis_backend has no save_dir.',
-                            logger='current',
-                            level=logging.WARNING)
-                        break
-
-            else:
+            if save_dir is not None:
                 save_dir = osp.join(save_dir, 'vis_data')
-                for vis_backend in vis_backends:
-                    name = vis_backend.pop('name', vis_backend['type'])
-                    vis_backend.setdefault('save_dir', save_dir)
-                    self._vis_backends[name] = VISBACKENDS.build(vis_backend)
+            for vis_backend in vis_backends:
+                name = vis_backend.pop('name', vis_backend['type'])
+                if 'save_dir' not in vis_backend:
+                    if save_dir is not None:
+                        vis_backend['save_dir'] = save_dir
+                    else:
+                        raise ValueError(
+                            f'save_dir should be specified in {vis_backend} or '
+                            f'{self.__class__.__name__}')
+                self._vis_backends[name] = VISBACKENDS.build(vis_backend)
         else:
             print_log(
                 '`Visualizer` backend is not initialized '

--- a/mmengine/visualization/visualizer.py
+++ b/mmengine/visualization/visualizer.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple, Union
 if TYPE_CHECKING:
     from matplotlib.font_manager import FontProperties
 
-import logging
-
 import cv2
 import numpy as np
 import torch
@@ -15,7 +13,6 @@ import torch.nn.functional as F
 
 from mmengine.config import Config
 from mmengine.dist import master_only
-from mmengine.logging import print_log
 from mmengine.registry import VISBACKENDS, VISUALIZERS
 from mmengine.structures import BaseDataElement
 from mmengine.utils import ManagerMixin
@@ -201,12 +198,6 @@ class Visualizer(ManagerMixin):
                             f'save_dir should be specified in {vis_backend} or '
                             f'{self.__class__.__name__}')
                 self._vis_backends[name] = VISBACKENDS.build(vis_backend)
-        else:
-            print_log(
-                '`Visualizer` backend is not initialized '
-                'because vis_backends is None.',
-                logger='current',
-                level=logging.WARNING)
 
         self.fig_save = None
         self.fig_save_cfg = fig_save_cfg

--- a/mmengine/visualization/visualizer.py
+++ b/mmengine/visualization/visualizer.py
@@ -185,7 +185,6 @@ class Visualizer(ManagerMixin):
             if None not in names and len(set(names)) != len(names):
                 raise RuntimeError('The name fields cannot be the same')
 
-            # check if vis_backends are initialized
             if save_dir is not None:
                 save_dir = osp.join(save_dir, 'vis_data')
             for vis_backend in vis_backends:
@@ -195,11 +194,10 @@ class Visualizer(ManagerMixin):
                         vis_backend['save_dir'] = save_dir
                     else:
                         raise ValueError(
-                            f'save_dir should be specified in {vis_backend} or '
-                            f'{self.__class__.__name__}')
+                            f'save_dir should be specified in {vis_backend} '
+                            f'or {self.__class__.__name__}')
                 self._vis_backends[name] = VISBACKENDS.build(vis_backend)
 
-        self.fig_save = None
         self.fig_save_cfg = fig_save_cfg
         self.fig_show_cfg = fig_show_cfg
 

--- a/mmengine/visualization/visualizer.py
+++ b/mmengine/visualization/visualizer.py
@@ -164,14 +164,7 @@ class Visualizer(ManagerMixin):
         super().__init__(name)
         self._dataset_meta: Optional[dict] = None
         self._vis_backends: Union[Dict, Dict[str, 'BaseVisBackend']] = dict()
-
-        if save_dir is None:
-            print_log(
-                '`Visualizer` backend is not initialized '
-                'because save_dir is None.',
-                logger='current',
-                level=logging.WARNING)
-        elif vis_backends is not None:
+        if vis_backends is not None:
             assert len(vis_backends) > 0, 'empty list'
             names = [
                 vis_backend.get('name', None) for vis_backend in vis_backends
@@ -194,11 +187,18 @@ class Visualizer(ManagerMixin):
             if None not in names and len(set(names)) != len(names):
                 raise RuntimeError('The name fields cannot be the same')
 
-            save_dir = osp.join(save_dir, 'vis_data')
+            save_dir = osp.join(save_dir, 'vis_data') if save_dir else None
 
             for vis_backend in vis_backends:
                 name = vis_backend.pop('name', vis_backend['type'])
-                vis_backend.setdefault('save_dir', save_dir)
+                backend_save_dir = vis_backend.setdefault('save_dir', save_dir)
+                if backend_save_dir is None:
+                    print_log(
+                        f'`Visualizer` backend {name} is not initialized '
+                        'and save_dir in Visualizer is None.',
+                        logger='current',
+                        level=logging.WARNING)
+                    continue
                 self._vis_backends[name] = VISBACKENDS.build(vis_backend)
 
         self.fig_save = None

--- a/tests/test_visualizer/test_visualizer.py
+++ b/tests/test_visualizer/test_visualizer.py
@@ -68,7 +68,7 @@ class TestVisualizer(TestCase):
         visualizer = Visualizer(image=self.image)
         visualizer.get_image()
 
-        # build without visualizer without `save_dir`
+        # build visualizer without `save_dir`
         visualizer = Visualizer(
             vis_backends=copy.deepcopy(self.vis_backend_cfg))
 

--- a/tests/test_visualizer/test_visualizer.py
+++ b/tests/test_visualizer/test_visualizer.py
@@ -11,7 +11,6 @@ import torch
 import torch.nn as nn
 
 from mmengine import VISBACKENDS, Config
-from mmengine.logging import MMLogger
 from mmengine.visualization import Visualizer
 
 
@@ -69,14 +68,9 @@ class TestVisualizer(TestCase):
         visualizer = Visualizer(image=self.image)
         visualizer.get_image()
 
-        # test save_dir
-        # Warning should be raised since no backend is initialized.
-        with self.assertLogs(MMLogger.get_current_instance(), level='WARNING'):
-            Visualizer()
-
-        visualizer = Visualizer(
-            vis_backends=copy.deepcopy(self.vis_backend_cfg))
-        assert visualizer.get_backend('mock1') is None
+        with pytest.raises(ValueError):
+            visualizer = Visualizer(
+                vis_backends=copy.deepcopy(self.vis_backend_cfg))
 
         visualizer = Visualizer(
             vis_backends=copy.deepcopy(self.vis_backend_cfg),

--- a/tests/test_visualizer/test_visualizer.py
+++ b/tests/test_visualizer/test_visualizer.py
@@ -68,9 +68,9 @@ class TestVisualizer(TestCase):
         visualizer = Visualizer(image=self.image)
         visualizer.get_image()
 
-        with pytest.raises(ValueError):
-            visualizer = Visualizer(
-                vis_backends=copy.deepcopy(self.vis_backend_cfg))
+        # build without visualizer without `save_dir`
+        visualizer = Visualizer(
+            vis_backends=copy.deepcopy(self.vis_backend_cfg))
 
         visualizer = Visualizer(
             vis_backends=copy.deepcopy(self.vis_backend_cfg),


### PR DESCRIPTION
## Motivation

To solve PR #1267 .

## Modification

Change the logic in the constructor of Visualizer. 
If vis_backends is not None, then check whether save_dir is None. If true, and if any of vis_backends has no save_dir, give users a warning. If vis_backends is None, give users a warning.