### PR TITLE
fix: Inherit Configuration Files Across Repositories.

### DIFF
--- a/docs/en/notes/contributing.md
+++ b/docs/en/notes/contributing.md
@@ -89,16 +89,16 @@ git commit -m "xxx" --no-verify
 
 ### 3. Create a development branch
 
-After configuring the pre-commit, we should create a branch based on the master branch to develop the new feature or fix the bug. The proposed branch name is `username/pr_name`
+After configuring the pre-commit, we should create a branch based on the main branch to develop the new feature or fix the bug. The proposed branch name is `username/pr_name`
 
 ```shell
 git checkout -b yhc/refactor_contributing_doc
 ```
 
-In subsequent development, if the master branch of the local repository is behind the master branch of "upstream", we need to pull the upstream for synchronization, and then execute the above command:
+In subsequent development, if the main branch of the local repository is behind the main branch of "upstream", we need to pull the upstream for synchronization, and then execute the above command:
 
 ```shell
-git pull upstream master
+git pull upstream main
 ```
 
 ### 4. Commit the code and pass the unit test
@@ -161,18 +161,18 @@ MMEngine will run unit test for the posted Pull Request on different platforms (
 
 ### 7. Resolve conflicts
 
-If your local branch conflicts with the latest master branch of "upstream", you'll need to resolove them. There are two ways to do this:
+If your local branch conflicts with the latest main branch of "upstream", you'll need to resolove them. There are two ways to do this:
 
 ```shell
 git fetch --all --prune
-git rebase upstream/master
+git rebase upstream/main
 ```
 
 or
 
 ```shell
 git fetch --all --prune
-git merge upstream/master
+git merge upstream/main
 ```
 
 If you are very good at handling conflicts, then you can use rebase to resolve conflicts, as this will keep your commit logs tidy. If you are not familiar with `rebase`, then you can use `merge` to resolve conflicts.

--- a/docs/zh_cn/notes/contributing.md
+++ b/docs/zh_cn/notes/contributing.md
@@ -77,13 +77,16 @@ pre-commit run --all-files
 
 <img src="https://user-images.githubusercontent.com/57566630/202368856-0465a90d-8fce-4345-918e-67b8b9c82614.png" width="1200">
 
-```{note}
+:::{note}
 如果你是中国用户，由于网络原因，可能会出现安装失败的情况，这时可以使用国内源
-pre-commit install -c .pre-commit-config-zh-cn.yaml
+
+```bash
 pre-commit run --all-files -c .pre-commit-config-zh-cn.yaml
 ```
 
-如果安装过程被中断，可以重复执行 `pre-commit run ...` 继续安装。
+:::
+
+如果安装过程被中断，可以重复执行 `pre-commit run --all-files` 继续安装。
 
 如果提交的代码不符合代码风格规范，pre-commit 会发出警告，并自动修复部分错误。
 
@@ -97,16 +100,16 @@ git commit -m "xxx" --no-verify
 
 ### 3. 创建开发分支
 
-安装完 pre-commit 之后，我们需要基于 master 创建开发分支，建议的分支命名规则为 `username/pr_name`。
+安装完 pre-commit 之后，我们需要基于 main 创建开发分支，建议的分支命名规则为 `username/pr_name`。
 
 ```shell
 git checkout -b yhc/refactor_contributing_doc
 ```
 
-在后续的开发中，如果本地仓库的 master 分支落后于 upstream 的 master 分支，我们需要先拉取 upstream 的代码进行同步，再执行上面的命令
+在后续的开发中，如果本地仓库的 main 分支落后于 upstream 的 main 分支，我们需要先拉取 upstream 的代码进行同步，再执行上面的命令
 
 ```shell
-git pull upstream master
+git pull upstream main
 ```
 
 ### 4. 提交代码并在本地通过单元测试
@@ -176,14 +179,14 @@ MMEngine 会在不同的平台（Linux、Window、Mac），基于不同版本的
 
 ```shell
 git fetch --all --prune
-git rebase upstream/master
+git rebase upstream/main
 ```
 
 或者
 
 ```shell
 git fetch --all --prune
-git merge upstream/master
+git merge upstream/main
 ```
 
 如果你非常善于处理冲突，那么可以使用 rebase 的方式来解决冲突，因为这能够保证你的 commit log 的整洁。如果你不太熟悉 `rebase` 的使用，那么可以使用 `merge` 的方式来解决冲突。

--- a/mmengine/config/utils.py
+++ b/mmengine/config/utils.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import ast
+import importlib
 import os.path as osp
 import re
 import sys
@@ -131,9 +132,15 @@ def _get_package_and_cfg_path(cfg_path: str) -> Tuple[str, str]:
                          'config name, but found multiple `::` in '
                          f'{cfg_path}')
     package, cfg_path = package_cfg
-    assert package in MODULE2PACKAGE, (
-        f'mmengine does not support to load {package} config.')
-    package = MODULE2PACKAGE[package]
+
+    if package in MODULE2PACKAGE:
+        package = MODULE2PACKAGE[package]
+    else:
+        try:
+            importlib.import_module(package)
+        except ModuleNotFoundError:
+            raise ValueError(f'Cannot find package `{package}`')
+    
     return package, cfg_path
 
 

--- a/mmengine/config/utils.py
+++ b/mmengine/config/utils.py
@@ -140,7 +140,7 @@ def _get_package_and_cfg_path(cfg_path: str) -> Tuple[str, str]:
             importlib.import_module(package)
         except ModuleNotFoundError:
             raise ValueError(f'Cannot find package `{package}`')
-    
+
     return package, cfg_path
 
 

--- a/mmengine/utils/package_utils.py
+++ b/mmengine/utils/package_utils.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import os.path as osp
 import subprocess
+
 from importlib_metadata import entry_points
 
 MODULE2PACKAGE = {

--- a/mmengine/utils/package_utils.py
+++ b/mmengine/utils/package_utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import os.path as osp
 import subprocess
-from importlib.metadata import entry_points
+from importlib_metadata import entry_points
 
 MODULE2PACKAGE = {
     'mmcls': 'mmcls',

--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -438,7 +438,7 @@ class WandbVisBackend(BaseVisBackend):
         assert isinstance(self._init_kwargs, dict)
         allow_val_change = self._init_kwargs.get('allow_val_change', False)
         self._wandb.config.update(
-            dict(config), allow_val_change=allow_val_change)
+            config.to_dict(), allow_val_change=allow_val_change)
         self._wandb.run.log_code(name=self._log_code_name)
 
     @force_init_env
@@ -752,7 +752,7 @@ class MLflowVisBackend(BaseVisBackend):
         """
         self.cfg = config
         if self._tracked_config_keys is None:
-            self._mlflow.log_params(self._flatten(self.cfg))
+            self._mlflow.log_params(self._flatten(self.cfg.to_dict()))
         else:
             tracked_cfg = dict()
             for k in self._tracked_config_keys:
@@ -915,7 +915,7 @@ class ClearMLVisBackend(BaseVisBackend):
             config (Config): The Config object
         """
         self.cfg = config
-        self._task.connect_configuration(vars(config))
+        self._task.connect_configuration(config.to_dict())
 
     @force_init_env
     def add_image(self,
@@ -1216,7 +1216,7 @@ class DVCLiveVisBackend(BaseVisBackend):
         """
         assert isinstance(config, Config)
         self.cfg = config
-        self._dvclive.log_params(self._to_dvc_paramlike(self.cfg))
+        self._dvclive.log_params(self._to_dvc_paramlike(self.cfg.to_dict()))
 
     @force_init_env
     def add_image(self,


### PR DESCRIPTION
## Motivation

Fix bugs with inherited configuration files.  #1410 

## Modification

Changed the logic for reading configuration files to work with any python package that conforms to the "MMEngine Installation specification" as described in the documentation.

> Config will parse mmdet:: to find mmdet package and inherits the specified configuration file. Actually, as long as the setup.py of the repository ( package) conforms to MMEngine Installation specification, Config can use {package_name}:: to inherit the specific configuration file.

Modified
``` python
    if package in MODULE2PACKAGE:
        package = MODULE2PACKAGE[package]
    else:
        try:
            importlib.import_module(package)
        except ModuleNotFoundError:
            raise ValueError(f'Cannot find package `{package}`')
```

Original([url](https://github.com/open-mmlab/mmengine/blob/e43bbb5e03a412ea07f9ef6d0f118586082c2845/mmengine/config/utils.py#L134-L136C38))
``` python
    assert package in MODULE2PACKAGE, (
        f'mmengine does not support to load {package} config.')
    package = MODULE2PACKAGE[package]
```

## BC-breaking (Optional)

Not expected. However, it may result in python packages that do not comply with the MMEngine Installation specification being able to be loaded just as well, making the error occur at a much later time, rather than on import.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
