### PR TITLE
[Feature] Support Adafactor Optimizer

### DIFF
--- a/docs/en/common_usage/better_optimizers.md
+++ b/docs/en/common_usage/better_optimizers.md
@@ -145,8 +145,8 @@ runner = Runner(
     model=ResNet18(),
     work_dir='./work_dir',
     train_dataloader=train_dataloader_cfg,
-    # To view the input parameters for AdamW8bit, you can refer to
-    # https://github.com/TimDettmers/bitsandbytes/blob/main/bitsandbytes/optim/adamw.py
+    # To view the input parameters for Adafactor, you can refer to
+    # https://github.com/huggingface/transformers/blob/v4.33.2/src/transformers/optimization.py#L492
     optim_wrapper=dict(optimizer=dict(type='Adafactor', lr=1e-5,
         weight_decay=1e-2, scale_parameter=False, relative_step=False)),
     train_cfg=dict(by_epoch=True, max_epochs=3),

--- a/docs/en/common_usage/better_optimizers.md
+++ b/docs/en/common_usage/better_optimizers.md
@@ -121,3 +121,35 @@ runner = Runner(
 )
 runner.train()
 ```
+
+## transformers
+
+[transformers](https://github.com/huggingface/transformers) provides `Adafactor` optimzier。
+
+```{note}
+If you use the optimizer provided by transformers, you need to upgrade mmengine to `0.8.5`.
+```
+
+- Installation
+
+```bash
+pip install transformers
+```
+
+- Usage
+
+Take the `Adafactor` as an example.
+
+```python
+runner = Runner(
+    model=ResNet18(),
+    work_dir='./work_dir',
+    train_dataloader=train_dataloader_cfg,
+    # To view the input parameters for AdamW8bit, you can refer to
+    # https://github.com/TimDettmers/bitsandbytes/blob/main/bitsandbytes/optim/adamw.py
+    optim_wrapper=dict(optimizer=dict(type='Adafactor', lr=1e-5,
+        weight_decay=1e-2, scale_parameter=False, relative_step=False)),
+    train_cfg=dict(by_epoch=True, max_epochs=3),
+)
+runner.train()
+```

--- a/mmengine/optim/optimizer/builder.py
+++ b/mmengine/optim/optimizer/builder.py
@@ -157,6 +157,21 @@ def register_bitsandbytes_optimizers() -> List[str]:
 BITSANDBYTES_OPTIMIZERS = register_bitsandbytes_optimizers()
 
 
+def register_transformers_optimizers():
+    transformer_optimizers = []
+    try:
+        from transformers import Adafactor
+    except ImportError:
+        pass
+    else:
+        OPTIMIZERS.register_module(name='Adafactor')(Adafactor)
+        transformer_optimizers.append('Adafactor')
+    return transformer_optimizers
+
+
+TRANSFORMERS_OPTIMIZERS = register_transformers_optimizers()
+
+
 def build_optim_wrapper(model: nn.Module,
                         cfg: Union[dict, Config, ConfigDict]) -> OptimWrapper:
     """Build function of OptimWrapper.

--- a/mmengine/optim/optimizer/builder.py
+++ b/mmengine/optim/optimizer/builder.py
@@ -164,7 +164,7 @@ def register_transformers_optimizers():
     except ImportError:
         pass
     else:
-        OPTIMIZERS.register_module(name='Adafactor')(Adafactor)
+        OPTIMIZERS.register_module(name='Adafactor', module=Adafactor)
         transformer_optimizers.append('Adafactor')
     return transformer_optimizers
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -11,3 +11,4 @@ neptune
 parameterized
 pydantic==1.10.9
 pytest
+transformers

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -17,7 +17,8 @@ from mmengine.optim import (OPTIM_WRAPPER_CONSTRUCTORS, OPTIMIZERS,
 from mmengine.optim.optimizer.builder import (BITSANDBYTES_OPTIMIZERS,
                                               DADAPTATION_OPTIMIZERS,
                                               LION_OPTIMIZERS,
-                                              TORCH_OPTIMIZERS)
+                                              TORCH_OPTIMIZERS,
+                                              TRANSFORMERS_OPTIMIZERS)
 from mmengine.registry import DefaultScope, Registry, build_from_cfg
 from mmengine.testing._internal import MultiProcessTestCase
 from mmengine.utils.dl_utils import TORCH_VERSION, mmcv_full_available
@@ -48,6 +49,14 @@ def has_lion() -> bool:
 def has_bitsandbytes() -> bool:
     try:
         import bitsandbytes  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def has_transformers() -> bool:
+    try:
+        import transformers  # noqa: F401
         return True
     except ImportError:
         return False
@@ -244,7 +253,7 @@ class TestBuilder(TestCase):
     def test_lion_optimizers(self):
         assert 'Lion' in LION_OPTIMIZERS
 
-    @unittest.skipIf(not has_bitsandbytes(), 'dadaptation is not installed')
+    @unittest.skipIf(not has_bitsandbytes(), 'bitsandbytes is not installed')
     def test_bitsandbytes_optimizers(self):
         bitsandbytes_optimizers = [
             'AdamW8bit', 'Adam8bit', 'Adagrad8bit', 'PagedAdam8bit',
@@ -253,6 +262,12 @@ class TestBuilder(TestCase):
         ]
         assert set(bitsandbytes_optimizers).issubset(
             set(BITSANDBYTES_OPTIMIZERS))
+
+    @unittest.skipIf(not has_transformers(), 'transformers is not installed')
+    def test_transformers_optimizers(self):
+        transformers_optimizers = ['Adafactor']
+        assert set(transformers_optimizers).issubset(
+            set(TRANSFORMERS_OPTIMIZERS))
 
     def test_build_optimizer(self):
         # test build function without ``constructor`` and ``paramwise_cfg``


### PR DESCRIPTION
## Motivation

[transformers](https://github.com/huggingface/transformers) provides `Adafactor` optimizer.
It is often used when training Stable Diffusion XL.

## Use cases (Optional)

```
pip install transformers
```

```
optim_wrapper = dict(
    optimizer=dict(
        type='Adafactor',
        lr=1e-5,
        weight_decay=1e-2,
        scale_parameter=False,
        relative_step=False))
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
