### PR TITLE
[Fix] Delete frozen parameters when using `paramwise_cfg`

### DIFF
--- a/mmengine/_strategy/deepspeed.py
+++ b/mmengine/_strategy/deepspeed.py
@@ -383,12 +383,6 @@ class DeepSpeedStrategy(BaseStrategy):
 
         if optim_wrapper is not None:
             self.optim_wrapper = self.build_optim_wrapper(optim_wrapper, model)
-            # Remove param_groups whose all parameters do not requires
-            # gradient, to ensure compatibility with DeepSpeed
-            self.optim_wrapper.optimizer.param_groups = [
-                group for group in self.optim_wrapper.optimizer.param_groups
-                if any(param.requires_grad for param in group['params'])
-            ]
 
             self.model = self._wrap_model(model)
 

--- a/mmengine/_strategy/deepspeed.py
+++ b/mmengine/_strategy/deepspeed.py
@@ -383,7 +383,6 @@ class DeepSpeedStrategy(BaseStrategy):
 
         if optim_wrapper is not None:
             self.optim_wrapper = self.build_optim_wrapper(optim_wrapper, model)
-
             self.model = self._wrap_model(model)
 
             self.optim_wrapper.model = self.model  # type: ignore

--- a/mmengine/_strategy/deepspeed.py
+++ b/mmengine/_strategy/deepspeed.py
@@ -378,6 +378,13 @@ class DeepSpeedStrategy(BaseStrategy):
 
         if optim_wrapper is not None:
             self.optim_wrapper = self.build_optim_wrapper(optim_wrapper, model)
+            # Remove param_groups whose all parameters do not requires
+            # gradient, to ensure compatibility with DeepSpeed
+            self.optim_wrapper.optimizer.param_groups = [
+                group for group in self.optim_wrapper.optimizer.param_groups
+                if any(param.requires_grad for param in group['params'])
+            ]
+
             self.model = self._wrap_model(model)
 
             self.optim_wrapper.model = self.model  # type: ignore

--- a/mmengine/optim/optimizer/default_constructor.py
+++ b/mmengine/optim/optimizer/default_constructor.py
@@ -213,6 +213,10 @@ class DefaultOptimWrapperConstructor:
                     level=logging.WARNING)
                 continue
             if not param.requires_grad:
+                print_log((f'{prefix}.{name} is skipped since its '
+                           f'requires_grad={param.requires_grad}'),
+                          logger='current',
+                          level=logging.WARNING)
                 continue
 
             # if the parameter match one of the custom keys, ignore other rules

--- a/mmengine/optim/optimizer/default_constructor.py
+++ b/mmengine/optim/optimizer/default_constructor.py
@@ -213,7 +213,6 @@ class DefaultOptimWrapperConstructor:
                     level=logging.WARNING)
                 continue
             if not param.requires_grad:
-                params.append(param_group)
                 continue
 
             # if the parameter match one of the custom keys, ignore other rules

--- a/tests/test_optim/test_optimizer/test_optimizer.py
+++ b/tests/test_optim/test_optimizer/test_optimizer.py
@@ -592,12 +592,16 @@ class TestBuilder(TestCase):
             dwconv_decay_mult=0.1,
             dcn_offset_lr_mult=0.1)
 
-        for param in self.model.parameters():
-            param.requires_grad = False
+        self.model.conv1.requires_grad_(False)
         optim_constructor = DefaultOptimWrapperConstructor(
             optim_wrapper_cfg, paramwise_cfg)
-        with self.assertRaises(ValueError):
-            optim_constructor(self.model)
+        optim_wrapper = optim_constructor(self.model)
+
+        all_params = []
+        for pg in optim_wrapper.param_groups:
+            all_params.extend(map(id, pg['params']))
+        self.assertNotIn(id(self.model.conv1.weight), all_params)
+        self.assertIn(id(self.model.conv2.weight), all_params)
 
     def test_default_optimizer_constructor_bypass_duplicate(self):
         # paramwise_cfg with bypass_duplicate option


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

It will cause errors when initializing DeepSpeed optimizer, with
1. Freezing some parameters of the model
2. Setting `paramwise_cfg` for optimizer to set different lr or weight_decay for different parameters

This is because that if setting `paramwise_cfg`, mmengine will treat each parameter (including frozen parameters) as a separate group, and that will lead to an empty list of `trainable_parameters` on the below code.

https://github.com/microsoft/DeepSpeed/blob/2afa1c7f2f961ef18042a88467ff5d3373c22c07/deepspeed/runtime/zero/stage_1_and_2.py#L308-L313

## Modification

`mmengine/_strategy/deepspeed.py`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
5. The documentation has been modified accordingly, like docstring or example tutorials.
