### PR TITLE
[Feature] Support slurm distributed training for mlu devices

### DIFF
--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -186,9 +186,12 @@ def _init_dist_slurm(backend,
     if local_rank_env is not None:
         local_rank = int(local_rank_env)
     else:
-        num_gpus = torch.cuda.device_count()
+        if is_mlu_available():
+            import torch_mlu
+            num_gpus = torch.mlu.device_count()
+        else: 
+            num_gpus = torch.cuda.device_count()
         local_rank = proc_id % num_gpus
-    torch.cuda.set_device(local_rank)
     addr = subprocess.getoutput(
         f'scontrol show hostname {node_list} | head -n1')
     # specify master port
@@ -206,22 +209,32 @@ def _init_dist_slurm(backend,
     os.environ['LOCAL_RANK'] = str(local_rank)
     os.environ['RANK'] = str(proc_id)
 
-    if init_backend == 'torch':
-        torch_dist.init_process_group(backend=backend, **kwargs)
-    elif init_backend == 'deepspeed':
-        import deepspeed
-        deepspeed.init_distributed(dist_backend=backend, **kwargs)
-    elif init_backend == 'colossalai':
-        import colossalai
-        colossalai.launch_from_slurm(
-            backend=backend,
-            host=os.environ['MASTER_ADDR'],
-            port=os.environ['MASTER_PORT'],
-            **kwargs,
-        )
+    rank = int(os.environ['RANK'])
+    if is_mlu_available():
+        import torch_mlu
+        torch.mlu.set_device(local_rank)
+        torch_dist.init_process_group(
+            backend='cncl',
+            rank=rank,
+            world_size=int(os.environ['WORLD_SIZE']),
+            **kwargs)
     else:
-        raise ValueError('supported "init_backend" is "torch" or "deepspeed", '
-                         f'but got {init_backend}')
+        if init_backend == 'torch':
+            torch_dist.init_process_group(backend=backend, **kwargs)
+        elif init_backend == 'deepspeed':
+            import deepspeed
+            deepspeed.init_distributed(dist_backend=backend, **kwargs)
+        elif init_backend == 'colossalai':
+            import colossalai
+            colossalai.launch_from_slurm(
+                backend=backend,
+                host=os.environ['MASTER_ADDR'],
+                port=os.environ['MASTER_PORT'],
+                **kwargs,
+            )
+        else:
+            raise ValueError('supported "init_backend" is "torch" or "deepspeed", '
+                            f'but got {init_backend}')
 
 
 def init_local_group(node_rank: int, num_gpus_per_node: int):

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -205,14 +205,11 @@ def _init_dist_slurm(backend,
     os.environ['LOCAL_RANK'] = str(local_rank)
     os.environ['RANK'] = str(proc_id)
 
-    rank = int(os.environ['RANK'])
     if is_mlu_available():
         import torch_mlu  # noqa: F401
         torch.mlu.set_device(local_rank)
         torch_dist.init_process_group(
             backend='cncl',
-            rank=rank,
-            world_size=int(os.environ['WORLD_SIZE']),
             **kwargs)
     else:
         torch.cuda.set_device(local_rank)

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -186,11 +186,7 @@ def _init_dist_slurm(backend,
     if local_rank_env is not None:
         local_rank = int(local_rank_env)
     else:
-        if is_mlu_available():
-            import torch_mlu  # noqa: F401
-            num_gpus = torch.mlu.device_count()
-        else:
-            num_gpus = torch.cuda.device_count()
+        num_gpus = torch.cuda.device_count()
         local_rank = proc_id % num_gpus
     addr = subprocess.getoutput(
         f'scontrol show hostname {node_list} | head -n1')
@@ -235,8 +231,9 @@ def _init_dist_slurm(backend,
                 **kwargs,
             )
         else:
-            raise ValueError('supported "init_backend" is "torch" or "deepspeed", ' \
-                            f'but got {init_backend}')
+            raise ValueError(
+                'supported "init_backend" is "torch" or "deepspeed", '
+                f'but got {init_backend}')
 
 
 def init_local_group(node_rank: int, num_gpus_per_node: int):

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -187,9 +187,9 @@ def _init_dist_slurm(backend,
         local_rank = int(local_rank_env)
     else:
         if is_mlu_available():
-            import torch_mlu
+            import torch_mlu  # noqa: F401
             num_gpus = torch.mlu.device_count()
-        else: 
+        else:
             num_gpus = torch.cuda.device_count()
         local_rank = proc_id % num_gpus
     addr = subprocess.getoutput(
@@ -211,7 +211,7 @@ def _init_dist_slurm(backend,
 
     rank = int(os.environ['RANK'])
     if is_mlu_available():
-        import torch_mlu
+        import torch_mlu  # noqa: F401
         torch.mlu.set_device(local_rank)
         torch_dist.init_process_group(
             backend='cncl',
@@ -219,6 +219,8 @@ def _init_dist_slurm(backend,
             world_size=int(os.environ['WORLD_SIZE']),
             **kwargs)
     else:
+        torch.cuda.set_device(local_rank)
+
         if init_backend == 'torch':
             torch_dist.init_process_group(backend=backend, **kwargs)
         elif init_backend == 'deepspeed':
@@ -233,7 +235,7 @@ def _init_dist_slurm(backend,
                 **kwargs,
             )
         else:
-            raise ValueError('supported "init_backend" is "torch" or "deepspeed", '
+            raise ValueError('supported "init_backend" is "torch" or "deepspeed", ' \
                             f'but got {init_backend}')
 
 

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -208,9 +208,7 @@ def _init_dist_slurm(backend,
     if is_mlu_available():
         import torch_mlu  # noqa: F401
         torch.mlu.set_device(local_rank)
-        torch_dist.init_process_group(
-            backend='cncl',
-            **kwargs)
+        torch_dist.init_process_group(backend='cncl', **kwargs)
     else:
         torch.cuda.set_device(local_rank)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

To support slurm distributed training for mlu devices.

## Modification
Modify the _init_dist_slurm function in `mmengine/dist/utils.py` to support slurm distributed training for mlu devices.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
