### PR TITLE
[Fix] Fix seed resume

### DIFF
--- a/mmengine/_strategy/base.py
+++ b/mmengine/_strategy/base.py
@@ -894,6 +894,15 @@ class BaseStrategy(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def resume_seed(self, filename: str):
+        """Resume seed from given ``filename``.
+
+        Args:
+            filename (str): Accept local filepath, URL, ``torchvision://xxx``,
+                ``open-mmlab://xxx``.
+        """
+
+    @abstractmethod
     def resume(
         self,
         filename: str,

--- a/mmengine/_strategy/deepspeed.py
+++ b/mmengine/_strategy/deepspeed.py
@@ -18,6 +18,7 @@ from mmengine.dist import init_dist
 from mmengine.optim import BaseOptimWrapper, _ParamScheduler
 from mmengine.registry import (MODEL_WRAPPERS, OPTIM_WRAPPERS, OPTIMIZERS,
                                STRATEGIES)
+from mmengine.runner.checkpoint import _load_checkpoint
 from mmengine.utils import apply_to, digit_version, get_git_hash
 from .base import BaseStrategy
 
@@ -416,7 +417,7 @@ class DeepSpeedStrategy(BaseStrategy):
         """Load checkpoint from given ``filename``.
 
         Warning:
-            `map_localtion` and `callback` parameters are not supported yet.
+            `map_location` and `callback` parameters are not supported yet.
 
         Args:
             filename (str): Accept local filepath, URL, ``torchvision://xxx``,
@@ -436,6 +437,30 @@ class DeepSpeedStrategy(BaseStrategy):
                 dirname, tag=basename, load_optimizer_states=False)
 
         return extra_ckpt
+
+    def resume_seed(self, filename: str):
+        """Resume seed from given ``filename``.
+
+        Args:
+            filename (str): Accept local filepath, URL, ``torchvision://xxx``,
+                ``open-mmlab://xxx``.
+        """
+        self.logger.info(f'Resume seed from {filename}')
+
+        from deepspeed.utils.zero_to_fp32 import get_model_state_files
+        filename = get_model_state_files(filename)[0]
+        checkpoint = _load_checkpoint(filename, map_location='cpu')
+
+        resumed_seed = checkpoint['meta'].get('seed', None)
+        current_seed = self._randomness.get('seed')
+        if resumed_seed is not None and resumed_seed != current_seed:
+            if current_seed is not None:
+                self.logger.warning(f'The value of random seed in the '
+                                    f'checkpoint "{resumed_seed}" is '
+                                    f'different from the value in '
+                                    f'`randomness` config "{current_seed}"')
+            self._randomness.update(seed=resumed_seed)
+            self._set_randomness(**self._randomness)
 
     def resume(
         self,
@@ -479,18 +504,6 @@ class DeepSpeedStrategy(BaseStrategy):
         if resume_param_scheduler and hasattr(self, 'param_schedulers'):
             param_schedulers = extra_ckpt.pop('param_schedulers')
             self.load_scheduler_state_dict(param_schedulers)
-
-        # resume random seed
-        resumed_seed = extra_ckpt['meta'].get('seed', None)
-        current_seed = self._randomness.get('seed')
-        if resumed_seed is not None and resumed_seed != current_seed:
-            if current_seed is not None:
-                self.logger.warning(f'The value of random seed in the '
-                                    f'checkpoint "{resumed_seed}" is '
-                                    f'different from the value in '
-                                    f'`randomness` config "{current_seed}"')
-            self._randomness.update(seed=resumed_seed)
-            self._set_randomness(**self._randomness)
 
         return extra_ckpt
 

--- a/mmengine/runner/_flexible_runner.py
+++ b/mmengine/runner/_flexible_runner.py
@@ -405,6 +405,9 @@ class FlexibleRunner:
         self.logger.info(f'Hooks will be executed in the following '
                          f'order:\n{self.get_hooks_info()}')
 
+        # resume seed if needed
+        self.resume_seed()
+
         # dump `cfg` to `work_dir`
         self.dump_config()
 
@@ -1115,6 +1118,24 @@ class FlexibleRunner:
                 info += '\n -------------------- '
                 stage_hook_infos.append(info)
         return '\n'.join(stage_hook_infos)
+
+    def resume_seed(self):
+        """resume seed."""
+
+        # decide to load from checkpoint or resume from checkpoint
+        resume_from = None
+        if isinstance(self._resume, str):
+            resume_from = self._resume
+        elif self._resume and self._load_from is None:
+            # auto resume from the latest checkpoint
+            resume_from = find_latest_checkpoint(self.work_dir)
+            self.logger.info(
+                f'Auto resumed from the latest checkpoint {resume_from}.')
+        elif self._resume and self._load_from is not None:
+            # resume from the specified checkpoint
+            resume_from = self._load_from
+        if resume_from is not None:
+            self.strategy.resume_seed(resume_from)
 
     def load_or_resume(self):
         """load or resume checkpoint."""

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -271,6 +271,12 @@ class IterBasedTrainLoop(BaseLoop):
         # In iteration-based training loop, we treat the whole training process
         # as a big epoch and execute the corresponding hook.
         self.runner.call_hook('before_train_epoch')
+        if self._iter > 0:
+            print_log(
+                f'Advance dataloader {self._iter} steps to skip data '
+                'that has already been trained', 'current')
+            for _ in range(self._iter):
+                next(self.dataloader_iterator)
         while self._iter < self._max_iters and not self.stop_training:
             self.runner.model.train()
 

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -444,6 +444,9 @@ class Runner:
         self.logger.info(f'Hooks will be executed in the following '
                          f'order:\n{self.get_hooks_info()}')
 
+        # resume seed if needed
+        self.resume_seed()
+
         # dump `cfg` to `work_dir`
         self.dump_config()
 
@@ -1994,6 +1997,43 @@ class Runner:
         if custom_hooks is not None:
             self.register_custom_hooks(custom_hooks)
 
+    def _resume_seed(self, filename: str) -> None:
+        """Resume seed from checkpoint.
+
+        Args:
+            filename (str): Accept local filepath, URL, ``torchvision://xxx``,
+                ``open-mmlab://xxx``.
+        """
+
+        checkpoint = _load_checkpoint(filename, map_location='cpu')
+
+        resumed_seed = checkpoint['meta'].get('seed', None)
+        current_seed = self._randomness_cfg.get('seed')
+        if resumed_seed is not None and resumed_seed != current_seed:
+            if current_seed is not None:
+                self.logger.warning(f'The value of random seed in the '
+                                    f'checkpoint "{resumed_seed}" is '
+                                    f'different from the value in '
+                                    f'`randomness` config "{current_seed}"')
+            self._randomness_cfg.update(seed=resumed_seed)
+            self.set_randomness(**self._randomness_cfg)
+
+    def resume_seed(self):
+        """resume seed."""
+
+        # decide to load from checkpoint or resume from checkpoint
+        resume_from = None
+        if self._resume and self._load_from is None:
+            # auto resume from the latest checkpoint
+            resume_from = find_latest_checkpoint(self.work_dir)
+            self.logger.info(f'Seed is auto resumed from the latest '
+                             f'checkpoint {resume_from}.')
+        elif self._resume and self._load_from is not None:
+            # resume from the specified checkpoint
+            resume_from = self._load_from
+        if resume_from is not None:
+            self._resume_seed(resume_from)
+
     def resume(self,
                filename: str,
                resume_optimizer: bool = True,
@@ -2046,18 +2086,6 @@ class Runner:
                         'consistent with resuming from checkpoint but the '
                         'leaning rate will be adjusted according to the '
                         f'setting in auto_scale_lr={self.auto_scale_lr}')
-
-        # resume random seed
-        resumed_seed = checkpoint['meta'].get('seed', None)
-        current_seed = self._randomness_cfg.get('seed')
-        if resumed_seed is not None and resumed_seed != current_seed:
-            if current_seed is not None:
-                self.logger.warning(f'The value of random seed in the '
-                                    f'checkpoint "{resumed_seed}" is '
-                                    f'different from the value in '
-                                    f'`randomness` config "{current_seed}"')
-            self._randomness_cfg.update(seed=resumed_seed)
-            self.set_randomness(**self._randomness_cfg)
 
         resumed_dataset_meta = checkpoint['meta'].get('dataset_meta', None)
         dataset_meta = getattr(self.train_dataloader.dataset, 'metainfo', None)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

1. The resume of seed is too late.

    For example, before the seed resuming, the dataloader and other parts have been constructed. In this situation, the sampler of dataloader uses the old seed, leading to inconsistent for resuming (especially for the iter-based training)

2. IterBasedTrainLoop is not correct for resume

    It always fetches data from the beginning (i.e., 0), instead of `self._iter`

## Modification

Load the resumed checkpoint in the `__init__` of runner, and resume the seed. This modification may seem foolish, but in my option, it is the most compatible way, especially for FlexibleRunner.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
5. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
6. The documentation has been modified accordingly, like docstring or example tutorials.
