### PR TITLE
[Fix] Fix ndarray metainfo check in ConcatDataset

### DIFF
--- a/mmengine/dataset/dataset_wrapper.py
+++ b/mmengine/dataset/dataset_wrapper.py
@@ -6,6 +6,7 @@ import math
 from collections import defaultdict
 from typing import List, Sequence, Tuple, Union
 
+import numpy as np
 from torch.utils.data.dataset import ConcatDataset as _ConcatDataset
 
 from mmengine.logging import print_log
@@ -73,7 +74,14 @@ class ConcatDataset(_ConcatDataset):
                     raise ValueError(
                         f'{key} does not in the meta information of '
                         f'the {i}-th dataset')
-                if self._metainfo[key] != dataset.metainfo[key]:
+                if isinstance(self._metainfo[key], np.ndarray) and isinstance(
+                        dataset.metainfo[key], np.ndarray):
+                    if not np.array_equal(self._metainfo[key],
+                                          dataset.metainfo[key]):
+                        raise ValueError(
+                            f'The meta information of the {i}-th dataset does'
+                            'not match meta information of the first dataset')
+                elif self._metainfo[key] != dataset.metainfo[key]:
                     raise ValueError(
                         f'The meta information of the {i}-th dataset does not '
                         'match meta information of the first dataset')

--- a/mmengine/dataset/dataset_wrapper.py
+++ b/mmengine/dataset/dataset_wrapper.py
@@ -74,14 +74,16 @@ class ConcatDataset(_ConcatDataset):
                     raise ValueError(
                         f'{key} does not in the meta information of '
                         f'the {i}-th dataset')
-                if isinstance(self._metainfo[key], np.ndarray) and isinstance(
-                        dataset.metainfo[key], np.ndarray):
-                    if not np.array_equal(self._metainfo[key],
-                                          dataset.metainfo[key]):
-                        raise ValueError(
-                            f'The meta information of the {i}-th dataset does'
-                            'not match meta information of the first dataset')
-                elif self._metainfo[key] != dataset.metainfo[key]:
+                first_type = type(self._metainfo[key])
+                cur_type = type(dataset.metainfo[key])
+                if first_type is cur_type:  # type: ignore
+                    raise TypeError(
+                        f'The type of {key} in the {i}-th dataset should be '
+                        'the same with the first dataset')
+                if (isinstance(self._metainfo[key], np.ndarray)
+                        and not np.array_equal(self._metainfo[key],
+                                               dataset.metainfo[key])
+                        or self._metainfo[key] != dataset.metainfo[key]):
                     raise ValueError(
                         f'The meta information of the {i}-th dataset does not '
                         'match meta information of the first dataset')

--- a/mmengine/dataset/dataset_wrapper.py
+++ b/mmengine/dataset/dataset_wrapper.py
@@ -76,10 +76,11 @@ class ConcatDataset(_ConcatDataset):
                         f'the {i}-th dataset')
                 first_type = type(self._metainfo[key])
                 cur_type = type(dataset.metainfo[key])
-                if first_type is cur_type:  # type: ignore
+                if first_type is not cur_type:  # type: ignore
                     raise TypeError(
-                        f'The type of {key} in the {i}-th dataset should be '
-                        'the same with the first dataset')
+                        f'The type {cur_type} of {key} in the {i}-th dataset '
+                        'should be the same with the first dataset '
+                        f'{first_type}')
                 if (isinstance(self._metainfo[key], np.ndarray)
                         and not np.array_equal(self._metainfo[key],
                                                dataset.metainfo[key])


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Be able to check the metainfo which is one numpy ndarray. #1330

## Modification

```python
     if isinstance(self._metainfo[key], np.ndarray) and isinstance(
                        dataset.metainfo[key], np.ndarray):
                    if not np.array_equal(self._metainfo[key],
                                          dataset.metainfo[key]):
                        raise ValueError(
                            f'The meta information of the {i}-th dataset does'
                            'not match meta information of the first dataset')
```

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
