### PR TITLE
[Fix] Support multi-node distributed training with NPU backend

### DIFF
--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -110,7 +110,8 @@ def _init_dist_pytorch(backend, init_backend='torch', **kwargs) -> None:
             **kwargs)
     elif is_npu_available():
         import torch_npu  # noqa: F401
-        torch.npu.set_device(rank)
+        local_rank = int(os.environ['LOCAL_RANK'])
+        torch.npu.set_device(local_rank)
         torch_dist.init_process_group(
             backend='hccl',
             rank=rank,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

Fix the problem that multi-node distributed training would fail at initial when training with NPU.

## Modification

In mmengine/dist/util.py, we change rank to local rank when initializing process group with NPU.

## BC-breaking (Optional)

None

## Use cases (Optional)

None

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
