### PR TITLE
replace deepcopy with dict copy

### DIFF
--- a/mmengine/structures/base_data_element.py
+++ b/mmengine/structures/base_data_element.py
@@ -228,9 +228,7 @@ class BaseDataElement:
         assert isinstance(
             metainfo,
             dict), f'metainfo should be a ``dict`` but got {type(metainfo)}'
-        print("METAINFO", metainfo)
         meta = metainfo.copy()
-        # meta = copy.deepcopy(metainfo)
         for k, v in meta.items():
             self.set_field(name=k, value=v, field_type='metainfo', dtype=None)
 

--- a/mmengine/structures/base_data_element.py
+++ b/mmengine/structures/base_data_element.py
@@ -229,7 +229,8 @@ class BaseDataElement:
             metainfo,
             dict), f'metainfo should be a ``dict`` but got {type(metainfo)}'
         print("METAINFO", metainfo)
-        meta = copy.deepcopy(metainfo)
+        meta = metainfo.copy()
+        # meta = copy.deepcopy(metainfo)
         for k, v in meta.items():
             self.set_field(name=k, value=v, field_type='metainfo', dtype=None)
 

--- a/mmengine/structures/base_data_element.py
+++ b/mmengine/structures/base_data_element.py
@@ -228,17 +228,8 @@ class BaseDataElement:
         assert isinstance(
             metainfo,
             dict), f'metainfo should be a ``dict`` but got {type(metainfo)}'
-        # meta = copy.deepcopy(metainfo)
-        meta = {}
-        for key, value in metainfo.items():
-            print("VALUE", value)
-            print("TYPE(VALUE)", type(value))
-            if isinstance(value, (torch.Tensor, torch.Size)):
-                print("CLONE")
-                meta[key] = value.clone()
-            else:
-                print("DEEPCOPY")
-                meta[key] = copy.deepcopy(value)
+        print("METAINFO", metainfo)
+        meta = copy.deepcopy(metainfo)
         for k, v in meta.items():
             self.set_field(name=k, value=v, field_type='metainfo', dtype=None)
 

--- a/mmengine/structures/base_data_element.py
+++ b/mmengine/structures/base_data_element.py
@@ -228,7 +228,8 @@ class BaseDataElement:
         assert isinstance(
             metainfo,
             dict), f'metainfo should be a ``dict`` but got {type(metainfo)}'
-        meta = copy.deepcopy(metainfo)
+        # meta = copy.deepcopy(metainfo)
+        meta = metainfo.clone()
         for k, v in meta.items():
             self.set_field(name=k, value=v, field_type='metainfo', dtype=None)
 

--- a/mmengine/structures/base_data_element.py
+++ b/mmengine/structures/base_data_element.py
@@ -229,7 +229,12 @@ class BaseDataElement:
             metainfo,
             dict), f'metainfo should be a ``dict`` but got {type(metainfo)}'
         # meta = copy.deepcopy(metainfo)
-        meta = metainfo.clone()
+        meta = {}
+        for key in metainfo:
+            if isinstance(metainfo[key], torch.Tensor):
+                meta[key] = metainfo[key].clone()
+            else:
+                meta[key] = copy.deepcopy(metainfo[key])
         for k, v in meta.items():
             self.set_field(name=k, value=v, field_type='metainfo', dtype=None)
 

--- a/mmengine/structures/base_data_element.py
+++ b/mmengine/structures/base_data_element.py
@@ -230,11 +230,14 @@ class BaseDataElement:
             dict), f'metainfo should be a ``dict`` but got {type(metainfo)}'
         # meta = copy.deepcopy(metainfo)
         meta = {}
-        for key in list(metainfo.keys()):
-            value = metainfo[key]
+        for key, value in metainfo.items():
+            print("VALUE", value)
+            print("TYPE(VALUE)", type(value))
             if isinstance(value, torch.Tensor):
+                print("CLONE")
                 meta[key] = value.clone()
             else:
+                print("DEEPCOPY")
                 meta[key] = copy.deepcopy(value)
         for k, v in meta.items():
             self.set_field(name=k, value=v, field_type='metainfo', dtype=None)

--- a/mmengine/structures/base_data_element.py
+++ b/mmengine/structures/base_data_element.py
@@ -233,7 +233,7 @@ class BaseDataElement:
         for key, value in metainfo.items():
             print("VALUE", value)
             print("TYPE(VALUE)", type(value))
-            if isinstance(value, torch.Tensor):
+            if isinstance(value, (torch.Tensor, torch.Size)):
                 print("CLONE")
                 meta[key] = value.clone()
             else:

--- a/mmengine/structures/base_data_element.py
+++ b/mmengine/structures/base_data_element.py
@@ -230,11 +230,12 @@ class BaseDataElement:
             dict), f'metainfo should be a ``dict`` but got {type(metainfo)}'
         # meta = copy.deepcopy(metainfo)
         meta = {}
-        for key in metainfo:
-            if isinstance(metainfo[key], torch.Tensor):
-                meta[key] = metainfo[key].clone()
+        for key in list(metainfo.keys()):
+            value = metainfo[key]
+            if isinstance(value, torch.Tensor):
+                meta[key] = value.clone()
             else:
-                meta[key] = copy.deepcopy(metainfo[key])
+                meta[key] = copy.deepcopy(value)
         for k, v in meta.items():
             self.set_field(name=k, value=v, field_type='metainfo', dtype=None)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

This PR is the first in an effort to integrate ONNX Runtime with MMDetection library for object detection and instance segmentation tasks. 

## Modification

The `copy.deepcopy()` function cannot operate on named tensors which is a requirement for ONNX input. Replacing the `copy.deepcopy()` call with dictionary `clone()` allows for named tensors to be copied and therefore traces properly by ONNX exporter.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

- ONNX Runtime integreation with MMDetection library

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
