### PR TITLE
[Enhance] Unify the parameter style of DeepSpeedStrategy

### DIFF
--- a/mmengine/_strategy/deepspeed.py
+++ b/mmengine/_strategy/deepspeed.py
@@ -298,6 +298,8 @@ class DeepSpeedStrategy(BaseStrategy):
         if gradient_accumulation_steps is not None:
             self.config['gradient_accumulation_steps'] = \
                 gradient_accumulation_steps
+        else:
+            self.config.setdefault('gradient_accumulation_steps', 1)
         self.config['steps_per_print'] = steps_per_print
         self._inputs_to_half = inputs_to_half
 

--- a/mmengine/_strategy/deepspeed.py
+++ b/mmengine/_strategy/deepspeed.py
@@ -219,10 +219,10 @@ class DeepSpeedStrategy(BaseStrategy):
             config for deepspeed. Defaults to None.
         zero_optimization (dict, optional): Enabling and configuring ZeRO
             memory optimizations. Defaults to None.
-        gradient_clipping (float): Enable gradient clipping with value.
-            Defaults to 1.0.
+        gradient_clipping (float, optional): Enable gradient clipping with
+            value. Defaults to None.
         fp16 (dict, optional): Configuration for using mixed precision/FP16
-            training that leverages NVIDIA's Apex package.
+            training that leverages NVIDIA's Apex package. Defaults to None.
         inputs_to_half (list[int or str], optional): Which inputs are to
             converted to half precision. Defaults to None.
             If ``fp16`` is enabled, it also should be set.
@@ -239,6 +239,12 @@ class DeepSpeedStrategy(BaseStrategy):
             offloading parameter and optimizer states to persistent (NVMe)
             storage. This module uses Linux native asynchronous I/O (libaio).
             Defaults to None.
+        train_micro_batch_size_per_gpu (int, optional): Batch size to be
+            processed by one GPU in one step (without gradient accumulation).
+            Defaults to None.
+        gradient_accumulation_steps (int, optional): Number of training steps
+            to accumulate gradients before averaging and applying them.
+            Defaults to None.
     """
 
     def __init__(
@@ -247,7 +253,7 @@ class DeepSpeedStrategy(BaseStrategy):
         # the following args are for deepspeed
         config: Union[str, dict, None] = None,
         zero_optimization: Optional[dict] = None,
-        gradient_clipping: float = 1.0,
+        gradient_clipping: Optional[float] = None,
         fp16: Optional[dict] = None,
         inputs_to_half: Optional[List[Union[int, str]]] = None,
         bf16: Optional[dict] = None,
@@ -255,7 +261,7 @@ class DeepSpeedStrategy(BaseStrategy):
         activation_checkpointing: Optional[dict] = None,
         aio: Optional[dict] = None,
         train_micro_batch_size_per_gpu: Optional[int] = None,
-        gradient_accumulation_steps: int = 1,
+        gradient_accumulation_steps: Optional[int] = None,
         # disable the log printed by deepseed
         steps_per_print: int = 10000000000000,
         # the following args are for BaseStrategy
@@ -270,7 +276,8 @@ class DeepSpeedStrategy(BaseStrategy):
         self.config = self._parse_config(config)
         if zero_optimization is not None:
             self.config['zero_optimization'] = zero_optimization
-        self.config['gradient_clipping'] = gradient_clipping
+        if gradient_clipping is not None:
+            self.config['gradient_clipping'] = gradient_clipping
         if fp16 is not None:
             self.config['fp16'] = fp16
         if bf16 is not None:
@@ -281,21 +288,16 @@ class DeepSpeedStrategy(BaseStrategy):
             self.config['activation_checkpointing'] = activation_checkpointing
         if aio is not None:
             self.config['aio'] = aio
-
-        if ('train_micro_batch_size_per_gpu' not in self.config
-                and 'train_batch_size' not in self.config):
-            assert train_micro_batch_size_per_gpu is not None, (
-                '`train_micro_batch_size_per_gpu` or `train_batch_size` '
-                'should be set!')
-            self.config['train_micro_batch_size_per_gpu'] = \
-                train_micro_batch_size_per_gpu
-
         if train_micro_batch_size_per_gpu is not None:
             self.config['train_micro_batch_size_per_gpu'] = \
                 train_micro_batch_size_per_gpu
-
-        self.config['gradient_accumulation_steps'] = \
-            gradient_accumulation_steps
+        assert ('train_micro_batch_size_per_gpu' in self.config
+                or 'train_batch_size' in self.config), (
+                    '`train_micro_batch_size_per_gpu` or `train_batch_size` '
+                    'should be set in deepspeed config!')
+        if gradient_accumulation_steps is not None:
+            self.config['gradient_accumulation_steps'] = \
+                gradient_accumulation_steps
         self.config['steps_per_print'] = steps_per_print
         self._inputs_to_half = inputs_to_half
 

--- a/mmengine/_strategy/deepspeed.py
+++ b/mmengine/_strategy/deepspeed.py
@@ -291,10 +291,6 @@ class DeepSpeedStrategy(BaseStrategy):
         if train_micro_batch_size_per_gpu is not None:
             self.config['train_micro_batch_size_per_gpu'] = \
                 train_micro_batch_size_per_gpu
-        assert ('train_micro_batch_size_per_gpu' in self.config
-                or 'train_batch_size' in self.config), (
-                    '`train_micro_batch_size_per_gpu` or `train_batch_size` '
-                    'should be set in deepspeed config!')
         if gradient_accumulation_steps is not None:
             self.config['gradient_accumulation_steps'] = \
                 gradient_accumulation_steps


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Unify the parameter format for `DeepSpeedStrategy`. Parameters such as `gradient_accumulation_steps` are able to override the input deepspeed config, while the default values for these parameters are set to None,  implying no override.

## Modification

`mmengine/_strategy/deepspeed.py`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
