### PR TITLE
[Bugfix] Delete yapf verify

### DIFF
--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Optional, Sequence, Tuple, Union
 
+import yapf
 from addict import Dict
 from rich.console import Console
 from rich.text import Text
@@ -1472,7 +1473,11 @@ class Config:
                 blank_line_before_nested_class_or_def=True,
                 split_before_expression_after_opening_paren=True)
             try:
-                text, _ = FormatCode(text, style_config=yapf_style)
+                if digit_version(yapf.__version__) >= digit_version('0.40.2'):
+                    text, _ = FormatCode(text, style_config=yapf_style)
+                else:
+                    text, _ = FormatCode(
+                        text, style_config=yapf_style, verify=True)
             except:  # noqa: E722
                 raise SyntaxError('Failed to format the config file, please '
                                   f'check the syntax of: \n{text}')

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -1472,8 +1472,7 @@ class Config:
                 blank_line_before_nested_class_or_def=True,
                 split_before_expression_after_opening_paren=True)
             try:
-                text, _ = FormatCode(
-                    text, style_config=yapf_style, verify=True)
+                text, _ = FormatCode(text, style_config=yapf_style)
             except:  # noqa: E722
                 raise SyntaxError('Failed to format the config file, please '
                                   f'check the syntax of: \n{text}')


### PR DESCRIPTION
## Motivation

yapf v0.40.2 has removed `verify` from `FormatCode`.

https://github.com/google/yapf/commit/6bc6de17f4da1e8fd04aad36b02b1252076387ef

[Please describe the motivation of this PR and the goal you want to achieve through this PR.](https://github.com/google/yapf/releases/tag/v0.40.2)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
