### PR TITLE
[Fix] Fix warning capture

### DIFF
--- a/tests/test_utils/test_dl_utils/test_torch_ops.py
+++ b/tests/test_utils/test_dl_utils/test_torch_ops.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import pytest
+import warnings
+
 import torch
 
 from mmengine.utils.dl_utils import torch_meshgrid
@@ -7,9 +8,8 @@ from mmengine.utils.dl_utils import torch_meshgrid
 
 def test_torch_meshgrid():
     # torch_meshgrid should not throw warning
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
         x = torch.tensor([1, 2, 3])
         y = torch.tensor([4, 5, 6])
         grid_x, grid_y = torch_meshgrid(x, y)
-
-    assert len(record) == 0

--- a/tests/test_utils/test_dl_utils/test_torch_ops.py
+++ b/tests/test_utils/test_dl_utils/test_torch_ops.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import pytest
+import warnings
+
 import torch
 
 from mmengine.utils.dl_utils import torch_meshgrid
@@ -7,8 +8,8 @@ from mmengine.utils.dl_utils import torch_meshgrid
 
 def test_torch_meshgrid():
     # torch_meshgrid should not throw warning
-    with pytest.warns(UserWarning) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
         x = torch.tensor([1, 2, 3])
         y = torch.tensor([4, 5, 6])
         grid_x, grid_y = torch_meshgrid(x, y)
-    assert len(record) == 0

--- a/tests/test_utils/test_dl_utils/test_torch_ops.py
+++ b/tests/test_utils/test_dl_utils/test_torch_ops.py
@@ -1,6 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import warnings
-
+import pytest
 import torch
 
 from mmengine.utils.dl_utils import torch_meshgrid
@@ -8,8 +7,8 @@ from mmengine.utils.dl_utils import torch_meshgrid
 
 def test_torch_meshgrid():
     # torch_meshgrid should not throw warning
-    with warnings.catch_warnings():
-        warnings.simplefilter('error')
+    with pytest.warns(UserWarning) as record:
         x = torch.tensor([1, 2, 3])
         y = torch.tensor([4, 5, 6])
         grid_x, grid_y = torch_meshgrid(x, y)
+    assert len(record) == 0


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

Due to the upgrade of `pytest`, passing None (`with pytest.warns(None) as record:`) has been deprecated.

## Modification

According to https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
