### PR TITLE
[Fix] fix bug in `load_model_state_dict` of `BaseStrategy`

### DIFF
--- a/mmengine/_strategy/base.py
+++ b/mmengine/_strategy/base.py
@@ -799,7 +799,8 @@ class BaseStrategy(metaclass=ABCMeta):
         else:
             model = self.model
 
-        _load_checkpoint_to_model(model, state_dict, strict, revise_keys)
+        _load_checkpoint_to_model(
+            model, state_dict, strict=strict, revise_keys=revise_keys)
 
     def load_optim_state_dict(self, state_dict: dict) -> None:
         """Load optimizer state from dict."""


### PR DESCRIPTION
## Motivation

Fix the bug in the `load_model_state_dict()` function in `BaseStrategy`. The bug is caused by incorrect argument assignments.

Specifically, the variable `revise_keys` in `load_model_state_dict()`:
https://github.com/open-mmlab/mmengine/blob/85c0976bc2434157f786d44cdd8f0fb2955414f0/mmengine/_strategy/base.py#L802
is passed into the `logger` argument in `_load_checkpoint_to_model()`:
https://github.com/open-mmlab/mmengine/blob/85c0976bc2434157f786d44cdd8f0fb2955414f0/mmengine/runner/checkpoint.py#L585-L592


## Modification

Use key-value assignment for `strict` and `revise_keys`.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
