### PR TITLE
[Fix] Support `exclude_frozen_parameters` for `DeepSpeedStrategy`'s `resume`

### DIFF
--- a/mmengine/_strategy/deepspeed.py
+++ b/mmengine/_strategy/deepspeed.py
@@ -463,8 +463,15 @@ class DeepSpeedStrategy(BaseStrategy):
         self.logger.info(f'Resume checkpoint from {filename}')
 
         dirname, basename = osp.split(filename)
-        _, extra_ckpt = self.model.load_checkpoint(
-            dirname, tag=basename, load_optimizer_states=resume_optimizer)
+        if digit_version(deepspeed.__version__) >= digit_version('0.10.1'):
+            _, extra_ckpt = self.model.load_checkpoint(
+                dirname,
+                tag=basename,
+                load_optimizer_states=resume_optimizer,
+                load_module_strict=not self.exclude_frozen_parameters)
+        else:
+            _, extra_ckpt = self.model.load_checkpoint(
+                dirname, tag=basename, load_optimizer_states=resume_optimizer)
 
         if resume_optimizer:
             self.load_optim_state_dict(extra_ckpt.pop('optim_wrapper'))


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

Support `exclude_frozen_parameters` for `DeepSpeedStrategy`'s `resume`.
In https://github.com/open-mmlab/mmengine/pull/1415, `exclude_frozen_parameters` has been added to `save_checkpoint` and `load_checkpoint`, while `resume` was overlooked...

## Modification

`mmengine/_strategy/deepspeed.py`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
