### PR TITLE
[Fix] fix a bug when module is missing in low version of bitsandbytes

### DIFF
--- a/mmengine/optim/optimizer/builder.py
+++ b/mmengine/optim/optimizer/builder.py
@@ -132,6 +132,10 @@ SOPHIA_OPTIMIZERS = register_sophia_optimizers()
 def register_bitsandbytes_optimizers() -> List[str]:
     """Register optimizers in ``bitsandbytes`` to the ``OPTIMIZERS`` registry.
 
+    In the `bitsandbytes` library, optimizers that have the same name as the
+    default optimizers in PyTorch are prefixed with ``bnb_``. For example,
+    ``bnb_Adagrad``.
+
     Returns:
         List[str]: A list of registered optimizers' name.
     """
@@ -141,16 +145,14 @@ def register_bitsandbytes_optimizers() -> List[str]:
     except ImportError:
         pass
     else:
-        for module_name in [
-                'AdamW8bit', 'Adam8bit', 'Adagrad8bit', 'PagedAdam8bit',
-                'PagedAdamW8bit', 'LAMB8bit', 'LARS8bit', 'RMSprop8bit',
-                'Lion8bit', 'PagedLion8bit', 'SGD8bit'
-        ]:
-            _optim = getattr(bnb.optim, module_name, None)
-            if inspect.isclass(_optim) and issubclass(_optim,
-                                                      torch.optim.Optimizer):
-                OPTIMIZERS.register_module(module=_optim)
-                dadaptation_optimizers.append(module_name)
+        optim_classes = inspect.getmembers(
+            bnb.optim, lambda _optim: (inspect.isclass(_optim) and issubclass(
+                _optim, torch.optim.Optimizer)))
+        for name, optim_cls in optim_classes:
+            if name in OPTIMIZERS:
+                name = f'bnb_{name}'
+            OPTIMIZERS.register_module(module=optim_cls, name=name)
+            dadaptation_optimizers.append(name)
     return dadaptation_optimizers
 
 

--- a/mmengine/optim/optimizer/builder.py
+++ b/mmengine/optim/optimizer/builder.py
@@ -146,7 +146,7 @@ def register_bitsandbytes_optimizers() -> List[str]:
                 'PagedAdamW8bit', 'LAMB8bit', 'LARS8bit', 'RMSprop8bit',
                 'Lion8bit', 'PagedLion8bit', 'SGD8bit'
         ]:
-            _optim = getattr(bnb.optim, module_name)
+            _optim = getattr(bnb.optim, module_name, None)
             if inspect.isclass(_optim) and issubclass(_optim,
                                                       torch.optim.Optimizer):
                 OPTIMIZERS.register_module(module=_optim)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

In [`register_bitsandbytes_optimizers`](https://github.com/open-mmlab/mmengine/blob/6c5eebb823e3c9381d63fd0cd1873ed1bd9ee9de/mmengine/optim/optimizer/builder.py#L132C14-L154), some optimizer modules are missing from a low version of `bitsandbytes`, resulting in a bug for users with lower versions. (e.g. https://github.com/open-mmlab/mmpose/issues/2747)

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
