### PR TITLE
[Enhance] metainfo of dataset can be a generic dict-like Mapping

### DIFF
--- a/mmengine/dataset/base_dataset.py
+++ b/mmengine/dataset/base_dataset.py
@@ -474,7 +474,8 @@ class BaseDataset(Dataset):
         return data_list
 
     @classmethod
-    def _load_metainfo(cls, metainfo: Union[Mapping, Config, None] = None) -> dict:
+    def _load_metainfo(cls,
+                       metainfo: Union[Mapping, Config, None] = None) -> dict:
         """Collect meta information from the dictionary of meta.
 
         Args:

--- a/mmengine/dataset/base_dataset.py
+++ b/mmengine/dataset/base_dataset.py
@@ -157,7 +157,7 @@ class BaseDataset(Dataset):
 
     Args:
         ann_file (str, optional): Annotation file path. Defaults to ''.
-        metainfo (Union[Mapping, Config], optional): Meta information for
+        metainfo (Mapping or Config, optional): Meta information for
             dataset, such as class information. Defaults to None.
         data_root (str, optional): The root directory for ``data_prefix`` and
             ``ann_file``. Defaults to ''.
@@ -215,7 +215,7 @@ class BaseDataset(Dataset):
 
     def __init__(self,
                  ann_file: Optional[str] = '',
-                 metainfo: Optional[Union[Mapping, Config]] = None,
+                 metainfo: Union[Mapping, Config, None] = None,
                  data_root: Optional[str] = '',
                  data_prefix: dict = dict(img_path=''),
                  filter_cfg: Optional[dict] = None,
@@ -474,11 +474,11 @@ class BaseDataset(Dataset):
         return data_list
 
     @classmethod
-    def _load_metainfo(cls, metainfo: Union[Mapping, Config] = None) -> dict:
+    def _load_metainfo(cls, metainfo: Union[Mapping, Config, None] = None) -> dict:
         """Collect meta information from the dictionary of meta.
 
         Args:
-            metainfo (Union[Mapping, Config]): Meta information dict.
+            metainfo (Mapping or Config, optional): Meta information dict.
                 If ``metainfo`` contains existed filename, it will be
                 parsed by ``list_from_file``.
 

--- a/mmengine/dataset/base_dataset.py
+++ b/mmengine/dataset/base_dataset.py
@@ -4,11 +4,13 @@ import functools
 import gc
 import logging
 import pickle
+from collections.abc import Mapping
 from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from torch.utils.data import Dataset
 
+from mmengine.config import Config
 from mmengine.fileio import join_path, list_from_file, load
 from mmengine.logging import print_log
 from mmengine.registry import TRANSFORMS
@@ -155,8 +157,8 @@ class BaseDataset(Dataset):
 
     Args:
         ann_file (str, optional): Annotation file path. Defaults to ''.
-        metainfo (dict, optional): Meta information for dataset, such as class
-            information. Defaults to None.
+        metainfo (Union[Mapping, Config], optional): Meta information for
+            dataset, such as class information. Defaults to None.
         data_root (str, optional): The root directory for ``data_prefix`` and
             ``ann_file``. Defaults to ''.
         data_prefix (dict): Prefix for training data. Defaults to
@@ -213,7 +215,7 @@ class BaseDataset(Dataset):
 
     def __init__(self,
                  ann_file: Optional[str] = '',
-                 metainfo: Optional[dict] = None,
+                 metainfo: Optional[Union[Mapping, Config]] = None,
                  data_root: Optional[str] = '',
                  data_prefix: dict = dict(img_path=''),
                  filter_cfg: Optional[dict] = None,
@@ -472,13 +474,13 @@ class BaseDataset(Dataset):
         return data_list
 
     @classmethod
-    def _load_metainfo(cls, metainfo: dict = None) -> dict:
+    def _load_metainfo(cls, metainfo: Union[Mapping, Config] = None) -> dict:
         """Collect meta information from the dictionary of meta.
 
         Args:
-            metainfo (dict): Meta information dict. If ``metainfo``
-                contains existed filename, it will be parsed by
-                ``list_from_file``.
+            metainfo (Union[Mapping, Config]): Meta information dict.
+                If ``metainfo`` contains existed filename, it will be
+                parsed by ``list_from_file``.
 
         Returns:
             dict: Parsed meta information.
@@ -487,9 +489,9 @@ class BaseDataset(Dataset):
         cls_metainfo = copy.deepcopy(cls.METAINFO)
         if metainfo is None:
             return cls_metainfo
-        if not isinstance(metainfo, dict):
-            raise TypeError(
-                f'metainfo should be a dict, but got {type(metainfo)}')
+        if not isinstance(metainfo, (Mapping, Config)):
+            raise TypeError('metainfo should be a Mapping or Config, '
+                            f'but got {type(metainfo)}')
 
         for k, v in metainfo.items():
             if isinstance(v, str):

--- a/tests/test_dataset/test_base_dataset.py
+++ b/tests/test_dataset/test_base_dataset.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
+from mmengine.config import Config, ConfigDict
 from mmengine.dataset import (BaseDataset, ClassBalancedDataset, Compose,
                               ConcatDataset, RepeatDataset, force_full_init)
 from mmengine.registry import DATASETS, TRANSFORMS
@@ -202,6 +203,39 @@ class TestBaseDataset:
             task_name='new_task',
             classes=('dog', ),
             empty_list=[])
+
+        # test dataset.metainfo with passing metainfo as Config into
+        # self.base_dataset
+        metainfo = Config(dict(classes=('dog', ), task_name='new_task'))
+        dataset = BaseDataset(
+            data_root=osp.join(osp.dirname(__file__), '../data/'),
+            data_prefix=dict(img_path='imgs'),
+            ann_file='annotations/dummy_annotation.json',
+            metainfo=metainfo)
+        assert BaseDataset.METAINFO == dict(
+            dataset_type=dataset_type, classes=('dog', 'cat'))
+        assert dataset.metainfo == dict(
+            dataset_type=dataset_type,
+            task_name='new_task',
+            classes=('dog', ),
+            empty_list=[])
+
+        # test dataset.metainfo with passing metainfo as ConfigDict (Mapping)
+        # into self.base_dataset
+        metainfo = ConfigDict(dict(classes=('dog', ), task_name='new_task'))
+        dataset = BaseDataset(
+            data_root=osp.join(osp.dirname(__file__), '../data/'),
+            data_prefix=dict(img_path='imgs'),
+            ann_file='annotations/dummy_annotation.json',
+            metainfo=metainfo)
+        assert BaseDataset.METAINFO == dict(
+            dataset_type=dataset_type, classes=('dog', 'cat'))
+        assert dataset.metainfo == dict(
+            dataset_type=dataset_type,
+            task_name='new_task',
+            classes=('dog', ),
+            empty_list=[])
+
         # reset `base_dataset.METAINFO`, the `dataset.metainfo` should not
         # change
         BaseDataset.METAINFO['classes'] = ('dog', 'cat', 'fish')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

Allowing metainfo to be more generic, so that it is compatible with other dict-like config systems.

## Modification

Please briefly describe what modification is made in this PR.

Allowing metainfo to be `Mapping` (more generic), instead of just `dict`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?

No

If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
