### PR TITLE
[CodeCamp2023-287] Add `DVCLiveVisBackend`

### DIFF
--- a/docs/en/api/visualization.rst
+++ b/docs/en/api/visualization.rst
@@ -36,3 +36,4 @@ visualization Backend
    WandbVisBackend
    ClearMLVisBackend
    NeptuneVisBackend
+   DVCLiveVisBackend

--- a/docs/en/common_usage/visualize_training_log.md
+++ b/docs/en/common_usage/visualize_training_log.md
@@ -1,6 +1,6 @@
 # Visualize Training Logs
 
-MMEngine integrates experiment management tools such as [TensorBoard](https://www.tensorflow.org/tensorboard), [Weights & Biases (WandB)](https://docs.wandb.ai/), [MLflow](https://mlflow.org/docs/latest/index.html), [ClearML](https://clear.ml/docs/latest/docs) and [Neptune](https://docs.neptune.ai/), making it easy to track and visualize metrics like loss and accuracy.
+MMEngine integrates experiment management tools such as [TensorBoard](https://www.tensorflow.org/tensorboard), [Weights & Biases (WandB)](https://docs.wandb.ai/), [MLflow](https://mlflow.org/docs/latest/index.html), [ClearML](https://clear.ml/docs/latest/docs), [Neptune](https://docs.neptune.ai/) and [DVCLive](https://dvc.org/doc/dvclive), making it easy to track and visualize metrics like loss and accuracy.
 
 Below, we'll show you how to configure an experiment management tool in just one line, based on the example from [15 minutes to get started with MMEngine](../get_started/15_minutes.md).
 
@@ -183,8 +183,10 @@ runner.train()
 Recommend not to set `work_dir` as `work_dirs`. Or DVC will give a warning `WARNING:dvclive:Error in cache: bad DVC file name 'work_dirs\xxx.dvc' is git-ignored` if you run experiments in a OpenMMLab's repo.
 ```
 
-More initialization configuration parameters are available at [DVCLive API Reference](https://dvc.org/doc/dvclive/live).
+Open the `report.html` file under `work_dir_dvc`, and you will see the visualization as shown in the following image.
+
+![image](https://github.com/open-mmlab/mmengine/assets/58739961/47d85520-9a4a-4143-a449-12ed7347cc63)
 
 You can also configure a VSCode extension of [DVC](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc) to visualize the training process.
 
-![dvc VSCode extension](https://github.com/open-mmlab/mmengine/assets/27466624/a573e11f-2fed-4775-a0cf-a42f5031dba9)
+More initialization configuration parameters are available at [DVCLive API Reference](https://dvc.org/doc/dvclive/live).

--- a/docs/en/common_usage/visualize_training_log.md
+++ b/docs/en/common_usage/visualize_training_log.md
@@ -149,3 +149,42 @@ runner.train()
 ```
 
 More initialization configuration parameters are available at [neptune.init_run API](https://docs.neptune.ai/api/neptune/#init_run).
+
+## DVCLive
+
+Before using DVCLive, you need to install `dvclive` dependency library and refer to [iterative.ai](https://dvc.org/doc/start) for configuration. Common configurations are as follows:
+
+```bash
+pip install dvclive
+cd ${WORK_DIR}
+git init
+dvc init
+git commit -m "DVC init"
+```
+
+Configure the `Runner` in the initialization parameters of the Runner, and set `vis_backends` to [DVCLiveVisBackend](mmengine.visualization.DVCLiveVisBackend).
+
+```python
+runner = Runner(
+    model=MMResNet50(),
+    work_dir='./work_dir_dvc',
+    train_dataloader=train_dataloader,
+    optim_wrapper=dict(optimizer=dict(type=SGD, lr=0.001, momentum=0.9)),
+    train_cfg=dict(by_epoch=True, max_epochs=5, val_interval=1),
+    val_dataloader=val_dataloader,
+    val_cfg=dict(),
+    val_evaluator=dict(type=Accuracy),
+    visualizer=dict(type='Visualizer', vis_backends=[dict(type='DVCLiveVisBackend')]),
+)
+runner.train()
+```
+
+```{note}
+Recommend not to set `work_dir` as `work_dirs`. Or DVC will give a warning `WARNING:dvclive:Error in cache: bad DVC file name 'work_dirs\xxx.dvc' is git-ignored` if you run experiments in a OpenMMLab's repo.
+```
+
+More initialization configuration parameters are available at [DVCLive API Reference](https://dvc.org/doc/dvclive/live).
+
+You can also configure a VSCode extension of [DVC](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc) to visualize the training process.
+
+![dvc VSCode extension](https://github.com/open-mmlab/mmengine/assets/27466624/a573e11f-2fed-4775-a0cf-a42f5031dba9)

--- a/docs/zh_cn/api/visualization.rst
+++ b/docs/zh_cn/api/visualization.rst
@@ -36,3 +36,4 @@ visualization Backend
    WandbVisBackend
    ClearMLVisBackend
    NeptuneVisBackend
+   DVCLiveVisBackend

--- a/docs/zh_cn/common_usage/visualize_training_log.md
+++ b/docs/zh_cn/common_usage/visualize_training_log.md
@@ -149,3 +149,42 @@ runner.train()
 ```
 
 更多初始化配置参数可点击 [neptune.init_run API](https://docs.neptune.ai/api/neptune/#init_run) 查询。
+
+## DVCLive
+
+使用 DVCLive 前需先安装依赖库 `dvclive` 并参考 [iterative.ai](https://dvc.org/doc/start) 进行配置。常见的配置方式如下：
+
+```bash
+pip install dvclive
+cd ${WORK_DIR}
+git init
+dvc init
+git commit -m "DVC init"
+```
+
+设置 `Runner` 初始化参数中的 `visualizer`，并将 `vis_backends` 设置为 [DVCLiveVisBackend](mmengine.visualization.DVCLiveVisBackend)。
+
+```python
+runner = Runner(
+    model=MMResNet50(),
+    work_dir='./work_dir_dvc',
+    train_dataloader=train_dataloader,
+    optim_wrapper=dict(optimizer=dict(type=SGD, lr=0.001, momentum=0.9)),
+    train_cfg=dict(by_epoch=True, max_epochs=5, val_interval=1),
+    val_dataloader=val_dataloader,
+    val_cfg=dict(),
+    val_evaluator=dict(type=Accuracy),
+    visualizer=dict(type='Visualizer', vis_backends=[dict(type='DVCLiveVisBackend')]),
+)
+runner.train()
+```
+
+```{note}
+推荐将 `work_dir` 设置为 `work_dirs`。否则，你在 OpenMMLab 仓库中运行试验时，DVC 会给出警告 `WARNING:dvclive:Error in cache: bad DVC file name 'work_dirs\xxx.dvc' is git-ignored`。
+```
+
+更多初始化配置参数可点击 [DVCLive API Reference](https://dvc.org/doc/dvclive/live) 查询。
+
+你还可以安装 VSCode 扩展 [DVC](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc) 来可视化训练过程。
+
+![dvc VSCode extension](https://github.com/open-mmlab/mmengine/assets/27466624/a573e11f-2fed-4775-a0cf-a42f5031dba9)

--- a/docs/zh_cn/common_usage/visualize_training_log.md
+++ b/docs/zh_cn/common_usage/visualize_training_log.md
@@ -1,6 +1,6 @@
 # 可视化训练日志
 
-MMEngine 集成了 [TensorBoard](https://www.tensorflow.org/tensorboard?hl=zh-cn)、[Weights & Biases (WandB)](https://docs.wandb.ai/)、[MLflow](https://mlflow.org/docs/latest/index.html) 、[ClearML](https://clear.ml/docs/latest/docs) 和 [Neptune](https://docs.neptune.ai/) 实验管理工具，你可以很方便地跟踪和可视化损失及准确率等指标。
+MMEngine 集成了 [TensorBoard](https://www.tensorflow.org/tensorboard?hl=zh-cn)、[Weights & Biases (WandB)](https://docs.wandb.ai/)、[MLflow](https://mlflow.org/docs/latest/index.html) 、[ClearML](https://clear.ml/docs/latest/docs)、[Neptune](https://docs.neptune.ai/) 和 [DVCLive](https://dvc.org/doc/dvclive) 实验管理工具，你可以很方便地跟踪和可视化损失及准确率等指标。
 
 下面基于[15 分钟上手 MMENGINE](../get_started/15_minutes.md)中的例子介绍如何一行配置实验管理工具。
 
@@ -183,8 +183,10 @@ runner.train()
 推荐将 `work_dir` 设置为 `work_dirs`。否则，你在 OpenMMLab 仓库中运行试验时，DVC 会给出警告 `WARNING:dvclive:Error in cache: bad DVC file name 'work_dirs\xxx.dvc' is git-ignored`。
 ```
 
+打开 `work_dir_dvc` 下面的 `report.html` 文件，即可看到如下图的可视化效果。
+
+![image](https://github.com/open-mmlab/mmengine/assets/58739961/47d85520-9a4a-4143-a449-12ed7347cc63)
+
+你还可以安装 VSCode 扩展 [DVC](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc) 进行可视化。
+
 更多初始化配置参数可点击 [DVCLive API Reference](https://dvc.org/doc/dvclive/live) 查询。
-
-你还可以安装 VSCode 扩展 [DVC](https://marketplace.visualstudio.com/items?itemName=Iterative.dvc) 来可视化训练过程。
-
-![dvc VSCode extension](https://github.com/open-mmlab/mmengine/assets/27466624/a573e11f-2fed-4775-a0cf-a42f5031dba9)

--- a/mmengine/visualization/__init__.py
+++ b/mmengine/visualization/__init__.py
@@ -1,11 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from .vis_backend import (BaseVisBackend, ClearMLVisBackend, LocalVisBackend,
-                          MLflowVisBackend, NeptuneVisBackend,
+from .vis_backend import (BaseVisBackend, ClearMLVisBackend, DVCLiveVisBackend,
+                          LocalVisBackend, MLflowVisBackend, NeptuneVisBackend,
                           TensorboardVisBackend, WandbVisBackend)
 from .visualizer import Visualizer
 
 __all__ = [
     'Visualizer', 'BaseVisBackend', 'LocalVisBackend', 'WandbVisBackend',
     'TensorboardVisBackend', 'MLflowVisBackend', 'ClearMLVisBackend',
-    'NeptuneVisBackend'
+    'NeptuneVisBackend', 'DVCLiveVisBackend'
 ]

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -1280,16 +1280,18 @@ class DVCLiveVisBackend(BaseVisBackend):
         if not hasattr(self, '_dvclive'):
             return
 
-        file_paths = dict()
-        for filename in scandir(self.cfg.work_dir, self._artifact_suffix,
-                                True):
-            file_path = osp.join(self.cfg.work_dir, filename)
-            relative_path = os.path.relpath(file_path, self.cfg.work_dir)
-            dir_path = os.path.dirname(relative_path)
-            file_paths[file_path] = dir_path
+        if (hasattr(self, 'cfg')
+                and osp.isdir(getattr(self.cfg, 'work_dir', ''))):
+            file_paths = dict()
+            for filename in scandir(self.cfg.work_dir, self._artifact_suffix,
+                                    True):
+                file_path = osp.join(self.cfg.work_dir, filename)
+                relative_path = os.path.relpath(file_path, self.cfg.work_dir)
+                dir_path = os.path.dirname(relative_path)
+                file_paths[file_path] = dir_path
 
-        for file_path, dir_path in file_paths.items():
-            self._dvclive.log_artifact(file_path, dir_path)
+            for file_path, dir_path in file_paths.items():
+                self._dvclive.log_artifact(file_path, dir_path)
 
         self._dvclive.end()
 

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -1301,9 +1301,7 @@ class DVCLiveVisBackend(BaseVisBackend):
 
         if isinstance(value, (dict, Config, ConfigDict)):
             return {k: self._to_dvc_paramlike(v) for k, v in value.items()}
-        elif isinstance(value, tuple):
-            return [self._to_dvc_paramlike(item) for item in value]
-        elif isinstance(value, list):
+        elif isinstance(value, (tuple, list)):
             return [self._to_dvc_paramlike(item) for item in value]
         elif isinstance(value, (torch.Tensor, np.ndarray)):
             return value.tolist()

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -1149,6 +1149,9 @@ class DVCLiveVisBackend(BaseVisBackend):
         >>> cfg = Config(dict(a=1, b=dict(b1=[0, 1])))
         >>> dvclive_vis_backend.add_config(cfg)
 
+    Note:
+        `New in version 0.8.5.`
+
     Args:
         save_dir (str, optional): The root directory to save the files
             produced by the visualizer.

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -1159,11 +1159,13 @@ class DVCLiveVisBackend(BaseVisBackend):
             is present and matplotlib is installed and html otherwise.
             If report is None, Live.make_report() won't generate anything.
         save_dvc_exp (bool): If True, DVCLive will create a new DVC experiment
-            as part of Live.end(). Defaults to False.
+            as part of Live.end(). Defaults to True.
         dvcyaml (bool): If True, DVCLive will write DVC configuration for
             metrics, plots, and parameters to Live.dvc_file as part of
             Live.next_step() and Live.end(). See Live.make_dvcyaml().
             Defaults to True.
+        cache_images (bool): If True, DVCLive will cache any images logged
+            with Live.log_image() as part of Live.end(). Defaults to True.
         exp_message (str, Optional): If not None, and save_dvc_exp is True,
             the provided string will be passed to dvc exp save --message.
         artifact_suffix (Tuple[str] or str, optional): The artifact suffix.
@@ -1174,8 +1176,9 @@ class DVCLiveVisBackend(BaseVisBackend):
                  save_dir: str,
                  resume: bool = False,
                  report: Optional[str] = 'auto',
-                 save_dvc_exp: bool = False,
+                 save_dvc_exp: bool = True,
                  dvcyaml: bool = True,
+                 cache_images: bool = True,
                  exp_message: Optional[str] = None,
                  artifact_suffix: SUFFIX_TYPE = ('.json', '.log', '.py',
                                                  'yaml')):
@@ -1184,6 +1187,7 @@ class DVCLiveVisBackend(BaseVisBackend):
         self._report = report
         self._save_dvc_exp = save_dvc_exp
         self._dvcyaml = dvcyaml
+        self._cache_images = cache_images,
         self._exp_message = exp_message
         self._artifact_suffix = artifact_suffix
 
@@ -1198,9 +1202,14 @@ class DVCLiveVisBackend(BaseVisBackend):
             raise ImportError(
                 'Please run "pip install dvclive" to install dvclive')
 
-        self._dvclive = Live(self._save_dir, self._resume, self._report,
-                             self._save_dvc_exp, self._dvcyaml,
-                             self._exp_message)
+        self._dvclive = Live(
+            dir=self._save_dir,
+            resume=self._resume,
+            report=self._report,
+            save_dvc_exp=self._save_dvc_exp,
+            dvcyaml=self._dvcyaml,
+            cache_images=self._cache_images,
+            exp_message=self._exp_message)
 
     @property  # type: ignore
     @force_init_env

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -1181,12 +1181,9 @@ class DVCLiveVisBackend(BaseVisBackend):
                 'Please run "pip install dvclive" to install dvclive')
         # if no git info, init dvc without git to avoid SCMError
         path = pygit2.discover_repository(os.fspath(os.curdir), True, '')
-        sig = pygit2.Repository(path).default_signature()
-        user_name = os.environ.get('GIT_COMMITTER_NAME',
-                                   sig.name if sig else None)
-        user_email = os.environ.get('GIT_COMMITTER_EMAIL',
-                                    sig.email if sig else None)
-        if user_name is None or user_email is None:
+        try:
+            pygit2.Repository(path).default_signature()
+        except KeyError:
             os.system('dvc init -f --no-scm')
 
         if self._init_kwargs is None:

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -12,7 +12,6 @@ from typing import Any, Callable, List, Optional, Sequence, Union
 
 import cv2
 import numpy as np
-import pygit2
 import torch
 
 from mmengine.config import Config, ConfigDict
@@ -1175,6 +1174,7 @@ class DVCLiveVisBackend(BaseVisBackend):
                                'to use DVCLiveVisBackend.')
 
         try:
+            import pygit2
             from dvclive import Live
         except ImportError:
             raise ImportError(

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -1155,7 +1155,7 @@ class DVCLiveVisBackend(BaseVisBackend):
         save_dir (str, optional): The root directory to save the files
             produced by the visualizer.
         artifact_suffix (Tuple[str] or str, optional): The artifact suffix.
-            Defaults to ('.json', '.log', '.py', 'yaml').
+            Defaults to ('.json', '.py', 'yaml').
         init_kwargs (dict, optional): DVCLive initialization parameters.
             See `DVCLive <https://dvc.org/doc/dvclive/live>`_ for details.
             Defaults to None.
@@ -1163,8 +1163,7 @@ class DVCLiveVisBackend(BaseVisBackend):
 
     def __init__(self,
                  save_dir: str,
-                 artifact_suffix: SUFFIX_TYPE = ('.json', '.log', '.py',
-                                                 'yaml'),
+                 artifact_suffix: SUFFIX_TYPE = ('.json', '.py', 'yaml'),
                  init_kwargs: Optional[dict] = None):
         super().__init__(save_dir)
         self._artifact_suffix = artifact_suffix
@@ -1190,15 +1189,10 @@ class DVCLiveVisBackend(BaseVisBackend):
             os.system('dvc init -f --no-scm')
 
         if self._init_kwargs is None:
-            self._init_kwargs = {
-                'dir': self._save_dir,
-                'save_dvc_exp': True,
-                'cache_images': True,
-            }
-        else:
-            self._init_kwargs.setdefault('dir', self._save_dir)
-            self._init_kwargs.setdefault('save_dvc_exp', True)
-            self._init_kwargs.setdefault('cache_images', True)
+            self._init_kwargs = {}
+        self._init_kwargs.setdefault('dir', self._save_dir)
+        self._init_kwargs.setdefault('save_dvc_exp', True)
+        self._init_kwargs.setdefault('cache_images', True)
 
         self._dvclive = Live(**self._init_kwargs)
 
@@ -1278,7 +1272,8 @@ class DVCLiveVisBackend(BaseVisBackend):
             file_path (str, optional): Useless parameter. Just for
                 interface unification. Defaults to None.
         """
-        self._dvclive.log_params(self._to_dvc_paramlike(scalar_dict))
+        for key, value in scalar_dict.items():
+            self.add_scalar(key, value, step, **kwargs)
 
     def close(self) -> None:
         """close an opened dvclive object."""

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -1253,7 +1253,8 @@ class DVCLiveVisBackend(BaseVisBackend):
         """
         if isinstance(value, torch.Tensor):
             value = value.numpy()
-        self._dvclive.log_metric(name, value, step)
+        self._dvclive.step = step
+        self._dvclive.log_metric(name, value)
 
     @force_init_env
     def add_scalars(self,
@@ -1272,7 +1273,6 @@ class DVCLiveVisBackend(BaseVisBackend):
         """
         for key, value in scalar_dict.items():
             self.add_scalar(key, value, step, **kwargs)
-        self._dvclive.next_step()
 
     def close(self) -> None:
         """close an opened dvclive object."""

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -13,7 +13,7 @@ import cv2
 import numpy as np
 import torch
 
-from mmengine.config import Config
+from mmengine.config import Config, ConfigDict
 from mmengine.fileio import dump
 from mmengine.hooks.logger_hook import SUFFIX_TYPE
 from mmengine.logging import MMLogger, print_log
@@ -1130,3 +1130,166 @@ class NeptuneVisBackend(BaseVisBackend):
         """close an opened object."""
         if hasattr(self, '_neptune'):
             self._neptune.stop()
+
+
+@VISBACKENDS.register_module()
+class DVCLiveVisBackend(BaseVisBackend):
+    """DVCLive visualization backend class.
+
+    Examples:
+        >>> from mmengine.visualization import DVCLiveVisBackend
+        >>> import numpy as np
+        >>> dvclive_vis_backend = DVCLiveVisBackend(save_dir='temp_dir')
+        >>> img=np.random.randint(0, 256, size=(10, 10, 3))
+        >>> dvclive_vis_backend.add_image('img', img)
+        >>> dvclive_vis_backend.add_scalar('mAP', 0.6)
+        >>> dvclive_vis_backend.add_scalars({'loss': 0.1, 'acc': 0.8})
+        >>> cfg = Config(dict(a=1, b=dict(b1=[0, 1])))
+        >>> dvclive_vis_backend.add_config(cfg)
+
+    Args:
+        save_dir (str, optional): The root directory to save the files
+            produced by the visualizer.
+        artifact_suffix (Tuple[str] or str, optional): The artifact suffix.
+            Defaults to ('.json', '.log', '.py', 'yaml').
+        init_kwargs (dict, optional): DVCLive initialization parameters.
+            See `DVCLive <https://dvc.org/doc/dvclive/live>`_ for details.
+            Defaults to None.
+    """
+
+    def __init__(self,
+                 save_dir: str,
+                 artifact_suffix: SUFFIX_TYPE = ('.json', '.log', '.py',
+                                                 'yaml'),
+                 init_kwargs: Optional[dict] = None):
+        super().__init__(save_dir)
+        self._artifact_suffix = artifact_suffix
+        self._init_kwargs = init_kwargs
+
+    def _init_env(self):
+        """Setup env for dvclive."""
+        if not os.path.exists(self._save_dir):
+            os.makedirs(self._save_dir, exist_ok=True)  # type: ignore
+
+        try:
+            from dvclive import Live
+        except ImportError:
+            raise ImportError(
+                'Please run "pip install dvclive" to install dvclive')
+
+        if self._init_kwargs is None:
+            self._init_kwargs = {
+                'dir': self._save_dir,
+                'save_dvc_exp': True,
+                'cache_images': True
+            }
+        else:
+            self._init_kwargs.setdefault('dir', self._save_dir)
+            self._init_kwargs.setdefault('save_dvc_exp', True)
+            self._init_kwargs.setdefault('cache_images', True)
+
+        self._dvclive = Live(**self._init_kwargs)
+
+    @property  # type: ignore
+    @force_init_env
+    def experiment(self):
+        """Return dvclive object.
+
+        The experiment attribute can get the dvclive backend, If you want to
+        write other data, such as writing a table, you can directly get the
+        dvclive backend through experiment.
+        """
+        return self._dvclive
+
+    @force_init_env
+    def add_config(self, config: Config, **kwargs) -> None:
+        """Record the config to dvclive.
+
+        Args:
+            config (Config): The Config object
+        """
+        assert isinstance(config, Config)
+        self.cfg = config
+        self._dvclive.log_params(self._to_dict(config))
+
+    @force_init_env
+    def add_image(self,
+                  name: str,
+                  image: np.ndarray,
+                  step: int = 0,
+                  **kwargs) -> None:
+        """Record the image to dvclive.
+
+        Args:
+            name (str): The image identifier.
+            image (np.ndarray): The image to be saved. The format
+                should be RGB.
+            step (int): Useless parameter. Dvclive does not
+                need this parameter. Defaults to 0.
+        """
+        assert image.dtype == np.uint8
+        save_file_name = f'{name}.png'
+
+        self._dvclive.log_image(save_file_name, image)
+
+    @force_init_env
+    def add_scalar(self,
+                   name: str,
+                   value: Union[int, float, torch.Tensor, np.ndarray],
+                   step: int = 0,
+                   **kwargs) -> None:
+        """Record the scalar data to dvclive.
+
+        Args:
+            name (str): The scalar identifier.
+            value (int, float, torch.Tensor, np.ndarray): Value to save.
+            step (int): Useless parameter. Dvclive does not
+                need this parameter. Defaults to 0.
+        """
+        self._dvclive.log_param(name, value)
+
+    @force_init_env
+    def add_scalars(self,
+                    scalar_dict: dict,
+                    step: int = 0,
+                    file_path: Optional[str] = None,
+                    **kwargs) -> None:
+        """Record the scalar's data to dvclive.
+
+        Args:
+            scalar_dict (dict): Key-value pair storing the tag and
+                corresponding values.
+            step (int): Useless parameter. Dvclive does not
+                need this parameter. Defaults to 0.
+            file_path (str, optional): Useless parameter. Just for
+                interface unification. Defaults to None.
+        """
+        self._dvclive.log_params(scalar_dict)
+
+    def close(self) -> None:
+        """close an opened dvclive object."""
+        if not hasattr(self, '_dvclive'):
+            return
+
+        file_paths = dict()
+        for filename in scandir(self.cfg.work_dir, self._artifact_suffix,
+                                True):
+            file_path = osp.join(self.cfg.work_dir, filename)
+            relative_path = os.path.relpath(file_path, self.cfg.work_dir)
+            dir_path = os.path.dirname(relative_path)
+            file_paths[file_path] = dir_path
+
+        for file_path, dir_path in file_paths.items():
+            self._dvclive.log_artifact(file_path, dir_path)
+
+        self._dvclive.end()
+
+    def _to_dict(self, config: Config) -> dict:
+        """Convert the <class 'Config' or 'ConfigDict'> to a normal dictionary
+        recursively."""
+        assert isinstance(config, Config)
+        config_dict = config.to_dict()
+        for k, v in config_dict.items():
+            if isinstance(v, ConfigDict):
+                config_dict[k] = v.to_dict()
+        return config_dict

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -1287,7 +1287,13 @@ class DVCLiveVisBackend(BaseVisBackend):
         for file_path, dir_path in file_paths.items():
             self._dvclive.log_artifact(file_path, dir_path)
 
-        self._dvclive.end()
+        try:
+            self._dvclive.end()
+        except Exception as e:
+            warnings.warn(f'Error occurred when closing DVCLive: {e}\n'
+                          'Try to initialize DVC again without Git.')
+            os.system('dvc init -f --no-scm')
+            self._dvclive.end()
 
     def _to_dict(self, config: Config) -> dict:
         """Convert the <class 'Config' or 'ConfigDict'> to a normal dictionary

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,7 @@
 clearml
 coverage
 dadaptation
+dvclive
 lion-pytorch
 lmdb
 mlflow

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -12,9 +12,10 @@ import torch
 from mmengine import Config
 from mmengine.fileio import load
 from mmengine.registry import VISBACKENDS
-from mmengine.visualization import (ClearMLVisBackend, LocalVisBackend,
-                                    MLflowVisBackend, NeptuneVisBackend,
-                                    TensorboardVisBackend, WandbVisBackend)
+from mmengine.visualization import (ClearMLVisBackend, DVCLiveVisBackend,
+                                    LocalVisBackend, MLflowVisBackend,
+                                    NeptuneVisBackend, TensorboardVisBackend,
+                                    WandbVisBackend)
 
 
 class TestLocalVisBackend:
@@ -391,3 +392,51 @@ class TestNeptuneVisBackend:
         neptune_vis_backend = NeptuneVisBackend()
         neptune_vis_backend._init_env()
         neptune_vis_backend.close()
+
+
+class TestDVCLiveVisBackend:
+
+    def test_init(self):
+        DVCLiveVisBackend('tmp_dir')
+        VISBACKENDS.build(dict(type='DVCLiveVisBackend', save_dir='temp_dir'))
+
+    def test_experiment(self):
+        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        assert dvclive_vis_backend.experiment == dvclive_vis_backend._dvclive
+        shutil.rmtree('temp_dir')
+
+    def test_add_config(self):
+        cfg = Config(dict(a=1, b=dict(b1=[0, 1])))
+        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        dvclive_vis_backend.add_config(cfg)
+        shutil.rmtree('temp_dir')
+
+    def test_add_image(self):
+        img = np.random.randint(0, 256, size=(10, 10, 3)).astype(np.uint8)
+        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        dvclive_vis_backend.add_image('img', img)
+        shutil.rmtree('temp_dir')
+
+    def test_add_scalar(self):
+        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        dvclive_vis_backend.add_scalar('mAP', 0.9)
+        # test append mode
+        dvclive_vis_backend.add_scalar('mAP', 0.9)
+        dvclive_vis_backend.add_scalar('mAP', 0.95)
+        shutil.rmtree('temp_dir')
+
+    def test_add_scalars(self):
+        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        input_dict = {'map': 0.7, 'acc': 0.9}
+        dvclive_vis_backend.add_scalars(input_dict)
+        # test append mode
+        dvclive_vis_backend.add_scalars({'map': 0.8, 'acc': 0.8})
+        shutil.rmtree('temp_dir')
+
+    def test_close(self):
+        cfg = Config(dict(work_dir='temp_dir'))
+        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        dvclive_vis_backend._init_env()
+        dvclive_vis_backend.add_config(cfg)
+        dvclive_vis_backend.close()
+        shutil.rmtree('temp_dir')

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -397,40 +397,46 @@ class TestNeptuneVisBackend:
 class TestDVCLiveVisBackend:
 
     def test_init(self):
-        DVCLiveVisBackend('tmp_dir')
+        DVCLiveVisBackend('temp_dir')
         VISBACKENDS.build(dict(type='DVCLiveVisBackend', save_dir='temp_dir'))
 
     def test_experiment(self):
-        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        dvclive_vis_backend = DVCLiveVisBackend('temp_dir')
         assert dvclive_vis_backend.experiment == dvclive_vis_backend._dvclive
+        shutil.rmtree('temp_dir')
 
     def test_add_config(self):
         cfg = Config(dict(a=1, b=dict(b1=[0, 1])))
-        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        dvclive_vis_backend = DVCLiveVisBackend('temp_dir')
         dvclive_vis_backend.add_config(cfg)
+        shutil.rmtree('temp_dir')
 
     def test_add_image(self):
         img = np.random.randint(0, 256, size=(10, 10, 3)).astype(np.uint8)
-        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        dvclive_vis_backend = DVCLiveVisBackend('temp_dir')
         dvclive_vis_backend.add_image('img', img)
+        shutil.rmtree('temp_dir')
 
     def test_add_scalar(self):
-        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        dvclive_vis_backend = DVCLiveVisBackend('temp_dir')
         dvclive_vis_backend.add_scalar('mAP', 0.9)
         # test append mode
         dvclive_vis_backend.add_scalar('mAP', 0.9)
         dvclive_vis_backend.add_scalar('mAP', 0.95)
+        shutil.rmtree('temp_dir')
 
     def test_add_scalars(self):
-        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        dvclive_vis_backend = DVCLiveVisBackend('temp_dir')
         input_dict = {'map': 0.7, 'acc': 0.9}
         dvclive_vis_backend.add_scalars(input_dict)
         # test append mode
         dvclive_vis_backend.add_scalars({'map': 0.8, 'acc': 0.8})
+        shutil.rmtree('temp_dir')
 
     def test_close(self):
         cfg = Config(dict(work_dir='temp_dir'))
-        dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
+        dvclive_vis_backend = DVCLiveVisBackend('temp_dir')
         dvclive_vis_backend._init_env()
         dvclive_vis_backend.add_config(cfg)
         dvclive_vis_backend.close()
+        shutil.rmtree('temp_dir')

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -403,19 +403,16 @@ class TestDVCLiveVisBackend:
     def test_experiment(self):
         dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
         assert dvclive_vis_backend.experiment == dvclive_vis_backend._dvclive
-        shutil.rmtree('temp_dir')
 
     def test_add_config(self):
         cfg = Config(dict(a=1, b=dict(b1=[0, 1])))
         dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
         dvclive_vis_backend.add_config(cfg)
-        shutil.rmtree('temp_dir')
 
     def test_add_image(self):
         img = np.random.randint(0, 256, size=(10, 10, 3)).astype(np.uint8)
         dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
         dvclive_vis_backend.add_image('img', img)
-        shutil.rmtree('temp_dir')
 
     def test_add_scalar(self):
         dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
@@ -423,7 +420,6 @@ class TestDVCLiveVisBackend:
         # test append mode
         dvclive_vis_backend.add_scalar('mAP', 0.9)
         dvclive_vis_backend.add_scalar('mAP', 0.95)
-        shutil.rmtree('temp_dir')
 
     def test_add_scalars(self):
         dvclive_vis_backend = DVCLiveVisBackend('tmp_dir')
@@ -431,7 +427,6 @@ class TestDVCLiveVisBackend:
         dvclive_vis_backend.add_scalars(input_dict)
         # test append mode
         dvclive_vis_backend.add_scalars({'map': 0.8, 'acc': 0.8})
-        shutil.rmtree('temp_dir')
 
     def test_close(self):
         cfg = Config(dict(work_dir='temp_dir'))
@@ -439,4 +434,3 @@ class TestDVCLiveVisBackend:
         dvclive_vis_backend._init_env()
         dvclive_vis_backend.add_config(cfg)
         dvclive_vis_backend.close()
-        shutil.rmtree('temp_dir')

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import os
+import platform
 import shutil
 import sys
 import warnings
@@ -12,6 +13,7 @@ import torch
 from mmengine import Config
 from mmengine.fileio import load
 from mmengine.registry import VISBACKENDS
+from mmengine.utils import digit_version
 from mmengine.visualization import (ClearMLVisBackend, DVCLiveVisBackend,
                                     LocalVisBackend, MLflowVisBackend,
                                     NeptuneVisBackend, TensorboardVisBackend,
@@ -394,6 +396,9 @@ class TestNeptuneVisBackend:
         neptune_vis_backend.close()
 
 
+@pytest.mark.skipif(
+    digit_version(platform.python_version()) < digit_version('3.8'),
+    reason='DVCLiveVisBackend does not support python version < 3.8')
 class TestDVCLiveVisBackend:
 
     def test_init(self):


### PR DESCRIPTION
## Motivation

Add `DVCLiveVisBackend`

**Note:**
The latest vesion of `dvclive` in Python 3.7 is `0.9.0` which doesn't support `log_param` and `log_params`.
Therefore, Python version should be 3.8 or higher version to use `DVCLiveVisBackend`.