### PR TITLE
gy77/add freeze hook

### DIFF
--- a/mmengine/hooks/__init__.py
+++ b/mmengine/hooks/__init__.py
@@ -3,6 +3,7 @@ from .checkpoint_hook import CheckpointHook
 from .early_stopping_hook import EarlyStoppingHook
 from .ema_hook import EMAHook
 from .empty_cache_hook import EmptyCacheHook
+from .freeze_hook import FreezeHook
 from .hook import Hook
 from .iter_timer_hook import IterTimerHook
 from .logger_hook import LoggerHook
@@ -18,5 +19,5 @@ __all__ = [
     'Hook', 'IterTimerHook', 'DistSamplerSeedHook', 'ParamSchedulerHook',
     'SyncBuffersHook', 'EmptyCacheHook', 'CheckpointHook', 'LoggerHook',
     'NaiveVisualizationHook', 'EMAHook', 'RuntimeInfoHook', 'ProfilerHook',
-    'PrepareTTAHook', 'NPUProfilerHook', 'EarlyStoppingHook'
+    'PrepareTTAHook', 'NPUProfilerHook', 'EarlyStoppingHook', 'FreezeHook'
 ]

--- a/mmengine/hooks/freeze_hook.py
+++ b/mmengine/hooks/freeze_hook.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import re
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence
 
 from mmengine.logging import print_log
 from mmengine.model import BaseModel, is_model_wrapper
@@ -10,15 +10,17 @@ from .hook import DATA_BATCH, Hook
 
 @HOOKS.register_module()
 class FreezeHook(Hook):
-    """FreezeHook is used to freeze or unfreeze network layers when training to
-    a specified epoch.
+    """FreezeHook is used to freeze/unfreeze network layers when training to a
+    specified epoch/iter.
 
     Args:
-        freeze_layers (tuple[str]): Model layers containing the keyword in
-            freeze_layers will freeze the gradient.
+        freeze_layers (str): Layers of the network that will be freeze. \
+            Match by regular expression.
+        freeze_iter (int): The iter number to start freezing layers.
         freeze_epoch (int): The epoch number to start freezing layers.
-        unfreeze_layers (tuple[str]): Model layers containing the keyword in
-            unfreeze_layers will unfreeze the gradient.
+        unfreeze_layers (str): Layers of the network that will be unfreeze. \
+            Match by regular expression.
+        unfreeze_iter (int): The iter number to start unfreezing layers.
         unfreeze_epoch (int): The epoch number to start unfreezing layers.
         verbose  (bool): Whether to log the requires_grad of each layer.
 
@@ -31,68 +33,55 @@ class FreezeHook(Hook):
         >>> # The simplest FreezeHook config.
         >>> freeze_hook_cfg = dict(
                 type="FreezeHook",
-                freeze_layers=("backbone.*",),
+                freeze_layers="backbone.*|neck.*",
                 freeze_epoch=0
             )
     """
 
     def __init__(
         self,
-        freeze_layers: Union[Sequence[str], str],
+        freeze_layers: str,
         freeze_iter: Optional[int] = None,
         freeze_epoch: Optional[int] = None,
-        unfreeze_layers: Optional[Union[Sequence[str], str]] = None,
+        unfreeze_layers: Optional[str] = None,
         unfreeze_iter: Optional[int] = None,
         unfreeze_epoch: Optional[int] = None,
         verbose: bool = False,
     ) -> None:
         # check arguments type
-        if not isinstance(freeze_layers, (tuple, list, str)):
-            raise TypeError('`freeze_layers` must be a tuple, list or str')
-        if len(freeze_layers) == 0:
-            raise TypeError('`freeze_layers` must not be empty')
-        if isinstance(freeze_layers,
-                      (tuple, list)) and not isinstance(freeze_layers[0], str):
-            raise TypeError(
-                '`freeze_layers` must be a tuple or list of string')
-        if not isinstance(freeze_iter, (int, type(None))):
-            raise TypeError('`freeze_iter` must be an integer or None')
-        if not isinstance(freeze_epoch, (int, type(None))):
-            raise TypeError('`freeze_epoch` must be an integer or None')
-        if not isinstance(unfreeze_layers, (tuple, list, str, type(None))):
-            raise TypeError(
-                '`unfreeze_layers` must be a tuple, list, str or None')
-        if unfreeze_layers is not None and len(unfreeze_layers) == 0:
-            raise TypeError('`unfreeze_layers` must not be empty')
-        if isinstance(
-                unfreeze_layers, (tuple, list)) and \
-                not isinstance(unfreeze_layers[0], str):
-            raise TypeError('`unfreeze_layers` must be a tuple or \
-                            list of string')
-        if not isinstance(unfreeze_iter, (int, type(None))):
-            raise TypeError('`unfreeze_iter` must be an integer or None')
-        if not isinstance(unfreeze_epoch, (int, type(None))):
-            raise TypeError('`unfreeze_epoch` must be an integer or None')
+        if not isinstance(freeze_layers, str):
+            raise TypeError('`freeze_layers` must be a str')
+        if not isinstance(freeze_iter, int) and freeze_iter is not None:
+            raise TypeError('`freeze_iter` must be a int or None')
+        if not isinstance(freeze_epoch, int) and freeze_epoch is not None:
+            raise TypeError('`freeze_epoch` must be a int or None')
+        if not isinstance(unfreeze_layers,
+                          str) and unfreeze_layers is not None:
+            raise TypeError('`unfreeze_layers` must be a str or None')
+        if not isinstance(unfreeze_iter, int) and unfreeze_iter is not None:
+            raise TypeError('`unfreeze_iter` must be a int or None')
+        if not isinstance(unfreeze_epoch, int) and unfreeze_epoch is not None:
+            raise TypeError('`unfreeze_epoch` must be a int or None')
         if not isinstance(verbose, bool):
             raise TypeError('`verbose`  must be a boolean')
         # check arguments value
-        if freeze_iter and freeze_iter < 0:
-            raise ValueError(
-                '`freeze_iter` must be greater than or equal to 0')
-        if freeze_epoch and freeze_epoch < 0:
-            raise ValueError(
-                '`freeze_epoch` must be greater than or equal to 0')
-        if (freeze_epoch is None) and (freeze_iter is None):
+        if freeze_iter is None and freeze_epoch is None:
             raise ValueError(
                 '`freeze_iter` and `freeze_epoch` should not be both None.')
-        if (freeze_epoch is not None) and (freeze_iter is not None):
+        if freeze_iter is not None and freeze_epoch is not None:
             raise ValueError(
                 '`freeze_iter` and `freeze_epoch` should not be both set.')
+        if freeze_iter is not None and freeze_iter < 0:
+            raise ValueError(
+                '`freeze_iter` must be greater than or equal to 0')
+        if freeze_epoch is not None and freeze_epoch < 0:
+            raise ValueError(
+                '`freeze_epoch` must be greater than or equal to 0')
         if unfreeze_layers is not None:
-            if (unfreeze_epoch is None) and (unfreeze_iter is None):
+            if unfreeze_epoch is None and unfreeze_iter is None:
                 raise ValueError('`unfreeze_iter` and `unfreeze_epoch` \
                                  should not be both None.')
-            if (unfreeze_epoch is not None) and (unfreeze_iter is not None):
+            if unfreeze_epoch is not None and unfreeze_iter is not None:
                 raise ValueError('`unfreeze_iter` and `unfreeze_epoch` \
                         should not be both set.')
         if unfreeze_iter is not None:
@@ -116,13 +105,9 @@ class FreezeHook(Hook):
                 raise ValueError('`unfreeze_epoch` must be greater than \
                         or equal to `freeze_epoch`')
 
-        if isinstance(freeze_layers, str):
-            freeze_layers = (freeze_layers, )
         self.freeze_layers = freeze_layers
         self.freeze_iter = freeze_iter
         self.freeze_epoch = freeze_epoch
-        if isinstance(unfreeze_layers, str):
-            unfreeze_layers = (unfreeze_layers, )
         self.unfreeze_layers = unfreeze_layers
         self.unfreeze_iter = unfreeze_iter
         self.unfreeze_epoch = unfreeze_epoch
@@ -132,10 +117,10 @@ class FreezeHook(Hook):
 
     def _modify_layers_grad(self, model: BaseModel, layers: Sequence[str],
                             requires_grad: bool):
-        """Modify the `requires_grad` of the specified layers.
+        """Modify the ``requires_grad`` of the specified layers.
 
         Args:
-            model (BaseModel): a BaseModel of mmengine.
+            model (BaseModel): A BaseModel of mmengine.
             layers (Sequence[str]): Network layers to be modified.
             requires_grad (bool): Whether to enable gradient.
         """
@@ -149,17 +134,17 @@ class FreezeHook(Hook):
         """Print `requires_grad` for all network layers.
 
         Args:
-            model (BaseModel): a BaseModel of mmengine.
+            model (BaseModel): A BaseModel of mmengine.
         """
         for k, v in model.named_parameters():
             print_log(
                 f'{k} requires_grad: {v.requires_grad}', logger='current')
 
-    def _main(self,
-              runner,
-              idx: int,
-              freeze_idx: int,
-              unfreeze_idx: Optional[int] = None) -> None:
+    def _freeze(self,
+                runner,
+                idx: int,
+                freeze_idx: int,
+                unfreeze_idx: Optional[int] = None) -> None:
         """The main function of FreezeHook.
 
         Args:
@@ -201,14 +186,12 @@ class FreezeHook(Hook):
         for k, _ in model.named_parameters():
             layer_names += f'{k}\n'
 
-        for pattern in self.freeze_layers:
-            freeze_names = re.findall(pattern, layer_names)
-            self.freeze_layer_names += freeze_names
+        freeze_names = re.findall(self.freeze_layers, layer_names)
+        self.freeze_layer_names += freeze_names
 
         if self.unfreeze_layers is not None:
-            for pattern in self.unfreeze_layers:
-                unfreeze_names = re.findall(pattern, layer_names)
-                self.unfreeze_layer_names += unfreeze_names
+            unfreeze_names = re.findall(self.unfreeze_layers, layer_names)
+            self.unfreeze_layer_names += unfreeze_names
 
     def before_train_iter(
         self,
@@ -227,8 +210,8 @@ class FreezeHook(Hook):
             outputs (dict, optional): Outputs from model. Defaults to None.
         """
         if self.freeze_iter is not None:
-            self._main(runner, runner.iter, self.freeze_iter,
-                       self.unfreeze_iter)
+            self._freeze(runner, runner.iter, self.freeze_iter,
+                         self.unfreeze_iter)
 
     def before_train_epoch(self, runner) -> None:
         """Update `requires_grad` before the start of `freeze_epoch`
@@ -237,5 +220,5 @@ class FreezeHook(Hook):
             runner (Runner): The runner of the training process.
         """
         if self.freeze_epoch is not None:
-            self._main(runner, runner.epoch, self.freeze_epoch,
-                       self.unfreeze_epoch)
+            self._freeze(runner, runner.epoch, self.freeze_epoch,
+                         self.unfreeze_epoch)

--- a/mmengine/hooks/freeze_hook.py
+++ b/mmengine/hooks/freeze_hook.py
@@ -1,0 +1,121 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Optional, Sequence, Union
+
+from mmengine.logging import print_log
+from mmengine.model import is_model_wrapper
+from mmengine.registry import HOOKS
+from .hook import Hook
+
+
+@HOOKS.register_module()
+class FreezeHook(Hook):
+    """FreezeHook is used to freeze or unfreeze network layers when training to
+    a specified epoch.
+
+    Args:
+        freeze_epoch (int): The epoch number to start freezing layers.
+        freeze_layers (tuple[str]): Model layers containing the keyword in
+            freeze_layers will freeze the gradient.
+        unfreeze_epoch (int): The epoch number to start unfreezing layers.
+        unfreeze_layers (tuple[str]): Model layers containing the keyword in
+            unfreeze_layers will unfreeze the gradient.
+        log_grad (bool): Whether to log the requires_grad of each layer.
+
+    Notes:
+        The GPU memory usage shown in the "nvidia-smi" command does not change
+        when you freeze model layers.
+        https://discuss.pytorch.org/t/how-can-we-release-gpu-memory-cache/14530/4
+
+    Examples:
+        >>> # The simplest FreezeHook config.
+        >>> freeze_hook_cfg = dict(
+                type="FreezeHook",
+                freeze_epoch=1,
+                freeze_layers=("backbone",)
+            )
+    """
+
+    def __init__(
+        self,
+        freeze_epoch: int,
+        freeze_layers: Union[Sequence[str], str],
+        unfreeze_epoch: Optional[int] = None,
+        unfreeze_layers: Optional[Union[Sequence[str], str]] = None,
+        log_grad: bool = False,
+    ) -> None:
+        # check arguments type
+        if not isinstance(freeze_epoch, int):
+            raise TypeError('freeze_epoch must be an integer')
+        if not isinstance(freeze_layers, (tuple, list, str)):
+            raise TypeError('freeze_layers must be a tuple, list or str')
+        if not isinstance(unfreeze_epoch, (int, type(None))):
+            raise TypeError('unfreeze_epoch must be an integer or None')
+        if not isinstance(unfreeze_layers, (tuple, list, str, type(None))):
+            raise TypeError(
+                'unfreeze_layers must be a tuple, list, str or None')
+        if not isinstance(log_grad, bool):
+            raise TypeError('log_grad must be a boolean')
+
+        # check arguments value
+        if freeze_epoch <= 0:
+            raise ValueError('freeze_epoch must be greater than 0')
+        if len(freeze_layers) == 0:
+            raise ValueError('freeze_layers must not be empty')
+        if unfreeze_epoch is not None and unfreeze_epoch <= 0:
+            raise ValueError('unfreeze_epoch must be greater than 0')
+        if unfreeze_epoch is not None and unfreeze_epoch <= freeze_epoch:
+            raise ValueError(
+                'unfreeze_epoch must be greater than freeze_epoch')
+        if unfreeze_epoch is not None and unfreeze_layers is None:
+            raise ValueError(
+                'unfreeze_layers must not be None when unfreeze_epoch '
+                'is not None.')
+        if (unfreeze_epoch is None and unfreeze_layers is not None) or (
+                unfreeze_epoch is not None and unfreeze_layers is None):
+            raise ValueError(
+                'unfreeze_epoch and unfreeze_layers must be both None '
+                'or not None')
+
+        self.freeze_epoch = freeze_epoch
+        if isinstance(freeze_layers, str):
+            freeze_layers = (freeze_layers, )
+        self.freeze_layers = freeze_layers
+        self.unfreeze_epoch = unfreeze_epoch
+        if isinstance(unfreeze_layers, str):
+            unfreeze_layers = (unfreeze_layers, )
+        self.unfreeze_layers = unfreeze_layers
+        self.log_grad = log_grad
+
+    def modify_layers_grad(self, model, layers, requires_grad):
+        if is_model_wrapper(model):
+            model = model.module
+        for k, v in model.named_parameters():
+            for layer in layers:
+                if layer in k:
+                    v.requires_grad = requires_grad
+                    break
+
+    def log_model_grad(self, model, log_grad=False):
+        if log_grad:
+            for k, v in model.named_parameters():
+                print_log(
+                    f'{k} requires_grad: {v.requires_grad}', logger='current')
+
+    def before_train_epoch(self, runner) -> None:
+        if (runner.epoch + 1) == self.freeze_epoch:
+            self.modify_layers_grad(
+                runner.model, self.freeze_layers, requires_grad=False)
+            self.log_model_grad(runner.model, self.log_grad)
+            print_log(
+                f'Freeze {self.freeze_layers} at epoch {runner.epoch + 1}',
+                logger='current')
+            # if you want to release GPU memory cache:
+            # import torch; torch.cuda.empty_cache()
+
+        if (runner.epoch + 1) == self.unfreeze_epoch:
+            self.modify_layers_grad(
+                runner.model, self.unfreeze_layers, requires_grad=True)
+            self.log_model_grad(runner.model, self.log_grad)
+            print_log(
+                f'Unfreeze {self.unfreeze_layers} at epoch {runner.epoch + 1}',
+                logger='current')

--- a/mmengine/hooks/freeze_hook.py
+++ b/mmengine/hooks/freeze_hook.py
@@ -78,10 +78,10 @@ class FreezeHook(Hook):
             raise ValueError(
                 '`freeze_epoch` must be greater than or equal to 0')
         if unfreeze_layers is not None:
-            if unfreeze_epoch is None and unfreeze_iter is None:
+            if unfreeze_iter is None and unfreeze_epoch is None:
                 raise ValueError('`unfreeze_iter` and `unfreeze_epoch` \
                                  should not be both None.')
-            if unfreeze_epoch is not None and unfreeze_iter is not None:
+            if unfreeze_iter is not None and unfreeze_epoch is not None:
                 raise ValueError('`unfreeze_iter` and `unfreeze_epoch` \
                         should not be both set.')
         if unfreeze_iter is not None:
@@ -187,11 +187,11 @@ class FreezeHook(Hook):
             layer_names += f'{k}\n'
 
         freeze_names = re.findall(self.freeze_layers, layer_names)
-        self.freeze_layer_names += freeze_names
+        self.freeze_layer_names = freeze_names
 
         if self.unfreeze_layers is not None:
             unfreeze_names = re.findall(self.unfreeze_layers, layer_names)
-            self.unfreeze_layer_names += unfreeze_names
+            self.unfreeze_layer_names = unfreeze_names
 
     def before_train_iter(
         self,

--- a/mmengine/hooks/freeze_hook.py
+++ b/mmengine/hooks/freeze_hook.py
@@ -1,10 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import re
 from typing import Optional, Sequence, Union
 
 from mmengine.logging import print_log
-from mmengine.model import is_model_wrapper
+from mmengine.model import BaseModel, is_model_wrapper
 from mmengine.registry import HOOKS
-from .hook import Hook
+from .hook import DATA_BATCH, Hook
 
 
 @HOOKS.register_module()
@@ -13,13 +14,13 @@ class FreezeHook(Hook):
     a specified epoch.
 
     Args:
-        freeze_epoch (int): The epoch number to start freezing layers.
         freeze_layers (tuple[str]): Model layers containing the keyword in
             freeze_layers will freeze the gradient.
-        unfreeze_epoch (int): The epoch number to start unfreezing layers.
+        freeze_epoch (int): The epoch number to start freezing layers.
         unfreeze_layers (tuple[str]): Model layers containing the keyword in
             unfreeze_layers will unfreeze the gradient.
-        log_grad (bool): Whether to log the requires_grad of each layer.
+        unfreeze_epoch (int): The epoch number to start unfreezing layers.
+        verbose  (bool): Whether to log the requires_grad of each layer.
 
     Notes:
         The GPU memory usage shown in the "nvidia-smi" command does not change
@@ -30,92 +31,211 @@ class FreezeHook(Hook):
         >>> # The simplest FreezeHook config.
         >>> freeze_hook_cfg = dict(
                 type="FreezeHook",
-                freeze_epoch=1,
-                freeze_layers=("backbone",)
+                freeze_layers=("backbone.*",),
+                freeze_epoch=0
             )
     """
 
     def __init__(
         self,
-        freeze_epoch: int,
         freeze_layers: Union[Sequence[str], str],
-        unfreeze_epoch: Optional[int] = None,
+        freeze_iter: Optional[int] = None,
+        freeze_epoch: Optional[int] = None,
         unfreeze_layers: Optional[Union[Sequence[str], str]] = None,
-        log_grad: bool = False,
+        unfreeze_iter: Optional[int] = None,
+        unfreeze_epoch: Optional[int] = None,
+        verbose: bool = False,
     ) -> None:
         # check arguments type
-        if not isinstance(freeze_epoch, int):
-            raise TypeError('freeze_epoch must be an integer')
         if not isinstance(freeze_layers, (tuple, list, str)):
-            raise TypeError('freeze_layers must be a tuple, list or str')
-        if not isinstance(unfreeze_epoch, (int, type(None))):
-            raise TypeError('unfreeze_epoch must be an integer or None')
+            raise TypeError('`freeze_layers` must be a tuple, list or str')
+        if len(freeze_layers) == 0:
+            raise TypeError('`freeze_layers` must not be empty')
+        if isinstance(freeze_layers,
+                      (tuple, list)) and not isinstance(freeze_layers[0], str):
+            raise TypeError(
+                '`freeze_layers` must be a tuple or list of string')
+        if not isinstance(freeze_iter, (int, type(None))):
+            raise TypeError('`freeze_iter` must be an integer or None')
+        if not isinstance(freeze_epoch, (int, type(None))):
+            raise TypeError('`freeze_epoch` must be an integer or None')
         if not isinstance(unfreeze_layers, (tuple, list, str, type(None))):
             raise TypeError(
-                'unfreeze_layers must be a tuple, list, str or None')
-        if not isinstance(log_grad, bool):
-            raise TypeError('log_grad must be a boolean')
-
+                '`unfreeze_layers` must be a tuple, list, str or None')
+        if unfreeze_layers is not None and len(unfreeze_layers) == 0:
+            raise TypeError('`unfreeze_layers` must not be empty')
+        if isinstance(
+                unfreeze_layers, (tuple, list)) and \
+                not isinstance(unfreeze_layers[0], str):
+            raise TypeError('`unfreeze_layers` must be a tuple or \
+                            list of string')
+        if not isinstance(unfreeze_iter, (int, type(None))):
+            raise TypeError('`unfreeze_iter` must be an integer or None')
+        if not isinstance(unfreeze_epoch, (int, type(None))):
+            raise TypeError('`unfreeze_epoch` must be an integer or None')
+        if not isinstance(verbose, bool):
+            raise TypeError('`verbose`  must be a boolean')
         # check arguments value
-        if freeze_epoch <= 0:
-            raise ValueError('freeze_epoch must be greater than 0')
-        if len(freeze_layers) == 0:
-            raise ValueError('freeze_layers must not be empty')
-        if unfreeze_epoch is not None and unfreeze_epoch <= 0:
-            raise ValueError('unfreeze_epoch must be greater than 0')
-        if unfreeze_epoch is not None and unfreeze_epoch <= freeze_epoch:
+        if freeze_iter and freeze_iter < 0:
             raise ValueError(
-                'unfreeze_epoch must be greater than freeze_epoch')
-        if unfreeze_epoch is not None and unfreeze_layers is None:
+                '`freeze_iter` must be greater than or equal to 0')
+        if freeze_epoch and freeze_epoch < 0:
             raise ValueError(
-                'unfreeze_layers must not be None when unfreeze_epoch '
-                'is not None.')
-        if (unfreeze_epoch is None and unfreeze_layers is not None) or (
-                unfreeze_epoch is not None and unfreeze_layers is None):
+                '`freeze_epoch` must be greater than or equal to 0')
+        if (freeze_epoch is None) and (freeze_iter is None):
             raise ValueError(
-                'unfreeze_epoch and unfreeze_layers must be both None '
-                'or not None')
+                '`freeze_iter` and `freeze_epoch` should not be both None.')
+        if (freeze_epoch is not None) and (freeze_iter is not None):
+            raise ValueError(
+                '`freeze_iter` and `freeze_epoch` should not be both set.')
+        if unfreeze_layers is not None:
+            if (unfreeze_epoch is None) and (unfreeze_iter is None):
+                raise ValueError('`unfreeze_iter` and `unfreeze_epoch` \
+                                 should not be both None.')
+            if (unfreeze_epoch is not None) and (unfreeze_iter is not None):
+                raise ValueError('`unfreeze_iter` and `unfreeze_epoch` \
+                        should not be both set.')
+        if unfreeze_iter is not None:
+            if unfreeze_iter < 0:
+                raise ValueError(
+                    '`unfreeze_iter` must be greater than or equal to 0')
+            if freeze_iter is None:
+                raise ValueError('`unfreeze_iter` and `freeze_iter` \
+                        should be set at the same time.')
+            if unfreeze_iter < freeze_iter:
+                raise ValueError('`unfreeze_iter` must be greater than \
+                        or equal to `freeze_iter`')
+        if unfreeze_epoch is not None:
+            if unfreeze_epoch < 0:
+                raise ValueError(
+                    '`unfreeze_epoch` must be greater than or equal to 0')
+            if freeze_epoch is None:
+                raise ValueError('`unfreeze_epoch` and `freeze_epoch` \
+                        should be set at the same time.')
+            if unfreeze_epoch < freeze_epoch:
+                raise ValueError('`unfreeze_epoch` must be greater than \
+                        or equal to `freeze_epoch`')
 
-        self.freeze_epoch = freeze_epoch
         if isinstance(freeze_layers, str):
             freeze_layers = (freeze_layers, )
         self.freeze_layers = freeze_layers
-        self.unfreeze_epoch = unfreeze_epoch
+        self.freeze_iter = freeze_iter
+        self.freeze_epoch = freeze_epoch
         if isinstance(unfreeze_layers, str):
             unfreeze_layers = (unfreeze_layers, )
         self.unfreeze_layers = unfreeze_layers
-        self.log_grad = log_grad
+        self.unfreeze_iter = unfreeze_iter
+        self.unfreeze_epoch = unfreeze_epoch
+        self.verbose = verbose
+        self.freeze_layer_names: list = []
+        self.unfreeze_layer_names: list = []
 
-    def modify_layers_grad(self, model, layers, requires_grad):
+    def _modify_layers_grad(self, model: BaseModel, layers: Sequence[str],
+                            requires_grad: bool):
+        """Modify the `requires_grad` of the specified layers.
+
+        Args:
+            model (BaseModel): a BaseModel of mmengine.
+            layers (Sequence[str]): Network layers to be modified.
+            requires_grad (bool): Whether to enable gradient.
+        """
         if is_model_wrapper(model):
             model = model.module
         for k, v in model.named_parameters():
-            for layer in layers:
-                if layer in k:
-                    v.requires_grad = requires_grad
-                    break
+            if k in layers:
+                v.requires_grad = requires_grad
 
-    def log_model_grad(self, model, log_grad=False):
-        if log_grad:
-            for k, v in model.named_parameters():
-                print_log(
-                    f'{k} requires_grad: {v.requires_grad}', logger='current')
+    def _log_model_grad(self, model: BaseModel):
+        """Print `requires_grad` for all network layers.
+
+        Args:
+            model (BaseModel): a BaseModel of mmengine.
+        """
+        for k, v in model.named_parameters():
+            print_log(
+                f'{k} requires_grad: {v.requires_grad}', logger='current')
+
+    def _main(self,
+              runner,
+              idx: int,
+              freeze_idx: int,
+              unfreeze_idx: Optional[int] = None) -> None:
+        """The main function of FreezeHook.
+
+        Args:
+            runner (Runner): The runner of the training process.
+            idx (int): The index in the train loop.
+            freeze_idx (int): The index to start freezing layers.
+            unfreeze_idx (int): The index to start unfreezing layers.
+        """
+        if idx in (freeze_idx, unfreeze_idx):
+            model = runner.model
+            if is_model_wrapper(model):
+                model = model.module
+
+            if idx == freeze_idx:
+                print_log('Start freezing layers.', logger='current')
+                self._modify_layers_grad(model, self.freeze_layer_names, False)
+                # if you want to release GPU memory cache:
+                # import torch; torch.cuda.empty_cache()
+
+            if idx == unfreeze_idx:
+                print_log('Start unfreezing layers.', logger='current')
+                self._modify_layers_grad(model, self.unfreeze_layer_names,
+                                         True)
+
+            if self.verbose:
+                self._log_model_grad(model)
+
+    def before_train(self, runner) -> None:
+        """Collect network layers that will be freeze or unfreeze.
+
+        Args:
+            runner (Runner): The runner of the training process.
+        """
+        model = runner.model
+        if is_model_wrapper(model):
+            model = model.module
+
+        layer_names = ''
+        for k, _ in model.named_parameters():
+            layer_names += f'{k}\n'
+
+        for pattern in self.freeze_layers:
+            freeze_names = re.findall(pattern, layer_names)
+            self.freeze_layer_names += freeze_names
+
+        if self.unfreeze_layers is not None:
+            for pattern in self.unfreeze_layers:
+                unfreeze_names = re.findall(pattern, layer_names)
+                self.unfreeze_layer_names += unfreeze_names
+
+    def before_train_iter(
+        self,
+        runner,
+        batch_idx: int,
+        data_batch: DATA_BATCH = None,
+        outputs: Optional[dict] = None,
+    ) -> None:
+        """Update `requires_grad` before the start of `freeze_iter`
+
+        Args:
+            runner (Runner): The runner of the training process.
+            batch_idx (int): The index of the current batch in the train loop.
+            data_batch (Sequence[dict], optional): Data from dataloader.
+                Defaults to None.
+            outputs (dict, optional): Outputs from model. Defaults to None.
+        """
+        if self.freeze_iter is not None:
+            self._main(runner, runner.iter, self.freeze_iter,
+                       self.unfreeze_iter)
 
     def before_train_epoch(self, runner) -> None:
-        if (runner.epoch + 1) == self.freeze_epoch:
-            self.modify_layers_grad(
-                runner.model, self.freeze_layers, requires_grad=False)
-            self.log_model_grad(runner.model, self.log_grad)
-            print_log(
-                f'Freeze {self.freeze_layers} at epoch {runner.epoch + 1}',
-                logger='current')
-            # if you want to release GPU memory cache:
-            # import torch; torch.cuda.empty_cache()
+        """Update `requires_grad` before the start of `freeze_epoch`
 
-        if (runner.epoch + 1) == self.unfreeze_epoch:
-            self.modify_layers_grad(
-                runner.model, self.unfreeze_layers, requires_grad=True)
-            self.log_model_grad(runner.model, self.log_grad)
-            print_log(
-                f'Unfreeze {self.unfreeze_layers} at epoch {runner.epoch + 1}',
-                logger='current')
+        Args:
+            runner (Runner): The runner of the training process.
+        """
+        if self.freeze_epoch is not None:
+            self._main(runner, runner.epoch, self.freeze_epoch,
+                       self.unfreeze_epoch)

--- a/tests/test_hooks/test_freeze_hook.py
+++ b/tests/test_hooks/test_freeze_hook.py
@@ -12,26 +12,26 @@ class TestFreezeHook(RunnerTestCase):
 
     def test_init(self):
         # Test FreezeHook TypeError.
-        FreezeHook(freeze_layers=('backbone.*', ), freeze_epoch=0)
+        FreezeHook(freeze_layers='backbone.*', freeze_epoch=0)
 
         with self.assertRaisesRegex(TypeError, '`freeze_layers`'):
             FreezeHook(freeze_layers=1, freeze_epoch=0)
 
         with self.assertRaisesRegex(TypeError, '`freeze_layers`'):
-            FreezeHook(freeze_layers=(), freeze_epoch=0)
+            FreezeHook(freeze_layers=(1, 2), freeze_epoch=0)
 
         with self.assertRaisesRegex(TypeError, '`freeze_layers`'):
-            FreezeHook(freeze_layers=(1, ), freeze_epoch=0)
+            FreezeHook(freeze_layers=('backbone.*', ), freeze_epoch=0)
 
         with self.assertRaisesRegex(TypeError, '`freeze_iter`'):
-            FreezeHook(freeze_layers=('backbone.*', ), freeze_iter='0')
+            FreezeHook(freeze_layers='backbone.*', freeze_iter='0')
 
         with self.assertRaisesRegex(TypeError, '`freeze_epoch`'):
-            FreezeHook(freeze_layers=('backbone.*', ), freeze_epoch='0')
+            FreezeHook(freeze_layers='backbone.*', freeze_epoch='0')
 
         with self.assertRaisesRegex(TypeError, '`unfreeze_layers`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_epoch=0,
                 unfreeze_layers=1,
                 unfreeze_epoch=0,
@@ -39,33 +39,33 @@ class TestFreezeHook(RunnerTestCase):
 
         with self.assertRaisesRegex(TypeError, '`unfreeze_layers`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_epoch=0,
-                unfreeze_layers=(),
+                unfreeze_layers=(1, 2),
                 unfreeze_epoch=0,
             )
 
         with self.assertRaisesRegex(TypeError, '`unfreeze_layers`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_epoch=0,
-                unfreeze_layers=(1, ),
+                unfreeze_layers=('backbone.*', ),
                 unfreeze_epoch=0,
             )
 
         with self.assertRaisesRegex(TypeError, '`unfreeze_iter`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_iter=0,
-                unfreeze_layers=('backbone.*', ),
+                unfreeze_layers='backbone.*',
                 unfreeze_iter='0',
             )
 
         with self.assertRaisesRegex(TypeError, '`unfreeze_epoch`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_epoch=0,
-                unfreeze_layers=('backbone.*', ),
+                unfreeze_layers='backbone.*',
                 unfreeze_epoch='0',
             )
 
@@ -74,82 +74,82 @@ class TestFreezeHook(RunnerTestCase):
 
         # Test FreezeHook ValueError.
         with self.assertRaisesRegex(ValueError, '`freeze_iter`'):
-            FreezeHook(freeze_layers=('backbone.*', ), freeze_iter=-1)
+            FreezeHook(freeze_layers='backbone.*', freeze_iter=-1)
 
         with self.assertRaisesRegex(ValueError, '`freeze_epoch`'):
-            FreezeHook(freeze_layers=('backbone.*', ), freeze_epoch=-1)
+            FreezeHook(freeze_layers='backbone.*', freeze_epoch=-1)
 
         with self.assertRaisesRegex(ValueError,
                                     '`freeze_iter` and `freeze_epoch`'):
-            FreezeHook(freeze_layers=('backbone.*', ))
+            FreezeHook(freeze_layers='backbone.*', )
 
         with self.assertRaisesRegex(ValueError,
                                     '`freeze_iter` and `freeze_epoch`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ), freeze_iter=0, freeze_epoch=0)
+                freeze_layers='backbone.*', freeze_iter=0, freeze_epoch=0)
 
         with self.assertRaisesRegex(ValueError,
                                     '`unfreeze_iter` and `unfreeze_epoch`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_epoch=0,
-                unfreeze_layers=('backbone.*', ))
+                unfreeze_layers='backbone.*')
 
         with self.assertRaisesRegex(ValueError,
                                     '`unfreeze_iter` and `unfreeze_epoch`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_epoch=0,
-                unfreeze_layers=('backbone.*', ),
+                unfreeze_layers='backbone.*',
                 unfreeze_iter=1,
                 unfreeze_epoch=2,
             )
 
         with self.assertRaisesRegex(ValueError, '`unfreeze_iter`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_iter=0,
-                unfreeze_layers=('backbone.*', ),
+                unfreeze_layers='backbone.*',
                 unfreeze_iter=-1,
             )
 
         with self.assertRaisesRegex(ValueError, '`freeze_iter`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_iter=None,
-                unfreeze_layers=('backbone.*', ),
+                unfreeze_layers='backbone.*',
                 unfreeze_iter=1,
             )
 
         with self.assertRaisesRegex(ValueError, '`unfreeze_iter`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_iter=2,
-                unfreeze_layers=('backbone.*', ),
+                unfreeze_layers='backbone.*',
                 unfreeze_iter=1,
             )
 
         with self.assertRaisesRegex(ValueError, '`unfreeze_epoch`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_epoch=0,
-                unfreeze_layers=('backbone.*', ),
+                unfreeze_layers='backbone.*',
                 unfreeze_epoch=-1,
             )
 
         with self.assertRaisesRegex(ValueError, '`freeze_epoch`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_epoch=None,
-                unfreeze_layers=('backbone.*', ),
+                unfreeze_layers='backbone.*',
                 unfreeze_epoch=1,
             )
 
         with self.assertRaisesRegex(ValueError, '`unfreeze_epoch`'):
             FreezeHook(
-                freeze_layers=('backbone.*', ),
+                freeze_layers='backbone.*',
                 freeze_epoch=2,
-                unfreeze_layers=('backbone.*', ),
+                unfreeze_layers='backbone.*',
                 unfreeze_epoch=1,
             )
 
@@ -158,9 +158,9 @@ class TestFreezeHook(RunnerTestCase):
         runner = self.build_runner(cfg)
 
         freeze_hook = FreezeHook(
-            freeze_layers=('linear1.*', 'linear2.*'),
+            freeze_layers='linear1.*|linear2.*',
             freeze_iter=1,
-            unfreeze_layers=('linear2.*', ),
+            unfreeze_layers='linear2.*',
             unfreeze_iter=3,
         )
         # Collect network layers that will be freeze or unfreeze.
@@ -194,9 +194,9 @@ class TestFreezeHook(RunnerTestCase):
         runner = self.build_runner(cfg)
 
         freeze_hook = FreezeHook(
-            freeze_layers=('linear1.*', 'linear2.*'),
+            freeze_layers='linear1.*|linear2.*',
             freeze_epoch=1,
-            unfreeze_layers=('linear2.*', ),
+            unfreeze_layers='linear2.*',
             unfreeze_epoch=3,
         )
         # Collect network layers that will be freeze or unfreeze.

--- a/tests/test_hooks/test_freeze_hook.py
+++ b/tests/test_hooks/test_freeze_hook.py
@@ -11,90 +11,218 @@ class TestFreezeHook(RunnerTestCase):
         super().setUp()
 
     def test_init(self):
-        # Test build freeze hook.
-        FreezeHook(freeze_epoch=1, freeze_layers=('backbone', ))
+        # Test FreezeHook TypeError.
+        FreezeHook(freeze_layers=('backbone.*', ), freeze_epoch=0)
 
-        with self.assertRaisesRegex(TypeError, 'freeze_epoch must be'):
-            FreezeHook(freeze_epoch='100', freeze_layers=('backbone', ))
+        with self.assertRaisesRegex(TypeError, '`freeze_layers`'):
+            FreezeHook(freeze_layers=1, freeze_epoch=0)
 
-        with self.assertRaisesRegex(ValueError, 'freeze_epoch'):
-            FreezeHook(freeze_epoch=0, freeze_layers=('backbone', ))
+        with self.assertRaisesRegex(TypeError, '`freeze_layers`'):
+            FreezeHook(freeze_layers=(), freeze_epoch=0)
 
-        with self.assertRaisesRegex(TypeError, 'freeze_layers must be'):
-            FreezeHook(freeze_epoch=1, freeze_layers=False)
+        with self.assertRaisesRegex(TypeError, '`freeze_layers`'):
+            FreezeHook(freeze_layers=(1, ), freeze_epoch=0)
 
-        with self.assertRaisesRegex(TypeError, 'freeze_layers must be'):
-            FreezeHook(freeze_epoch=1, freeze_layers=1)
+        with self.assertRaisesRegex(TypeError, '`freeze_iter`'):
+            FreezeHook(freeze_layers=('backbone.*', ), freeze_iter='0')
 
-        with self.assertRaisesRegex(TypeError, 'unfreeze_epoch must be'):
+        with self.assertRaisesRegex(TypeError, '`freeze_epoch`'):
+            FreezeHook(freeze_layers=('backbone.*', ), freeze_epoch='0')
+
+        with self.assertRaisesRegex(TypeError, '`unfreeze_layers`'):
             FreezeHook(
-                freeze_epoch=1, freeze_layers='backbone', unfreeze_epoch='100')
+                freeze_layers=('backbone.*', ),
+                freeze_epoch=0,
+                unfreeze_layers=1,
+                unfreeze_epoch=0,
+            )
 
-        with self.assertRaisesRegex(ValueError, 'unfreeze_epoch'):
+        with self.assertRaisesRegex(TypeError, '`unfreeze_layers`'):
             FreezeHook(
-                freeze_epoch=1,
-                freeze_layers='backbone',
-                unfreeze_layers=('backbone', ))
+                freeze_layers=('backbone.*', ),
+                freeze_epoch=0,
+                unfreeze_layers=(),
+                unfreeze_epoch=0,
+            )
 
-        with self.assertRaisesRegex(ValueError, 'unfreeze_epoch'):
+        with self.assertRaisesRegex(TypeError, '`unfreeze_layers`'):
             FreezeHook(
-                freeze_epoch=1, freeze_layers='backbone', unfreeze_epoch=2)
+                freeze_layers=('backbone.*', ),
+                freeze_epoch=0,
+                unfreeze_layers=(1, ),
+                unfreeze_epoch=0,
+            )
 
-        with self.assertRaisesRegex(ValueError, 'unfreeze_epoch'):
+        with self.assertRaisesRegex(TypeError, '`unfreeze_iter`'):
             FreezeHook(
-                freeze_epoch=1,
-                freeze_layers='backbone',
+                freeze_layers=('backbone.*', ),
+                freeze_iter=0,
+                unfreeze_layers=('backbone.*', ),
+                unfreeze_iter='0',
+            )
+
+        with self.assertRaisesRegex(TypeError, '`unfreeze_epoch`'):
+            FreezeHook(
+                freeze_layers=('backbone.*', ),
+                freeze_epoch=0,
+                unfreeze_layers=('backbone.*', ),
+                unfreeze_epoch='0',
+            )
+
+        with self.assertRaisesRegex(TypeError, '`verbose`'):
+            FreezeHook(freeze_layers='backbone.*', freeze_epoch=1, verbose=1)
+
+        # Test FreezeHook ValueError.
+        with self.assertRaisesRegex(ValueError, '`freeze_iter`'):
+            FreezeHook(freeze_layers=('backbone.*', ), freeze_iter=-1)
+
+        with self.assertRaisesRegex(ValueError, '`freeze_epoch`'):
+            FreezeHook(freeze_layers=('backbone.*', ), freeze_epoch=-1)
+
+        with self.assertRaisesRegex(ValueError,
+                                    '`freeze_iter` and `freeze_epoch`'):
+            FreezeHook(freeze_layers=('backbone.*', ))
+
+        with self.assertRaisesRegex(ValueError,
+                                    '`freeze_iter` and `freeze_epoch`'):
+            FreezeHook(
+                freeze_layers=('backbone.*', ), freeze_iter=0, freeze_epoch=0)
+
+        with self.assertRaisesRegex(ValueError,
+                                    '`unfreeze_iter` and `unfreeze_epoch`'):
+            FreezeHook(
+                freeze_layers=('backbone.*', ),
+                freeze_epoch=0,
+                unfreeze_layers=('backbone.*', ))
+
+        with self.assertRaisesRegex(ValueError,
+                                    '`unfreeze_iter` and `unfreeze_epoch`'):
+            FreezeHook(
+                freeze_layers=('backbone.*', ),
+                freeze_epoch=0,
+                unfreeze_layers=('backbone.*', ),
+                unfreeze_iter=1,
+                unfreeze_epoch=2,
+            )
+
+        with self.assertRaisesRegex(ValueError, '`unfreeze_iter`'):
+            FreezeHook(
+                freeze_layers=('backbone.*', ),
+                freeze_iter=0,
+                unfreeze_layers=('backbone.*', ),
+                unfreeze_iter=-1,
+            )
+
+        with self.assertRaisesRegex(ValueError, '`freeze_iter`'):
+            FreezeHook(
+                freeze_layers=('backbone.*', ),
+                freeze_iter=None,
+                unfreeze_layers=('backbone.*', ),
+                unfreeze_iter=1,
+            )
+
+        with self.assertRaisesRegex(ValueError, '`unfreeze_iter`'):
+            FreezeHook(
+                freeze_layers=('backbone.*', ),
+                freeze_iter=2,
+                unfreeze_layers=('backbone.*', ),
+                unfreeze_iter=1,
+            )
+
+        with self.assertRaisesRegex(ValueError, '`unfreeze_epoch`'):
+            FreezeHook(
+                freeze_layers=('backbone.*', ),
+                freeze_epoch=0,
+                unfreeze_layers=('backbone.*', ),
+                unfreeze_epoch=-1,
+            )
+
+        with self.assertRaisesRegex(ValueError, '`freeze_epoch`'):
+            FreezeHook(
+                freeze_layers=('backbone.*', ),
+                freeze_epoch=None,
+                unfreeze_layers=('backbone.*', ),
                 unfreeze_epoch=1,
-                unfreeze_layers=('backbone', ))
+            )
 
-        with self.assertRaisesRegex(TypeError, 'unfreeze_layers must be'):
+        with self.assertRaisesRegex(ValueError, '`unfreeze_epoch`'):
             FreezeHook(
-                freeze_epoch=1,
-                freeze_layers='backbone',
-                unfreeze_layers=False)
+                freeze_layers=('backbone.*', ),
+                freeze_epoch=2,
+                unfreeze_layers=('backbone.*', ),
+                unfreeze_epoch=1,
+            )
 
-        with self.assertRaisesRegex(TypeError, 'unfreeze_layers must be'):
-            FreezeHook(
-                freeze_epoch=1, freeze_layers='backbone', unfreeze_layers=1)
+    def test_before_train_iter(self):
+        cfg = copy.deepcopy(self.iter_based_cfg)
+        runner = self.build_runner(cfg)
 
-        with self.assertRaisesRegex(ValueError, 'unfreeze_layers'):
-            FreezeHook(
-                freeze_epoch=1, freeze_layers='backbone', unfreeze_epoch=2)
+        freeze_hook = FreezeHook(
+            freeze_layers=('linear1.*', 'linear2.*'),
+            freeze_iter=1,
+            unfreeze_layers=('linear2.*', ),
+            unfreeze_iter=3,
+        )
+        # Collect network layers that will be freeze or unfreeze.
+        freeze_hook.before_train(runner)
+        freeze_hook.before_train_iter(runner, 1)
+        self.assertTrue(runner.model.linear1.weight.requires_grad)
+        self.assertTrue(runner.model.linear2.weight.requires_grad)
 
-        with self.assertRaisesRegex(TypeError, 'log_grad must be'):
-            FreezeHook(freeze_epoch=1, freeze_layers='backbone', log_grad=1)
+        runner.train_loop._iter = 1
+        freeze_hook.before_train_iter(runner, 1)
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertFalse(runner.model.linear2.weight.requires_grad)
+
+        runner.train_loop._iter = 2
+        freeze_hook.before_train_iter(runner, 1)
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertFalse(runner.model.linear2.weight.requires_grad)
+
+        runner.train_loop._iter = 3
+        freeze_hook.before_train_iter(runner, 1)
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertTrue(runner.model.linear2.weight.requires_grad)
+
+        runner.train_loop._iter = 4
+        freeze_hook.before_train_iter(runner, 1)
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertTrue(runner.model.linear2.weight.requires_grad)
 
     def test_before_train_epoch(self):
         cfg = copy.deepcopy(self.epoch_based_cfg)
         runner = self.build_runner(cfg)
 
         freeze_hook = FreezeHook(
-            freeze_epoch=2, freeze_layers=('linear1', 'linear2'))
+            freeze_layers=('linear1.*', 'linear2.*'),
+            freeze_epoch=1,
+            unfreeze_layers=('linear2.*', ),
+            unfreeze_epoch=3,
+        )
+        # Collect network layers that will be freeze or unfreeze.
+        freeze_hook.before_train(runner)
         freeze_hook.before_train_epoch(runner)
         self.assertTrue(runner.model.linear1.weight.requires_grad)
         self.assertTrue(runner.model.linear2.weight.requires_grad)
 
-        runner.train_loop._epoch = 3
-        freeze_hook = FreezeHook(
-            freeze_epoch=4, freeze_layers=('linear1', 'linear2'))
+        runner.train_loop._epoch = 1
         freeze_hook.before_train_epoch(runner)
         self.assertFalse(runner.model.linear1.weight.requires_grad)
         self.assertFalse(runner.model.linear2.weight.requires_grad)
 
-        runner.train_loop._epoch = 5
+        runner.train_loop._epoch = 2
+        freeze_hook.before_train_epoch(runner)
         self.assertFalse(runner.model.linear1.weight.requires_grad)
         self.assertFalse(runner.model.linear2.weight.requires_grad)
 
-        runner.train_loop._epoch = 7
-        freeze_hook = FreezeHook(
-            freeze_epoch=4,
-            freeze_layers=('linear1', 'linear2'),
-            unfreeze_epoch=8,
-            unfreeze_layers=('linear2', ))
+        runner.train_loop._epoch = 3
+        freeze_hook.before_train_epoch(runner)
         freeze_hook.before_train_epoch(runner)
         self.assertFalse(runner.model.linear1.weight.requires_grad)
         self.assertTrue(runner.model.linear2.weight.requires_grad)
 
-        runner.train_loop._epoch = 9
+        runner.train_loop._epoch = 4
+        freeze_hook.before_train_epoch(runner)
+        freeze_hook.before_train_epoch(runner)
         self.assertFalse(runner.model.linear1.weight.requires_grad)
         self.assertTrue(runner.model.linear2.weight.requires_grad)

--- a/tests/test_hooks/test_freeze_hook.py
+++ b/tests/test_hooks/test_freeze_hook.py
@@ -1,0 +1,100 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import copy
+
+from mmengine.hooks import FreezeHook
+from mmengine.testing import RunnerTestCase
+
+
+class TestFreezeHook(RunnerTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+    def test_init(self):
+        # Test build freeze hook.
+        FreezeHook(freeze_epoch=1, freeze_layers=('backbone', ))
+
+        with self.assertRaisesRegex(TypeError, 'freeze_epoch must be'):
+            FreezeHook(freeze_epoch='100', freeze_layers=('backbone', ))
+
+        with self.assertRaisesRegex(ValueError, 'freeze_epoch'):
+            FreezeHook(freeze_epoch=0, freeze_layers=('backbone', ))
+
+        with self.assertRaisesRegex(TypeError, 'freeze_layers must be'):
+            FreezeHook(freeze_epoch=1, freeze_layers=False)
+
+        with self.assertRaisesRegex(TypeError, 'freeze_layers must be'):
+            FreezeHook(freeze_epoch=1, freeze_layers=1)
+
+        with self.assertRaisesRegex(TypeError, 'unfreeze_epoch must be'):
+            FreezeHook(
+                freeze_epoch=1, freeze_layers='backbone', unfreeze_epoch='100')
+
+        with self.assertRaisesRegex(ValueError, 'unfreeze_epoch'):
+            FreezeHook(
+                freeze_epoch=1,
+                freeze_layers='backbone',
+                unfreeze_layers=('backbone', ))
+
+        with self.assertRaisesRegex(ValueError, 'unfreeze_epoch'):
+            FreezeHook(
+                freeze_epoch=1, freeze_layers='backbone', unfreeze_epoch=2)
+
+        with self.assertRaisesRegex(ValueError, 'unfreeze_epoch'):
+            FreezeHook(
+                freeze_epoch=1,
+                freeze_layers='backbone',
+                unfreeze_epoch=1,
+                unfreeze_layers=('backbone', ))
+
+        with self.assertRaisesRegex(TypeError, 'unfreeze_layers must be'):
+            FreezeHook(
+                freeze_epoch=1,
+                freeze_layers='backbone',
+                unfreeze_layers=False)
+
+        with self.assertRaisesRegex(TypeError, 'unfreeze_layers must be'):
+            FreezeHook(
+                freeze_epoch=1, freeze_layers='backbone', unfreeze_layers=1)
+
+        with self.assertRaisesRegex(ValueError, 'unfreeze_layers'):
+            FreezeHook(
+                freeze_epoch=1, freeze_layers='backbone', unfreeze_epoch=2)
+
+        with self.assertRaisesRegex(TypeError, 'log_grad must be'):
+            FreezeHook(freeze_epoch=1, freeze_layers='backbone', log_grad=1)
+
+    def test_before_train_epoch(self):
+        cfg = copy.deepcopy(self.epoch_based_cfg)
+        runner = self.build_runner(cfg)
+
+        freeze_hook = FreezeHook(
+            freeze_epoch=2, freeze_layers=('linear1', 'linear2'))
+        freeze_hook.before_train_epoch(runner)
+        self.assertTrue(runner.model.linear1.weight.requires_grad)
+        self.assertTrue(runner.model.linear2.weight.requires_grad)
+
+        runner.train_loop._epoch = 3
+        freeze_hook = FreezeHook(
+            freeze_epoch=4, freeze_layers=('linear1', 'linear2'))
+        freeze_hook.before_train_epoch(runner)
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertFalse(runner.model.linear2.weight.requires_grad)
+
+        runner.train_loop._epoch = 5
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertFalse(runner.model.linear2.weight.requires_grad)
+
+        runner.train_loop._epoch = 7
+        freeze_hook = FreezeHook(
+            freeze_epoch=4,
+            freeze_layers=('linear1', 'linear2'),
+            unfreeze_epoch=8,
+            unfreeze_layers=('linear2', ))
+        freeze_hook.before_train_epoch(runner)
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertTrue(runner.model.linear2.weight.requires_grad)
+
+        runner.train_loop._epoch = 9
+        self.assertFalse(runner.model.linear1.weight.requires_grad)
+        self.assertTrue(runner.model.linear2.weight.requires_grad)


### PR DESCRIPTION
## Motivation

Motivation: 

1. Freeze some parameters of the model when training the model.

Goal: 

1. Specify the epoch to freeze the specified network layer. 
2. Available for all downstream repositories.

 <p><br></p>

## Modification

Add FreezeHook and FreezeHook unit tests.

 <p><br></p>

## Use cases

1. Network layers matching `freeze_layers` are freeze before `freeze_iter/freeze_epoch` starts.
2. Network layers matching `unfreeze_layers` are freeze before `unfreeze_iter/unfreeze_epoch` starts.
3. `freeze_layers/unfreeze_layers` matches network layers via regular expression
4. The index of `iter/epoch` starts at 0, with epoch=0 for the first epoch.
5. `unfreeze_iter`, `unfreeze_epoch` and `unfreeze_layers` are optional. If `freeze_epoch/freeze_iter` is not None, `unfreeze_layers` must not be None.
6. Only one of `freeze_iter` and `freeze_epoch` can be set, as well as `unfreeze_iter` and `unfreeze_epoch`.

```python
ImageClassifier(
    (backbone):ResNet(
        ...
        (layer1):Sequential(...)
        (layer2):Sequential(...)
        (layer3):Sequential(...)
        (layer4):Sequential(...)
    )
    (neck):GlobalAveragePooling2d(...)
    (head):Linear(...)
)
```


1. Freeze the parameters of backbone before the start of 1st training epoch.

 ```python
custom_hooks = [
 ...
 dict(
     type="FreezeHook",
     freeze_layers="backbone.*",
     freeze_epoch=0)
]
 ```


2. Freeze the layer1 and layer2 parameters in the backbone before the start of 10th training epoch.

 ```python
custom_hooks = [
 ...
 dict(
     type="FreezeHook",
     freeze_layers="backbone.layer1.*|backbone.layer2.*",
     freeze_epoch=10)
]
 ```


3. Freeze the parameters of backbone before the start of 1st training epoch. Unfreeze the parameters of the the backbone before the start of 10th training epoch.

```python
custom_hooks = [
 ...
 dict(
     type="FreezeHook",
     freeze_layers="backbone.*",
     freeze_epoch=0,
     unfreeze_layers="backbone.*",
     unfreeze_epoch=9)
]
```

4. The `verbose` parameter is used to determine whether to print the `requires_grad` variable for each model layer.

```python
custom_hooks = [
 ...
 dict(
     type="FreezeHook",
     freeze_layers="backbone.*",
     freeze_epoch=1,
     verbose=True)
]
```


 ```powershell
mmengine - INFO - backbone.conv1.weight requires_grad: True
mmengine - INFO - backbone.bn1.weight requires_grad: True
...
mmengine - INFO - head.light_head.weight requires_grad: True
mmengine - INFO - head.light_head.bias requires_grad: True
 ```

