### PR TITLE
Update logger_hook.py

### DIFF
--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -288,9 +288,7 @@ class LoggerHook(Hook):
         tag, log_str = runner.log_processor.get_log_after_epoch(
             runner, len(runner.test_dataloader), 'test', with_non_scalar=True)
         runner.logger.info(log_str)
-        dump(
-            self._process_tags(tag),
-            osp.join(runner.log_dir, self.json_log_path))  # type: ignore
+        runner.visualizer.add_scalars(tag, step=iter, file_path=self.json_log_path)
 
     @staticmethod
     def _process_tags(tags: dict):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

I believe the metrics computed during a test run to evaluate a model are not being logged to the visualizer (i.e.: MLflow). 

## Modification

It consists of simply calling the add_scalars method of the visualizer to log them

## Use cases (Optional)

It would be desirable to visualize the test metrics on MLflow for instance.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
