### PR TITLE
[Enhance] turn Runner.build_model / .build_evaluator / .build_log_processor

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -789,7 +789,8 @@ class Runner:
                 'visualizer should be Visualizer object, a dict or None, '
                 f'but got {visualizer}')
 
-    def build_model(self, model: Union[nn.Module, Dict]) -> nn.Module:
+    @staticmethod
+    def build_model(model: Union[nn.Module, Dict]) -> nn.Module:
         """Build model.
 
         If ``model`` is a dict, it will be used to build a nn.Module object.
@@ -1259,8 +1260,8 @@ class Runner:
 
             return param_schedulers
 
-    def build_evaluator(self, evaluator: Union[Dict, List,
-                                               Evaluator]) -> Evaluator:
+    @staticmethod
+    def build_evaluator(evaluator: Union[Dict, List, Evaluator]) -> Evaluator:
         """Build evaluator.
 
         Examples of ``evaluator``::
@@ -1591,8 +1592,9 @@ class Runner:
 
         return loop  # type: ignore
 
+    @staticmethod
     def build_log_processor(
-            self, log_processor: Union[LogProcessor, Dict]) -> LogProcessor:
+            log_processor: Union[LogProcessor, Dict]) -> LogProcessor:
         """Build test log_processor.
 
         Examples of ``log_processor``:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Some methods in `Runner` like `Runner.build_model / .build_evaluator / .build_log_processor` can be use as `staticmethod` which can be used without creating an instance of Runner.

## Modification
Modify the `runner.py`


```python

"""line 792"""
def build_model(self, model: Union[nn.Module, Dict]) -> nn.Module

# turn to
@staticmethod
def build_model(model: Union[nn.Module, Dict]) -> nn.Module



"""line 1263"""
def build_evaluator(self, evaluator: Union[Dict, List, Evaluator]) -> Evaluator:

# turn to
@staticmethod
def build_evaluator(evaluator: Union[Dict, List, Evaluator]) -> Evaluator:



"""line 1595"""
def build_log_processor(
        self, log_processor: Union[LogProcessor, Dict]) -> LogProcessor:

# turn to
@staticmethod
def build_log_processor(
        log_processor: Union[LogProcessor, Dict]) -> LogProcessor:
```

## BC-breaking (Optional)
If the downstream repos overwrite `Runner.build_model / .build_evaluator / .build_log_processor`, it is needed to be modified. 

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
