### PR TITLE
[Feature] Support bitsandbytes

### DIFF
--- a/docs/en/common_usage/better_optimizers.md
+++ b/docs/en/common_usage/better_optimizers.md
@@ -90,3 +90,34 @@ runner = Runner(
 )
 runner.train()
 ```
+
+## bitsandbytes
+
+[bitsandbytes](https://github.com/TimDettmers/bitsandbytes) provides `AdamW8bit`, `Adam8bit`, `Adagrad8bit`, `PagedAdam8bit`, `PagedAdamW8bit`, `LAMB8bit`, `LARS8bit`, `RMSprop8bit`, `Lion8bit`, `PagedLion8bit` and `SGD8bit` optimziers。
+
+```{note}
+If you use the optimizer provided by bitsandbytes, you need to upgrade mmengine to `0.8.5`.
+```
+
+- Installation
+
+```bash
+pip install bitsandbytes
+```
+
+- Usage
+
+Take the `AdamW8bit` as an example.
+
+```python
+runner = Runner(
+    model=ResNet18(),
+    work_dir='./work_dir',
+    train_dataloader=train_dataloader_cfg,
+    # To view the input parameters for DAdaptAdaGrad, you can refer to
+    # https://github.com/facebookresearch/dadaptation/blob/main/dadaptation/dadapt_adagrad.py
+    optim_wrapper=dict(optimizer=dict(type='AdamW8bit', lr=1e-4, weight_decay=1e-2)),
+    train_cfg=dict(by_epoch=True, max_epochs=3),
+)
+runner.train()
+```

--- a/mmengine/optim/optimizer/builder.py
+++ b/mmengine/optim/optimizer/builder.py
@@ -129,6 +129,34 @@ def register_sophia_optimizers() -> List[str]:
 SOPHIA_OPTIMIZERS = register_sophia_optimizers()
 
 
+def register_bitsandbytes_optimizers() -> List[str]:
+    """Register optimizers in ``bitsandbytes`` to the ``OPTIMIZERS`` registry.
+
+    Returns:
+        List[str]: A list of registered optimizers' name.
+    """
+    dadaptation_optimizers = []
+    try:
+        import bitsandbytes as bnb
+    except ImportError:
+        pass
+    else:
+        for module_name in [
+                'AdamW8bit', 'Adam8bit', 'Adagrad8bit', 'PagedAdam8bit',
+                'PagedAdamW8bit', 'LAMB8bit', 'LARS8bit', 'RMSprop8bit',
+                'Lion8bit', 'PagedLion8bit', 'SGD8bit'
+        ]:
+            _optim = getattr(bnb.optim, module_name)
+            if inspect.isclass(_optim) and issubclass(_optim,
+                                                      torch.optim.Optimizer):
+                OPTIMIZERS.register_module(module=_optim)
+                dadaptation_optimizers.append(module_name)
+    return dadaptation_optimizers
+
+
+BITSANDBYTES_OPTIMIZERS = register_bitsandbytes_optimizers()
+
+
 def build_optim_wrapper(model: nn.Module,
                         cfg: Union[dict, Config, ConfigDict]) -> OptimWrapper:
     """Build function of OptimWrapper.

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,5 @@
 aim
+bitsandbytes
 clearml
 coverage
 dadaptation

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -14,7 +14,8 @@ from mmengine.logging import MMLogger
 from mmengine.optim import (OPTIM_WRAPPER_CONSTRUCTORS, OPTIMIZERS,
                             DefaultOptimWrapperConstructor, OptimWrapper,
                             build_optim_wrapper)
-from mmengine.optim.optimizer.builder import (DADAPTATION_OPTIMIZERS,
+from mmengine.optim.optimizer.builder import (BITSANDBYTES_OPTIMIZERS,
+                                              DADAPTATION_OPTIMIZERS,
                                               LION_OPTIMIZERS,
                                               TORCH_OPTIMIZERS)
 from mmengine.registry import DefaultScope, Registry, build_from_cfg
@@ -39,6 +40,14 @@ def has_dadaptation() -> bool:
 def has_lion() -> bool:
     try:
         import lion_pytorch  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def has_bitsandbytes() -> bool:
+    try:
+        import bitsandbytes  # noqa: F401
         return True
     except ImportError:
         return False
@@ -234,6 +243,16 @@ class TestBuilder(TestCase):
     @unittest.skipIf(not has_lion(), 'lion-pytorch is not installed')
     def test_lion_optimizers(self):
         assert 'Lion' in LION_OPTIMIZERS
+
+    @unittest.skipIf(not has_bitsandbytes(), 'dadaptation is not installed')
+    def test_bitsandbytes_optimizers(self):
+        bitsandbytes_optimizers = [
+            'AdamW8bit', 'Adam8bit', 'Adagrad8bit', 'PagedAdam8bit',
+            'PagedAdamW8bit', 'LAMB8bit', 'LARS8bit', 'RMSprop8bit',
+            'Lion8bit', 'PagedLion8bit', 'SGD8bit'
+        ]
+        assert set(bitsandbytes_optimizers).issubset(
+            set(BITSANDBYTES_OPTIMIZERS))
 
     def test_build_optimizer(self):
         # test build function without ``constructor`` and ``paramwise_cfg``


### PR DESCRIPTION
## Motivation

[bitsandbytes](https://github.com/TimDettmers/bitsandbytes) provides `AdamW8bit`, `Adam8bit`, `Adagrad8bit`, `PagedAdam8bit`, `PagedAdamW8bit`, `LAMB8bit`, `LARS8bit`, `RMSprop8bit`, `Lion8bit`, `PagedLion8bit` and `SGD8bit` optimziers。

## Use cases (Optional)

```
pip install bitsandbytes
```

```
optim_wrapper=dict(optimizer=dict(type='AdamW8bit', lr=1e-4, weight_decay=1e-2))
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
