### PR TITLE
add freeze_hook

### DIFF
--- a/mmengine/hooks/__init__.py
+++ b/mmengine/hooks/__init__.py
@@ -3,6 +3,7 @@ from .checkpoint_hook import CheckpointHook
 from .early_stopping_hook import EarlyStoppingHook
 from .ema_hook import EMAHook
 from .empty_cache_hook import EmptyCacheHook
+from .freeze_hook import FreezeHook
 from .hook import Hook
 from .iter_timer_hook import IterTimerHook
 from .logger_hook import LoggerHook
@@ -18,5 +19,5 @@ __all__ = [
     'Hook', 'IterTimerHook', 'DistSamplerSeedHook', 'ParamSchedulerHook',
     'SyncBuffersHook', 'EmptyCacheHook', 'CheckpointHook', 'LoggerHook',
     'NaiveVisualizationHook', 'EMAHook', 'RuntimeInfoHook', 'ProfilerHook',
-    'PrepareTTAHook', 'NPUProfilerHook', 'EarlyStoppingHook'
+    'PrepareTTAHook', 'NPUProfilerHook', 'EarlyStoppingHook', 'FreezeHook'
 ]

--- a/mmengine/hooks/freeze_hook.py
+++ b/mmengine/hooks/freeze_hook.py
@@ -1,0 +1,121 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Optional, Sequence, Union
+
+from mmengine.logging import print_log
+from mmengine.model import is_model_wrapper
+from mmengine.registry import HOOKS
+from .hook import Hook
+
+
+@HOOKS.register_module()
+class FreezeHook(Hook):
+    """FreezeHook is used to freeze or unfreeze network layers when training to
+    a specified epoch.
+
+    Args:
+        freeze_epoch (int): The epoch number to start freezing layers.
+        freeze_layers (tuple[str]): Model layers containing the keyword in
+            freeze_layers will freeze the gradient.
+        unfreeze_epoch (int): The epoch number to start unfreezing layers.
+        unfreeze_layers (tuple[str]): Model layers containing the keyword in
+            unfreeze_layers will unfreeze the gradient.
+        log_grad (bool): Whether to log the requires_grad of each layer.
+
+    Notes:
+        The GPU memory usage shown in the "nvidia-smi" command does not change
+        when you freeze model layers.
+        https://discuss.pytorch.org/t/how-can-we-release-gpu-memory-cache/14530/4
+
+    Examples:
+        >>> # The simplest FreezeHook config.
+        >>> freeze_hook_cfg = dict(
+                type="FreezeHook",
+                freeze_epoch=1,
+                freeze_layers=("backbone",)
+            )
+    """
+
+    def __init__(
+        self,
+        freeze_epoch: int,
+        freeze_layers: Union[Sequence[str], str],
+        unfreeze_epoch: Optional[int] = None,
+        unfreeze_layers: Optional[Union[Sequence[str], str]] = None,
+        log_grad: bool = False,
+    ) -> None:
+        # check arguments type
+        if not isinstance(freeze_epoch, int):
+            raise TypeError('freeze_epoch must be an integer')
+        if not isinstance(freeze_layers, (tuple, list, str)):
+            raise TypeError('freeze_layers must be a tuple, list or str')
+        if not isinstance(unfreeze_epoch, (int, type(None))):
+            raise TypeError('unfreeze_epoch must be an integer or None')
+        if not isinstance(unfreeze_layers, (tuple, list, str, type(None))):
+            raise TypeError(
+                'unfreeze_layers must be a tuple, list, str or None')
+        if not isinstance(log_grad, bool):
+            raise TypeError('log_grad must be a boolean')
+
+        # check arguments value
+        if freeze_epoch <= 0:
+            raise ValueError('freeze_epoch must be greater than 0')
+        if len(freeze_layers) == 0:
+            raise ValueError('freeze_layers must not be empty')
+        if unfreeze_epoch is not None and unfreeze_epoch <= 0:
+            raise ValueError('unfreeze_epoch must be greater than 0')
+        if unfreeze_epoch is not None and unfreeze_epoch <= freeze_epoch:
+            raise ValueError(
+                'unfreeze_epoch must be greater than freeze_epoch')
+        if unfreeze_epoch is not None and unfreeze_layers is None:
+            raise ValueError(
+                'unfreeze_layers must not be None when unfreeze_epoch '
+                'is not None.')
+        if (unfreeze_epoch is None and unfreeze_layers is not None) or (
+                unfreeze_epoch is not None and unfreeze_layers is None):
+            raise ValueError(
+                'unfreeze_epoch and unfreeze_layers must be both None '
+                'or not None')
+
+        self.freeze_epoch = freeze_epoch
+        if isinstance(freeze_layers, str):
+            freeze_layers = (freeze_layers, )
+        self.freeze_layers = freeze_layers
+        self.unfreeze_epoch = unfreeze_epoch
+        if isinstance(unfreeze_layers, str):
+            unfreeze_layers = (unfreeze_layers, )
+        self.unfreeze_layers = unfreeze_layers
+        self.log_grad = log_grad
+
+    def modify_layers_grad(self, model, layers, requires_grad):
+        if is_model_wrapper(model):
+            model = model.module
+        for k, v in model.named_parameters():
+            for layer in layers:
+                if layer in k:
+                    v.requires_grad = requires_grad
+                    break
+
+    def log_model_grad(self, model, log_grad=False):
+        if log_grad:
+            for k, v in model.named_parameters():
+                print_log(
+                    f'{k} requires_grad: {v.requires_grad}', logger='current')
+
+    def before_train_epoch(self, runner) -> None:
+        if (runner.epoch + 1) == self.freeze_epoch:
+            self.modify_layers_grad(
+                runner.model, self.freeze_layers, requires_grad=False)
+            self.log_model_grad(runner.model, self.log_grad)
+            print_log(
+                f'Freeze {self.freeze_layers} at epoch {runner.epoch + 1}',
+                logger='current')
+            # if you want to release GPU memory cache:
+            # import torch; torch.cuda.empty_cache()
+
+        if (runner.epoch + 1) == self.unfreeze_epoch:
+            self.modify_layers_grad(
+                runner.model, self.unfreeze_layers, requires_grad=True)
+            self.log_model_grad(runner.model, self.log_grad)
+            print_log(
+                f'Unfreeze {self.unfreeze_layers} at epoch {runner.epoch + 1}',
+                logger='current')

--- a/tests/test_hooks/test_freeze_hook.py
+++ b/tests/test_hooks/test_freeze_hook.py
@@ -1,0 +1,100 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import copy
+
+from mmengine.hooks import FreezeHook
+from mmengine.testing import RunnerTestCase
+
+
+class TestFreezeHook(RunnerTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+    def test_init(self):
+        # Test build freeze hook.
+        FreezeHook(freeze_epoch=1, freeze_layers=('backbone', ))
+
+        with self.assertRaisesRegex(TypeError, 'freeze_epoch must be'):
+            FreezeHook(freeze_epoch='100', freeze_layers=('backbone', ))
+
+        with self.assertRaisesRegex(ValueError, 'freeze_epoch'):
+            FreezeHook(freeze_epoch=0, freeze_layers=('backbone', ))
+
+        with self.assertRaisesRegex(TypeError, 'freeze_layers must be'):
+            FreezeHook(freeze_epoch=1, freeze_layers=False)
+
+        with self.assertRaisesRegex(TypeError, 'freeze_layers must be'):
+            FreezeHook(freeze_epoch=1, freeze_layers=1)
+
+        with self.assertRaisesRegex(TypeError, 'unfreeze_epoch must be'):
+            FreezeHook(
+                freeze_epoch=1, freeze_layers='backbone', unfreeze_epoch='100')
+
+        with self.assertRaisesRegex(ValueError, 'unfreeze_epoch'):
+            FreezeHook(
+                freeze_epoch=1,
+                freeze_layers='backbone',
+                unfreeze_layers=('backbone', ))
+
+        with self.assertRaisesRegex(ValueError, 'unfreeze_epoch'):
+            FreezeHook(
+                freeze_epoch=1, freeze_layers='backbone', unfreeze_epoch=2)
+
+        with self.assertRaisesRegex(ValueError, 'unfreeze_epoch'):
+            FreezeHook(
+                freeze_epoch=1,
+                freeze_layers='backbone',
+                unfreeze_epoch=1,
+                unfreeze_layers=('backbone', ))
+
+        with self.assertRaisesRegex(TypeError, 'unfreeze_layers must be'):
+            FreezeHook(
+                freeze_epoch=1,
+                freeze_layers='backbone',
+                unfreeze_layers=False)
+
+        with self.assertRaisesRegex(TypeError, 'unfreeze_layers must be'):
+            FreezeHook(
+                freeze_epoch=1, freeze_layers='backbone', unfreeze_layers=1)
+
+        with self.assertRaisesRegex(ValueError, 'unfreeze_layers'):
+            FreezeHook(
+                freeze_epoch=1, freeze_layers='backbone', unfreeze_epoch=2)
+
+        with self.assertRaisesRegex(TypeError, 'log_grad must be'):
+            FreezeHook(freeze_epoch=1, freeze_layers='backbone', log_grad=1)
+
+    def test_before_train_epoch(self):
+        cfg = copy.deepcopy(self.epoch_based_cfg)
+        runner = self.build_runner(cfg)
+
+        freeze_hook = FreezeHook(
+            freeze_epoch=2, freeze_layers=('linear1', 'linear2'))
+        freeze_hook.before_train_epoch(runner)
+        self.assertTrue(runner.model.linear1.weight.requires_grad)
+        self.assertTrue(runner.model.linear2.weight.requires_grad)
+
+        runner.train_loop._epoch = 3
+        freeze_hook = FreezeHook(
+            freeze_epoch=4, freeze_layers=('linear1', 'linear2'))
+        freeze_hook.before_train_epoch(runner)
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertFalse(runner.model.linear2.weight.requires_grad)
+
+        runner.train_loop._epoch = 5
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertFalse(runner.model.linear2.weight.requires_grad)
+
+        runner.train_loop._epoch = 7
+        freeze_hook = FreezeHook(
+            freeze_epoch=4,
+            freeze_layers=('linear1', 'linear2'),
+            unfreeze_epoch=8,
+            unfreeze_layers=('linear2', ))
+        freeze_hook.before_train_epoch(runner)
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertTrue(runner.model.linear2.weight.requires_grad)
+
+        runner.train_loop._epoch = 9
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertTrue(runner.model.linear2.weight.requires_grad)


### PR DESCRIPTION
## Motivation

Motivation: 

1. Freeze some parameters of the model when training the model.

Goal: 

1. Specify the epoch to freeze the specified network layer. 
2. Available for all downstream repositories.
 <p><br></p>

## Modification

Add FreezeHook and FreezeHook unit tests.
 <p><br></p>

## Use cases

1. Model layers containing the `freeze_layers` keyword are freeze before `freeze_epoch` training begins.
2. unfreeze_epoch and unfreeze_layers are optional. If unfreeze_epoch is not None, unfreeze_layers must not be None.
3. Model layers containing the `unfreeze_layers` keyword are unfreeze before `unfreeze_epoch` training begins.

```python
ImageClassifier(
    (backbone):ResNet(
        ...
        (layer1):Sequential(...)
        (layer2):Sequential(...)
        (layer3):Sequential(...)
        (layer4):Sequential(...)
    )
    (neck):GlobalAveragePooling2d(...)
    (head):Linear(...)
)
```
 <p><br></p>

1. Freeze the parameters of backbone before the start of 1st training epoch.

   ```python
   custom_hooks = [
    ...
    dict(
        type="FreezeHook",
        freeze_epoch=1,
        freeze_layers=(
            "backbone",
        ),)
   ]
   ```

 <p><br></p>

2. Freeze the parameters of backbone and neck before the start of 10th training epoch.

   ```python
   custom_hooks = [
    ...
    dict(
        type="FreezeHook",
        freeze_epoch=10,
        freeze_layers=(
            "backbone",
            "neck",
        ),)
   ]
   ```
 <p><br></p>
   

3. Freeze the layer1 and layer2 parameters in the backbone before the start of 10th training epoch.

   ```python
   custom_hooks = [
    ...
    dict(
        type="FreezeHook",
        freeze_epoch=10,
        freeze_layers=(
            "backbone.layer1",
            "backbone.layer2",
        ),)
   ]
   ```
 <p><br></p>
   

4. Freeze [backbone.layer1, backbone.layer2, backbone.layer3, backbone.layer4] parameters in the backbone before the start of 10th training epoch.

   ```python
   custom_hooks = [
    ...
    dict(
        type="FreezeHook",
        freeze_epoch=10,
        freeze_layers=(
            "backbone.layer",
        ),)
   ]
   ```
 <p><br></p>
   

5. Freeze the parameters of backbone before the start of 1st training epoch. Unfreeze the parameters of the the backbone before the start of 10th training epoch.

   ```python
   custom_hooks = [
    ...
    dict(
        type="FreezeHook",
        freeze_epoch=1,
        freeze_layers=(
            "backbone",
        ),
        unfreeze_epoch=10,
        unfreeze_layers=("backbone",))
   ]
   ```
 <p><br></p>
   

6. The log_grad parameter is used to determine whether to print the `requires_grad` variable for each model layer.

   ```python
   custom_hooks = [
    ...
    dict(
        type="FreezeHook",
        freeze_epoch=1,
        freeze_layers=(
            "backbone",
        ),
        log_grad=True)
   ]
   ```


   ```powershell
   mmengine - INFO - backbone.conv1.weight requires_grad: True
   mmengine - INFO - backbone.bn1.weight requires_grad: True
   ...
   mmengine - INFO - head.light_head.weight requires_grad: True
   mmengine - INFO - head.light_head.bias requires_grad: True
   ```
 <p><br></p>

   