### PR TITLE
[MMSIG] Add resize, padding function to pixeldata

### DIFF
--- a/mmengine/structures/pixel_data.py
+++ b/mmengine/structures/pixel_data.py
@@ -128,7 +128,6 @@ class PixelData(BaseDataElement):
         else:
             return None
 
-    # TODO padding, resize
     def resize(self,
                size: Sequence[int],
                interpolation: str = 'bilinear') -> 'PixelData':

--- a/tests/test_structures/test_pixel_data.py
+++ b/tests/test_structures/test_pixel_data.py
@@ -115,3 +115,52 @@ class TestPixelData(TestCase):
             resized_pixel_data = pixel_data.resize(20)
         with self.assertRaises(AssertionError):
             resized_pixel_data = pixel_data.resize((1, 20, 20))
+
+    def test_padding(self):
+        pixel_data = self.setup_data()
+
+        # left=5, right=10
+        padded_pixel_data = pixel_data.padding((5, 10))
+        assert padded_pixel_data.shape == (20, 55)
+
+        # left=5, right=10, top=15, bottom=20
+        padded_pixel_data = pixel_data.padding((5, 10, 15, 20))
+        assert padded_pixel_data.shape == (55, 55)
+
+        # left=5, right=10, top=15, bottom=20, front=2, back=3
+        padded_pixel_data = pixel_data.padding((5, 10, 15, 20, 2, 3))
+        assert padded_pixel_data.shape == (55, 55)
+        assert padded_pixel_data.image.shape == (9, 55, 55)
+        assert padded_pixel_data.featmap.shape == (15, 55, 55)
+
+        with self.assertRaises(TypeError):
+            padded_pixel_data = pixel_data.padding(5)
+
+        # different mode
+        # reflect support width, height
+        padded_pixel_data = pixel_data.padding((5, 10), mode='reflect')
+        assert padded_pixel_data.shape == (20, 55)
+        padded_pixel_data = pixel_data.padding((5, 10, 2, 4), mode='reflect')
+        assert padded_pixel_data.shape == (26, 55)
+        with self.assertRaises(RuntimeError):
+            padded_pixel_data = pixel_data.padding((5, 10, 2, 4, 6, 8),
+                                                   mode='reflect')
+
+        # replicate support width, height
+        padded_pixel_data = pixel_data.padding((5, 10), mode='replicate')
+        assert padded_pixel_data.shape == (20, 55)
+        padded_pixel_data = pixel_data.padding((5, 10, 2, 4), mode='replicate')
+        assert padded_pixel_data.shape == (26, 55)
+        with self.assertRaises(RuntimeError):
+            padded_pixel_data = pixel_data.padding((5, 10, 2, 4, 6, 8),
+                                                   mode='replicate')
+
+        # circular support width
+        padded_pixel_data = pixel_data.padding((5, 10), mode='circular')
+        assert padded_pixel_data.shape == (20, 55)
+        with self.assertRaises(RuntimeError):
+            padded_pixel_data = pixel_data.padding((5, 10, 2, 4),
+                                                   mode='circular')
+        with self.assertRaises(RuntimeError):
+            padded_pixel_data = pixel_data.padding((5, 10, 2, 4, 6, 8),
+                                                   mode='circular')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

Add resize, padding function to pixeldata.

## Modification

1. Add two function `resize` and `padding` in class `PixelData`.
2. Add two test function `test_resize` and `test_padding` in `tests/test_structures/test_pixel_data.py`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

resize:
```python
metainfo = dict(
  img_id=random.randint(0, 100),
  img_shape=(random.randint(400, 600), random.randint(400, 600)))
image = np.random.randint(0, 255, (4, 20, 40))
featmap = torch.randint(0, 255, (10, 20, 40))
pixel_data = PixelData(metainfo=metainfo, image=image, featmap=featmap)
resized_pixel_data = pixel_data.resize((40, 20), interpolation='bilinear')
print(resized_pixel_data.shape)  # output: (40, 20)
```

padding:
```python
metainfo = dict(
  img_id=random.randint(0, 100),
  img_shape=(random.randint(400, 600), random.randint(400, 600)))
image = np.random.randint(0, 255, (4, 20, 40))
featmap = torch.randint(0, 255, (10, 20, 40))
pixel_data = PixelData(metainfo=metainfo, image=image, featmap=featmap)
padded_pixel_data = pixel_data.padding((5, 10, 2, 4), mode='constant', value=0)
print(padded_pixel_data.shape)  # output: (26, 55)
```

See more in `tests/test_structures/test_pixel_data.py`

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
5. The documentation has been modified accordingly, like docstring or example tutorials.
