### PR TITLE
[Fix] ConcatDataset raise error when metainfo is np.array

### DIFF
--- a/mmengine/dataset/dataset_wrapper.py
+++ b/mmengine/dataset/dataset_wrapper.py
@@ -84,8 +84,8 @@ class ConcatDataset(_ConcatDataset):
                 if (isinstance(self._metainfo[key], np.ndarray)
                         and not np.array_equal(self._metainfo[key],
                                                dataset.metainfo[key])
-                        or (not isinstance(self._metainfo[key], np.ndarray) and
-                            self._metainfo[key] != dataset.metainfo[key])):
+                        or (not isinstance(self._metainfo[key], np.ndarray)
+                            and self._metainfo[key] != dataset.metainfo[key])):
                     raise ValueError(
                         f'The meta information of the {i}-th dataset does not '
                         'match meta information of the first dataset')

--- a/mmengine/dataset/dataset_wrapper.py
+++ b/mmengine/dataset/dataset_wrapper.py
@@ -84,7 +84,8 @@ class ConcatDataset(_ConcatDataset):
                 if (isinstance(self._metainfo[key], np.ndarray)
                         and not np.array_equal(self._metainfo[key],
                                                dataset.metainfo[key])
-                        or self._metainfo[key] != dataset.metainfo[key]):
+                        or (not isinstance(self._metainfo[key], np.ndarray) and
+                            self._metainfo[key] != dataset.metainfo[key])):
                     raise ValueError(
                         f'The meta information of the {i}-th dataset does not '
                         'match meta information of the first dataset')


### PR DESCRIPTION
When metainfo is N-dim np.array and is the same, the ConcatDataset will raise the following errors:

```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

This is caused by the `!=` comparation of np.array

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

bug fix

## Modification

`ConcatDataset` in `dataset_wrapper.py`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
