### PR TITLE
[CodeCamp2023-305] Improve Visualizer Rendering Speed with OpenCV Backend

### DIFF
--- a/mmengine/visualization/utils.py
+++ b/mmengine/visualization/utils.py
@@ -120,6 +120,34 @@ def color_val_matplotlib(
         raise TypeError(f'Invalid type for color: {type(colors)}')
 
 
+def color_val_opencv(
+    colors: Union[str, tuple, List[Union[str, tuple]]]
+) -> Union[str, tuple, List[Union[str, tuple]]]:
+    """Convert various input in BGR order to normalized BGR opencv color
+    tuples,
+    Args:
+        colors (Union[str, tuple, List[Union[str, tuple]]]): Color inputs
+    Returns:
+        Union[str, tuple, List[Union[str, tuple]]]: A tuple of 3 ints
+        indicating BGR channels.
+    """
+    if isinstance(colors, str):
+        return color_str2rgb(colors)
+    elif isinstance(colors, tuple):
+        assert len(colors) == 3
+        for channel in colors:
+            assert 0 <= channel <= 255
+        return colors
+    elif isinstance(colors, list):
+        colors = [
+            color_val_opencv(color)  # type:ignore
+            for color in colors
+        ]
+        return colors
+    else:
+        raise TypeError(f'Invalid type for color: {type(colors)}')
+
+
 def color_str2rgb(color: str) -> tuple:
     """Convert Matplotlib str color to an RGB color which range is 0 to 255,
     silently dropping the alpha channel.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

As https://github.com/open-mmlab/mmengine/issues/1101 described. 

## Modification

I have shown the design ideas in functions such as `__init__`, `get_image`, `draw_lines`, etc. The basic idea is to add a parameter called `backend` to the `Visualizer` to control whether the rendering backend used for drawing is `cv2` or `matplotlib`. The design idea of the drawing function is basically the same as that of `draw_lines`, that is, the original parameters of the function can be input into the drawing function of cv2 as much as possible. If it is not possible, a prompt will be thrown. This is my first draft, which shows the overall implementation idea of this task. If my idea have any problems, please correct me in time. I will complete the remaining code, documents and test cases as soon as possible.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
