### PR TITLE
[Feature] Add RecorderHook

### DIFF
--- a/examples/recorder_hook_test.py
+++ b/examples/recorder_hook_test.py
@@ -67,11 +67,22 @@ val_dataloader = DataLoader(
 # default_hooks = dict(logger=dict(type='LoggerHook', interval=20))
 
 runner = Runner(
-    # default_hooks=default_hooks,
+    # custom_hooks=[
+    #     dict(
+    #         type='RecorderHook',
+    #         recorders=[dict(type='FunctionRecorder', target='x')],
+    #         save_dir='./work_dir',
+    #         print_modification=True)
+    # ],
     custom_hooks=[
         dict(
             type='RecorderHook',
-            recorders=[dict(type='FunctionRecorder', target='self.resnet')],
+            recorders=[
+                dict(
+                    type='AttributeRecorder',
+                    target='self.resnet',
+                    attribute='weight')
+            ],
             save_dir='./work_dir',
             print_modification=True)
     ],

--- a/examples/recorder_hook_test.py
+++ b/examples/recorder_hook_test.py
@@ -1,0 +1,87 @@
+import torch.nn.functional as F
+import torchvision
+import torchvision.transforms as transforms
+from torch.optim import SGD
+from torch.utils.data import DataLoader
+
+from mmengine.evaluator import BaseMetric
+from mmengine.model import BaseModel
+from mmengine.runner import Runner
+
+
+class MMResNet50(BaseModel):
+
+    def __init__(self):
+        super().__init__()
+        self.resnet = torchvision.models.resnet50()
+
+    def forward(self, imgs, labels, mode):
+        x = self.resnet(imgs)
+        if mode == 'loss':
+            return {'loss': F.cross_entropy(x, labels)}
+        elif mode == 'predict':
+            return x, labels
+
+
+class Accuracy(BaseMetric):
+
+    def process(self, data_batch, data_samples):
+        score, gt = data_samples
+        self.results.append({
+            'batch_size': len(gt),
+            'correct': (score.argmax(dim=1) == gt).sum().cpu(),
+        })
+
+    def compute_metrics(self, results):
+        total_correct = sum(item['correct'] for item in results)
+        total_size = sum(item['batch_size'] for item in results)
+        return dict(accuracy=100 * total_correct / total_size)
+
+
+norm_cfg = dict(mean=[0.491, 0.482, 0.447], std=[0.202, 0.199, 0.201])
+train_dataloader = DataLoader(
+    batch_size=32,
+    shuffle=True,
+    dataset=torchvision.datasets.CIFAR10(
+        'data/cifar10',
+        train=True,
+        download=True,
+        transform=transforms.Compose([
+            transforms.RandomCrop(32, padding=4),
+            transforms.RandomHorizontalFlip(),
+            transforms.ToTensor(),
+            transforms.Normalize(**norm_cfg)
+        ])))
+
+val_dataloader = DataLoader(
+    batch_size=32,
+    shuffle=False,
+    dataset=torchvision.datasets.CIFAR10(
+        'data/cifar10',
+        train=False,
+        download=True,
+        transform=transforms.Compose(
+            [transforms.ToTensor(),
+             transforms.Normalize(**norm_cfg)])))
+
+# default_hooks = dict(logger=dict(type='LoggerHook', interval=20))
+
+runner = Runner(
+    # default_hooks=default_hooks,
+    custom_hooks=[
+        dict(
+            type='RecorderHook',
+            recorders=[dict(type='FunctionRecorder', target='self.resnet')],
+            save_dir='./work_dir',
+            print_modification=True)
+    ],
+    model=MMResNet50(),
+    work_dir='./work_dir',
+    train_dataloader=train_dataloader,
+    optim_wrapper=dict(optimizer=dict(type=SGD, lr=0.001, momentum=0.9)),
+    train_cfg=dict(by_epoch=True, max_epochs=5, val_interval=1),
+    val_dataloader=val_dataloader,
+    val_cfg=dict(),
+    val_evaluator=dict(type=Accuracy),
+)
+runner.train()

--- a/mmengine/hooks/__init__.py
+++ b/mmengine/hooks/__init__.py
@@ -9,6 +9,7 @@ from .logger_hook import LoggerHook
 from .naive_visualization_hook import NaiveVisualizationHook
 from .param_scheduler_hook import ParamSchedulerHook
 from .profiler_hook import NPUProfilerHook, ProfilerHook
+from .recorder_hook import RecorderHook
 from .runtime_info_hook import RuntimeInfoHook
 from .sampler_seed_hook import DistSamplerSeedHook
 from .sync_buffer_hook import SyncBuffersHook
@@ -18,5 +19,5 @@ __all__ = [
     'Hook', 'IterTimerHook', 'DistSamplerSeedHook', 'ParamSchedulerHook',
     'SyncBuffersHook', 'EmptyCacheHook', 'CheckpointHook', 'LoggerHook',
     'NaiveVisualizationHook', 'EMAHook', 'RuntimeInfoHook', 'ProfilerHook',
-    'PrepareTTAHook', 'NPUProfilerHook', 'EarlyStoppingHook'
+    'PrepareTTAHook', 'NPUProfilerHook', 'EarlyStoppingHook', 'RecorderHook'
 ]

--- a/mmengine/hooks/recorder_hook.py
+++ b/mmengine/hooks/recorder_hook.py
@@ -5,10 +5,53 @@ import inspect
 import textwrap
 import types
 from typing import Any, List, Optional, Tuple, Union
+from collections import defaultdict
 
 from mmengine.logging import HistoryBuffer, MessageHub
 from mmengine.registry import HOOKS
 from . import Hook
+from abc import ABCMeta, abstractmethod
+
+
+class Recorder(metaclass=ABCMeta):
+    def __init__(self, target: str):
+        self._target = target
+
+    @abstractmethod
+    def rewrite(self, ast_tree):
+        pass
+
+# FunctionRecorder
+class FunctionRecorder(Recorder):
+    def __init__(self, target: str):
+        super().__init__(target)
+        self.visit_assign = self._get_adder_class()
+    # super.__init__()
+
+    def _get_adder_class(self):
+        outer_class = self
+        class FunctionRecorderAdder(ast.NodeTransformer):
+            def visit_Assign(self, node):
+                if node.targets[0].id != outer_class._target:
+                    return node
+                add2messagehub = ast.Expr(
+                    value=ast.Call(
+                        func=ast.Attribute(
+                            value=ast.Name(id='message_hub', ctx=ast.Load()),
+                            attr='update_info',
+                            ctx=ast.Load()),
+                        args=[
+                            ast.Constant(value = node.targets[0].id),
+                            ast.Name(id=node.targets[0].id, ctx=ast.Load())
+                        ],
+                        keywords=[]))
+
+                # 插入print语句
+                return [node, add2messagehub]
+        return FunctionRecorderAdder()
+
+    def rewrite(self, ast_tree):
+        return self.visit_assign.visit(ast_tree)
 
 
 # model的 存到 runner的 message_hub
@@ -19,7 +62,7 @@ class RecorderAdder(ast.NodeTransformer):
             value=ast.Call(
                 func=ast.Attribute(
                     value=ast.Name(id='message_hub', ctx=ast.Load()),
-                    attr='update_scalar',
+                    attr='update_info',
                     ctx=ast.Load()),
                 args=[
                     ast.Constant(value='task'),
@@ -31,31 +74,16 @@ class RecorderAdder(ast.NodeTransformer):
         return [node, add2messagehub]
 
 
-# class RecorderAdder(ast.NodeTransformer):
-#     def visit_Assign(self, node):
-#         # 这将创建一个新的print调用节点
-#         print_call = ast.Expr(
-#             value=ast.Call(
-#                 func=ast.Name(id='RecorderHook', ctx=ast.Load()),
-#                 attr='add2buffer',
-#                 args=[
-#                     ast.Name(id=node.targets[0].id, ctx=ast.Load())
-#                 ],
-#                 keywords=[]
-#             )
-#         )
-#
-#         # 插入print语句
-#         return [node, print_call]
-
-
 @HOOKS.register_module()
 class RecorderHook(Hook):
     priority = 'LOWEST'
 
+    # RECORDER_MESSAGEHUB_NAME = "_recorder"
+
     # recorder = FunctionRecorder()
 
     def __init__(self, ):
+        self.tensor_dict = defaultdict(list)
         pass
 
     def _get_ast(source_code):
@@ -75,7 +103,7 @@ class RecorderHook(Hook):
             level=0)
 
         func_body = tree.body[0].body
-        import_statement = ast.ImportFrom(
+        import_messagehub_statement = ast.ImportFrom(
             module='mmengine.logging',
             names=[ast.alias(name='MessageHub')],
             level=0)
@@ -84,15 +112,17 @@ class RecorderHook(Hook):
             value=ast.Call(
                 func=ast.Attribute(
                     value=ast.Name(id='MessageHub', ctx=ast.Load()),
-                    attr='get_instance',
+                    attr='get_current_instance',
                     ctx=ast.Load()),
-                args=[ast.Constant(value='mmengine')],
+                args=[],
                 keywords=[]))
-        tree.body[0].body = [import_statement, add_message_hub] + func_body
+
+        tree.body[0].body = [import_messagehub_statement, add_message_hub] + func_body
         # tree.body[0].body.insert(0, import_statement)
 
         # 修改AST
-        tree = RecorderAdder().visit(tree)
+        # breakpoint()
+        tree = FunctionRecorder("x").rewrite(tree)
         tree = ast.fix_missing_locations(tree)
 
         print(ast.dump(tree, indent=4))
@@ -113,12 +143,16 @@ class RecorderHook(Hook):
         log_scalars = dict(loss=HistoryBuffer())
         runtime_info = dict()
         resumed_keys = dict(loss=True)
-        # create `MessageHub` from data.
-        self.message_hub2 = MessageHub(
-            name='name',
-            log_scalars=log_scalars,
-            runtime_info=runtime_info,
-            resumed_keys=resumed_keys)
+        # # create `MessageHub` from data.
+        # self.message_hub2 = MessageHub(
+        #     name=RecorderHook.RECORDER_MESSAGEHUB_NAME,
+        #     log_scalars=log_scalars,
+        #     runtime_info=runtime_info,
+        #     resumed_keys=resumed_keys)
+        # self.message_hub2.update_info("task", "1111")
+        # self.message_hub2.update_info("task", {1231312: "dfasfd"})
+        self.message_hub2 = MessageHub.get_current_instance()
+
         model = runner.model
         print('---------------------------')
         # breakpoint()
@@ -131,4 +165,7 @@ class RecorderHook(Hook):
                          batch_idx: int,
                          data_batch=None,
                          outputs=None) -> None:
-        print(self.message_hub2.__dict__)
+
+        # print(self.message_hub2.__dict__)
+        # print(self.message_hub2.get_info("task"))
+        self.tensor_dict["task"].append(self.message_hub2.get_info("task"))

--- a/mmengine/hooks/recorder_hook.py
+++ b/mmengine/hooks/recorder_hook.py
@@ -127,8 +127,8 @@ class RecorderHook(Hook):
             self._modify_func(model.forward), model)
 
     def after_train_iter(self,
-                        runner,
-                        batch_idx: int,
-                        data_batch = None,
-                        outputs = None) -> None:
+                         runner,
+                         batch_idx: int,
+                         data_batch=None,
+                         outputs=None) -> None:
         print(self.message_hub2.__dict__)

--- a/mmengine/hooks/recorder_hook.py
+++ b/mmengine/hooks/recorder_hook.py
@@ -23,8 +23,8 @@ class Recorder(metaclass=ABCMeta):
         pass
 
 
-# FunctionRecorder
-class FunctionRecorder(Recorder):
+# AttributeRecorder
+class AttributeRecorder(Recorder):
 
     def __init__(self, target: str):
         super().__init__(target)
@@ -35,7 +35,7 @@ class FunctionRecorder(Recorder):
     def _get_adder_class(self):
         outer_class = self
 
-        class FunctionRecorderAdder(ast.NodeTransformer):
+        class AttributeRecorderAdder(ast.NodeTransformer):
 
             def visit_Assign(self, node):
                 if node.targets[0].id != outer_class._target:
@@ -55,7 +55,7 @@ class FunctionRecorder(Recorder):
                 # 插入print语句
                 return [node, add2messagehub]
 
-        return FunctionRecorderAdder()
+        return AttributeRecorderAdder()
 
     def rewrite(self, ast_tree):
         return self.visit_assign.visit(ast_tree)
@@ -87,7 +87,7 @@ class RecorderHook(Hook):
 
     # RECORDER_MESSAGEHUB_NAME = "_recorder"
 
-    # recorder = FunctionRecorder()
+    # recorder = AttributeRecorder()
 
     def __init__(self, ):
         self.tensor_dict = defaultdict(list)
@@ -131,7 +131,7 @@ class RecorderHook(Hook):
 
         # 修改AST
         # breakpoint()
-        tree = FunctionRecorder('x').rewrite(tree)
+        tree = AttributeRecorder('x').rewrite(tree)
         tree = ast.fix_missing_locations(tree)
 
         print(ast.dump(tree, indent=4))

--- a/mmengine/hooks/recorder_hook.py
+++ b/mmengine/hooks/recorder_hook.py
@@ -4,7 +4,7 @@ import inspect
 import textwrap
 import types
 from abc import ABCMeta, abstractmethod
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from mmengine.logging import MessageHub
 from mmengine.registry import HOOKS, RECORDERS
@@ -12,6 +12,7 @@ from . import Hook
 
 
 class AttributeRecorderAdder(ast.NodeTransformer):
+
     def __init__(self, target):
         super().__init__()
         self._target = target
@@ -159,9 +160,11 @@ class RecorderHook(Hook):
     priority = 'LOWEST'
 
     def __init__(self, recorders: Optional[List[Dict]] = None):
-        self.tensor_dict = {}
+        self.tensor_dict: Dict[str, Any] = {}
         self.origin_forward = None
-        self._recorders = {}
+        self._recorders: Dict[str, Recorder] = {}
+        if recorders is None:
+            raise ValueError('recorders not initialized')
         for recorder in recorders:
             assert recorder.get('target') is not None
             self.tensor_dict[recorder['target']] = list()

--- a/mmengine/hooks/recorder_hook.py
+++ b/mmengine/hooks/recorder_hook.py
@@ -1,0 +1,160 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import ast
+import dis
+import inspect
+import textwrap
+from typing import Any, List, Optional, Tuple, Union
+
+from mmengine.registry import HOOKS
+from . import Hook
+
+
+class FunctionRecorder():
+
+    def __init__(self):
+        self._data_buffer: List = list()
+        self.now_epoch = 0
+
+    @property
+    def data_buffer(self) -> List:
+        """list: data buffer."""
+        return self._data_buffer
+
+    def func_after_assign(self):
+        pass
+
+    def next_epoch(self):
+        self.now_epoch += 1
+
+    def get_record_data(self,
+                        record_idx: int = 0,
+                        data_idx: Optional[int] = None) -> Any:
+        """Get data from ``data_buffer``.
+
+        Args:
+            record_idx (int): The index of the record saved in
+                ``data_buffer``. If a source is executed N times during
+                forward, there will be N records in ``data_buffer``.
+            data_index (int, optional):  The index of target data in
+                a record. A record may be a tuple or a list, if data_idx is
+                None, the whole list or tuple is returned. Defaults to None.
+
+        Returns:
+            Any: The type of the return value is undefined, and different
+                source data may have different types.
+        """
+        assert record_idx < len(self._data_buffer), \
+            'record_idx is illegal. The length of data_buffer is ' \
+            f'{len(self._data_buffer)}, but record_idx is ' \
+            f'{record_idx}.'
+
+        record = self._data_buffer[record_idx]
+
+        if data_idx is None:
+            target_data = record
+        else:
+            if isinstance(record, (list, tuple)):
+                assert data_idx < len(record), \
+                    'data_idx is illegal. The length of record is ' \
+                    f'{len(record)}, but data_idx is {data_idx}.'
+                target_data = record[data_idx]
+            else:
+                raise TypeError('When data_idx is not None, record should be '
+                                'a list or tuple instance, but got '
+                                f'{type(record)}.')
+
+        return target_data
+
+    def reset_data_buffer(self) -> None:
+        """Clear data in data_buffer."""
+
+        self._data_buffer = list()
+
+
+# model的 存到 runner的 message_hub
+class RecorderAdder(ast.NodeTransformer):
+
+    def visit_Assign(self, node):
+        # 这将创建一个新的print调用节点
+        print_call = ast.Expr(
+            value=ast.Call(
+                func=ast.Name(id='print', ctx=ast.Load()),
+                args=[
+                    ast.Str(s='Assigning to variable '),
+                    ast.Name(id=node.targets[0].id, ctx=ast.Load())
+                ],
+                keywords=[]))
+
+        # 插入print语句
+        return [node, print_call]
+
+
+# class RecorderAdder(ast.NodeTransformer):
+#     def visit_Assign(self, node):
+#         # 这将创建一个新的print调用节点
+#         print_call = ast.Expr(
+#             value=ast.Call(
+#                 func=ast.Name(id='RecorderHook', ctx=ast.Load()),
+#                 attr='add2buffer',
+#                 args=[
+#                     ast.Name(id=node.targets[0].id, ctx=ast.Load())
+#                 ],
+#                 keywords=[]
+#             )
+#         )
+#
+#         # 插入print语句
+#         return [node, print_call]
+
+
+@HOOKS.register_module()
+class RecorderHook(Hook):
+    priority = 'LOWEST'
+
+    recorder = FunctionRecorder()
+
+    def __init__(self, ):
+        pass
+
+    def _modify_func(self, func):
+        # 获取函数的源代码
+        source = inspect.getsource(func)
+        source = textwrap.dedent(source)
+
+        # 解析源代码为AST
+        tree = ast.parse(source)
+
+        import_from_statement = ast.ImportFrom(
+            module='mmengine.hooks',
+            names=[ast.alias(name='RecorderHook', asname=None)],
+            level=0)
+
+        tree.body[0].body.insert(0, import_from_statement)
+
+        # 修改AST
+        tree = RecorderAdder().visit(tree)
+        tree = ast.fix_missing_locations(tree)
+
+        # print(ast.dump(tree, indent=4))
+
+        # 编译修改后的AST为一个新的函数
+        namespace = {}
+        exec(
+            compile(tree, filename='<ast>', mode='exec'), func.__globals__,
+            namespace)
+        return namespace[func.__name__]
+
+    def before_run(self, runner) -> None:
+        """Check `stop_training` variable in `runner.train_loop`.
+
+        Args:
+            runner (Runner): The runner of the training process.
+        """
+        import dis
+        model = runner.model
+        print('---------------------------')
+        # breakpoint()
+        import types
+
+        model.forward = types.MethodType(
+            self._modify_func(model.forward), model)

--- a/mmengine/hooks/recorder_hook.py
+++ b/mmengine/hooks/recorder_hook.py
@@ -124,9 +124,8 @@ class AttributeRecorderTransformer(ast.NodeTransformer):
 
 class Recorder(metaclass=ABCMeta):
 
-    def __init__(self, target: str, saved_tensor_key: str):
+    def __init__(self, target: str):
         self._target = target
-        self._saved_tensor_key = saved_tensor_key
 
     @abstractmethod
     def rewrite(self, ast_tree):
@@ -136,8 +135,8 @@ class Recorder(metaclass=ABCMeta):
 @RECORDERS.register_module()
 class FunctionRecorder(Recorder):
 
-    def __init__(self, target: str, saved_tensor_key: str):
-        super().__init__(target, saved_tensor_key)
+    def __init__(self, target: str):
+        super().__init__(target)
         self.visit_assign = self._get_transformer_class()
 
     def _get_transformer_class(self):
@@ -150,11 +149,8 @@ class FunctionRecorder(Recorder):
 @RECORDERS.register_module()
 class AttributeRecorder(Recorder):
 
-    def __init__(self,
-                 target: str,
-                 saved_tensor_key: str,
-                 attribute: str = None):
-        super().__init__(target, saved_tensor_key)
+    def __init__(self, target: str, attribute: str = None):
+        super().__init__(target)
         self.attribute = attribute
         self.visit_assign = self._get_transformer_class()
 

--- a/mmengine/hooks/recorder_hook.py
+++ b/mmengine/hooks/recorder_hook.py
@@ -59,7 +59,6 @@ class FuncCallVisitor(ast.NodeTransformer):
         else:
             # 倒序遍历call_chain_list
             for i in range(len(call_chain_list) - 1, 0, -1):
-                print(ast.dump(call_node))
                 if isinstance(call_node, ast.Attribute
                               ) and call_node.attr == call_chain_list[i]:
                     call_node = call_node.value
@@ -168,14 +167,11 @@ class FunctionRecorder(Recorder):
 class RecorderHook(Hook):
     priority = 'LOWEST'
 
-    # RECORDER_MESSAGEHUB_NAME = "_recorder"
-
-    # recorder = AttributeRecorder()
-
-    def __init__(self, ):
+    def __init__(self, 
+                recorders: Optional[List[Dict]] = None):
         self.tensor_dict = defaultdict(list)
         self.origin_forward = None
-        pass
+        self._recorders = []
 
     def _get_ast(source_code):
         return ast.parse(source_code)

--- a/mmengine/registry/__init__.py
+++ b/mmengine/registry/__init__.py
@@ -6,9 +6,9 @@ from .registry import Registry
 from .root import (DATA_SAMPLERS, DATASETS, EVALUATOR, FUNCTIONS, HOOKS,
                    INFERENCERS, LOG_PROCESSORS, LOOPS, METRICS, MODEL_WRAPPERS,
                    MODELS, OPTIM_WRAPPER_CONSTRUCTORS, OPTIM_WRAPPERS,
-                   OPTIMIZERS, PARAM_SCHEDULERS, RUNNER_CONSTRUCTORS, RUNNERS,
-                   STRATEGIES, TASK_UTILS, TRANSFORMS, VISBACKENDS,
-                   VISUALIZERS, WEIGHT_INITIALIZERS)
+                   OPTIMIZERS, PARAM_SCHEDULERS, RECORDERS,
+                   RUNNER_CONSTRUCTORS, RUNNERS, STRATEGIES, TASK_UTILS,
+                   TRANSFORMS, VISBACKENDS, VISUALIZERS, WEIGHT_INITIALIZERS)
 from .utils import (count_registered_modules, init_default_scope,
                     traverse_registry_tree)
 
@@ -20,5 +20,6 @@ __all__ = [
     'VISBACKENDS', 'VISUALIZERS', 'LOG_PROCESSORS', 'EVALUATOR', 'INFERENCERS',
     'DefaultScope', 'traverse_registry_tree', 'count_registered_modules',
     'build_model_from_cfg', 'build_runner_from_cfg', 'build_from_cfg',
-    'build_scheduler_from_cfg', 'init_default_scope', 'FUNCTIONS', 'STRATEGIES'
+    'build_scheduler_from_cfg', 'init_default_scope', 'FUNCTIONS',
+    'STRATEGIES', 'RECORDERS'
 ]

--- a/mmengine/registry/root.py
+++ b/mmengine/registry/root.py
@@ -57,6 +57,9 @@ VISUALIZERS = Registry('visualizer')
 # manage visualizer backend
 VISBACKENDS = Registry('vis_backend')
 
+# manage recorders
+RECORDERS = Registry('recorder')
+
 # manage logprocessor
 LOG_PROCESSORS = Registry('log_processor')
 


### PR DESCRIPTION
## A glcc summer camp project. 

## Motivation

The user expects to visualize the output of any layer of the network in the visualization hook, not necessarily the output of nn.module.forward, but also intermediate variables, and will inevitably need to invasively modify the code to update the output into the message hub. Then retrieve the value of the message hub in the visualization hook for visualization. Rather than intrusively modifying the code, we want to have a scheme that can non-intrusively obtain the output of any layer of the network. In addition, it also needs to provide the ability to get properties of a specified instance.

## Modification

In short, use ast module to modify the forward function of `runner.model`.
Here is a simple example.

```python
class MMResNet50(BaseModel):

    def __init__(self):
        super().__init__()
        self.resnet = torchvision.models.resnet50()

    def forward(self, imgs, labels, mode):
        x = self.resnet(imgs)
        if mode == 'loss':
            return {'loss': F.cross_entropy(x, labels)}
        elif mode == 'predict':
            return x, labels
```

The API of RecorderHook is like this:
```python
cfg.custom_hooks = [
    dict(
        type='RecorderHook',
        recorders=[
            dict(type='FunctionRecorder', ...),  # Function recorder1
            dict(type='FunctionRecorder', ...),  # Function recorder2
            dict(type='AttributeRecorder', ...)  # AttributeRecorder1
            ... 
        ],
    )
]
```
RecorderHook uses FunctionRecorder and AttributeRecorder to record different things in `forward` method.

### FunctionRecorder

#### function

Gets the output and intermediate variables of the specified function or method.

#### case

```python
    custom_hooks=[
        dict(
            type='RecorderHook',
            recorders=[dict(type='FunctionRecorder', target='x')],
            save_dir='./work_dir',
            print_modification=True)
    ],

```

#### Forward method after modification

```python
def forward(self, imgs, labels, mode):
    from mmengine.logging import MessageHub
    message_hub = MessageHub.get_current_instance()
    x = self.resnet(imgs)
    message_hub.update_info('x', x)
    if mode == 'loss':
        return {'loss': F.cross_entropy(x, labels)}
    elif mode == 'predict':
        return (x, labels)

```

### AttributeRecorder

#### function

Gets the value of the specified property.

#### case

```python
    custom_hooks=[
        dict(
            type='RecorderHook',
            recorders=[dict(type='AttributeRecorder', target='self.resnet', attribute='weight')],
            save_dir='./work_dir',
            print_modification=True)
    ],

```

#### Forward method after modification
*There is bug here*

```python
def forward(self, imgs, labels, mode):
    from mmengine.logging import MessageHub
    message_hub = MessageHub.get_current_instance()
    self_resnet_weight = self.resnet(imgs)
    message_hub.update_info('self_resnet_weight', self_resnet_weight.weight)
    x = self_resnet
    if mode == 'loss':
        return {'loss': F.cross_entropy(x, labels)}
    elif mode == 'predict':
        return (x, labels)
```

## TODO

* Add test cases.
* Recorder attribute of child module. For example, record tensors in self.resnet's forward method.
* Tensors could have the same name. Record all of them or should the user points out which one to record?

