### PR TITLE
[Fix] Ensure from_cfg of Runner have the same defaults values as its __init__

### DIFF
--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -463,7 +463,7 @@ class Runner:
             load_from=cfg.get('load_from'),
             resume=cfg.get('resume', False),
             launcher=cfg.get('launcher', 'none'),
-            env_cfg=cfg.get('env_cfg', dict(dist_cfg=dict(backend='nccl'))),  # type: ignore
+            env_cfg=cfg.get('env_cfg', dict(dist_cfg=dict(backend='nccl'))),  # noqa: E501
             log_processor=cfg.get('log_processor'),
             log_level=cfg.get('log_level', 'INFO'),
             visualizer=cfg.get('visualizer'),

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -463,7 +463,7 @@ class Runner:
             load_from=cfg.get('load_from'),
             resume=cfg.get('resume', False),
             launcher=cfg.get('launcher', 'none'),
-            env_cfg=cfg.get('env_cfg'),  # type: ignore
+            env_cfg=cfg.get('env_cfg', dict(dist_cfg=dict(backend='nccl'))),  # type: ignore
             log_processor=cfg.get('log_processor'),
             log_level=cfg.get('log_level', 'INFO'),
             visualizer=cfg.get('visualizer'),

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -463,7 +463,7 @@ class Runner:
             load_from=cfg.get('load_from'),
             resume=cfg.get('resume', False),
             launcher=cfg.get('launcher', 'none'),
-            env_cfg=cfg.get('env_cfg', dict(dist_cfg=dict(backend='nccl'))),  # noqa: E501
+            env_cfg=cfg.get('env_cfg', dict(dist_cfg=dict(backend='nccl'))),
             log_processor=cfg.get('log_processor'),
             log_level=cfg.get('log_level', 'INFO'),
             visualizer=cfg.get('visualizer'),


### PR DESCRIPTION

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When I followed the 15-minute tutorial in MMENGINE to write the configuration file, I found that I was missing the setting of env_cfg, but directly instantiating the Runner does not require setting env_cfg. Ensuring that the default parameters for a runner instantiated from a configuration file and instantiated directly are the same will be less confusing.

## Modification
Add default parameters consistent with the Runner class to the env_cfg of the configuration file.
