### PR TITLE
[Bugs] Fix a corner case in _lazy2string

### DIFF
--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -15,6 +15,7 @@ from argparse import Action, ArgumentParser, Namespace
 from collections import OrderedDict, abc
 from contextlib import contextmanager
 from pathlib import Path
+from types import FunctionType
 from typing import Any, Optional, Sequence, Tuple, Union
 
 from addict import Dict
@@ -52,6 +53,8 @@ def _lazy2string(cfg_dict, dict_type=None):
         return type(cfg_dict)(_lazy2string(v) for v in cfg_dict)
     elif isinstance(cfg_dict, (LazyAttr, LazyObject)):
         return f'{cfg_dict.module}.{str(cfg_dict)}'
+    elif isinstance(cfg_dict, FunctionType):
+        return str(cfg_dict)
     else:
         return cfg_dict
 


### PR DESCRIPTION
When I import a Python function in the configuration file using a relative path, an error occurs when attempting to convert the config file to pretty_text.

```python
from mmengine import read_base
with read_base():
    from ..xxx import xxx_func
```

We should consider in _lazy2string that a dictionary value can have the type of functiontype.
