### PR TITLE
Add the loop stage in message_hub

### DIFF
--- a/mmengine/hooks/runtime_info_hook.py
+++ b/mmengine/hooks/runtime_info_hook.py
@@ -149,8 +149,8 @@ class RuntimeInfoHook(Hook):
                     runner.message_hub.update_info(f'val/{key}', value)
 
     def after_val(self, runner) -> None:
-        # ValLoop may be called within in the TrainLoop, so we need to reset
-        # the loop_state
+        # ValLoop may be called within the TrainLoop, so we need to reset
+        # the loop_stage
         # workflow: before_train -> before_val -> after_val -> after_train
         if self.last_loop_stage == 'train':
             runner.message_hub.update_info('loop_stage', self.last_loop_stage)

--- a/mmengine/logging/message_hub.py
+++ b/mmengine/logging/message_hub.py
@@ -202,6 +202,20 @@ class MessageHub(ManagerMixin):
         self._set_resumed_keys(key, resumed)
         self._runtime_info[key] = value
 
+    def pop_info(self, key: str, default: Optional[Any] = None) -> Any:
+        """Remove runtime information by key. If the key does not exist, this
+        method will return the default value.
+
+        Args:
+            key (str): Key of runtime information.
+            default (Any, optional): The default returned value for the
+                given key.
+
+        Returns:
+            Any: The runtime information if the key exists.
+        """
+        return self._runtime_info.pop(key, default)
+
     def update_info_dict(self, info_dict: dict, resumed: bool = True) -> None:
         """Update runtime information with dictionary.
 
@@ -289,7 +303,7 @@ class MessageHub(ManagerMixin):
         return self.log_scalars[key]
 
     def get_info(self, key: str, default: Optional[Any] = None) -> Any:
-        """Get runtime information by key. if the key does not exist, this
+        """Get runtime information by key. If the key does not exist, this
         method will return default information.
 
         Args:

--- a/tests/test_logging/test_message_hub.py
+++ b/tests/test_logging/test_message_hub.py
@@ -55,6 +55,14 @@ class TestMessageHub:
         message_hub.update_info('key', 1)
         assert message_hub.runtime_info['key'] == 1
 
+    def test_pop_info(self):
+        message_hub = MessageHub.get_instance('mmengine')
+        message_hub.update_info('pop_key', 'pop_info')
+        assert message_hub.runtime_info['pop_key'] == 'pop_info'
+        assert message_hub.pop_info('pop_key') == 'pop_info'
+
+        assert message_hub.pop_info('not_existed_key', 'info') == 'info'
+
     def test_update_infos(self):
         message_hub = MessageHub.get_instance('mmengine')
         # test runtime value can be overwritten.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Users might want to execute different logic in the `transform` of the pipeline (such as `RandomCrop`) based on the current stage (train, val, or test).

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

```python
from mmcv.transforms import BaseTransform
from mmengine.logging import MessageHub

class CustomTransform(BaseTransform):
    def __init__(self):
        self.message_hub = MessageHub.get_current_instance()
    
     def transform(self, results: dict) -> dict:
         loop_stage = message_hub.get_info('loop_stage')
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
