### PR TITLE
[Feature] Support calculating loss during validation

### DIFF
--- a/mmengine/model/base_model/base_model.py
+++ b/mmengine/model/base_model/base_model.py
@@ -116,7 +116,7 @@ class BaseModel(BaseModule):
         optim_wrapper.update_params(parsed_losses)
         return log_vars
 
-    def val_step(self, data: Union[tuple, dict, list]) -> list:
+    def val_step(self, data: Union[tuple, dict, list]) -> Union[tuple, list]:
         """Gets the predictions of given data.
 
         Calls ``self.data_preprocessor(data, False)`` and
@@ -132,7 +132,7 @@ class BaseModel(BaseModule):
         data = self.data_preprocessor(data, False)
         return self._run_forward(data, mode='predict')  # type: ignore
 
-    def test_step(self, data: Union[dict, tuple, list]) -> list:
+    def test_step(self, data: Union[dict, tuple, list]) -> Union[tuple, list]:
         """``BaseModel`` implements ``test_step`` the same as ``val_step``.
 
         Args:

--- a/mmengine/model/base_model/base_model.py
+++ b/mmengine/model/base_model/base_model.py
@@ -116,7 +116,7 @@ class BaseModel(BaseModule):
         optim_wrapper.update_params(parsed_losses)
         return log_vars
 
-    def val_step(self, data: Union[tuple, dict, list]) -> Union[tuple, list]:
+    def val_step(self, data: Union[tuple, dict, list]) -> list:
         """Gets the predictions of given data.
 
         Calls ``self.data_preprocessor(data, False)`` and
@@ -132,7 +132,7 @@ class BaseModel(BaseModule):
         data = self.data_preprocessor(data, False)
         return self._run_forward(data, mode='predict')  # type: ignore
 
-    def test_step(self, data: Union[dict, tuple, list]) -> Union[tuple, list]:
+    def test_step(self, data: Union[dict, tuple, list]) -> list:
         """``BaseModel`` implements ``test_step`` the same as ``val_step``.
 
         Args:

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -10,7 +10,6 @@ from torch.utils.data import DataLoader
 from mmengine.evaluator import Evaluator
 from mmengine.logging import print_log
 from mmengine.registry import LOOPS
-from mmengine.structures import BaseDataElement
 from mmengine.utils import is_list_of
 from .amp import autocast
 from .base_loop import BaseLoop
@@ -363,7 +362,7 @@ class ValLoop(BaseLoop):
                 logger='current',
                 level=logging.WARNING)
         self.fp16 = fp16
-        self.val_loss = dict()
+        self.val_loss: Dict[str, list] = dict()
 
     def run(self) -> dict:
         """Launch validation."""
@@ -381,7 +380,7 @@ class ValLoop(BaseLoop):
             avg_loss = sum(loss_value) / len(loss_value)
             metrics[loss_name] = avg_loss
             if 'loss' in loss_name:
-                val_loss += avg_loss
+                val_loss += avg_loss  # type: ignore
         metrics['val_loss'] = val_loss
 
         self.runner.call_hook('after_val_epoch', metrics=metrics)
@@ -458,7 +457,7 @@ class TestLoop(BaseLoop):
                 logger='current',
                 level=logging.WARNING)
         self.fp16 = fp16
-        self.test_loss = dict()
+        self.test_loss: Dict[str, list] = dict()
 
     def run(self) -> dict:
         """Launch test."""
@@ -476,7 +475,7 @@ class TestLoop(BaseLoop):
             avg_loss = sum(loss_value) / len(loss_value)
             metrics[loss_name] = avg_loss
             if 'loss' in loss_name:
-                test_loss += avg_loss
+                test_loss += avg_loss  # type: ignore
         metrics['test_loss'] = test_loss
 
         self.runner.call_hook('after_test_epoch', metrics=metrics)

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -382,7 +382,8 @@ class ValLoop(BaseLoop):
             metrics[loss_name] = avg_loss
             if 'loss' in loss_name:
                 val_loss += avg_loss  # type: ignore
-        metrics['val_loss'] = val_loss
+        if val_loss != 0:
+            metrics['val_loss'] = val_loss
 
         self.runner.call_hook('after_val_epoch', metrics=metrics)
         self.runner.call_hook('after_val')
@@ -479,7 +480,8 @@ class TestLoop(BaseLoop):
             metrics[loss_name] = avg_loss
             if 'loss' in loss_name:
                 test_loss += avg_loss  # type: ignore
-        metrics['test_loss'] = test_loss
+        if test_loss != 0:
+            metrics['test_loss'] = test_loss
 
         self.runner.call_hook('after_test_epoch', metrics=metrics)
         self.runner.call_hook('after_test')

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -400,6 +400,7 @@ class ValLoop(BaseLoop):
         # outputs should be sequence of BaseDataElement
         with autocast(enabled=self.fp16):
             results = self.runner.model.test_step(data_batch)
+        outputs, loss = list(), dict()
         if isinstance(results, tuple):
             outputs, loss = results
         elif isinstance(results, list):
@@ -494,6 +495,7 @@ class TestLoop(BaseLoop):
         # predictions should be sequence of BaseDataElement
         with autocast(enabled=self.fp16):
             results = self.runner.model.test_step(data_batch)
+        outputs, loss = list(), dict()
         if isinstance(results, tuple):
             outputs, loss = results
         elif isinstance(results, list):

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -372,20 +372,21 @@ class ValLoop(BaseLoop):
         self.runner.model.eval()
 
         # clear val loss
-        self.val_loss = dict()
+        self.val_loss.clear()
         for idx, data_batch in enumerate(self.dataloader):
             self.run_iter(idx, data_batch)
 
         # compute metrics
         metrics = self.evaluator.evaluate(len(self.dataloader.dataset))
-        # get val loss and save to metrics
-        val_loss = 0
-        for loss_name, loss_value in self.val_loss.items():
-            avg_loss = sum(loss_value) / len(loss_value)
-            metrics[loss_name] = avg_loss
-            if 'loss' in loss_name:
-                val_loss += avg_loss  # type: ignore
-        if len(self.val_loss.keys()) != 0:
+
+        if self.val_loss:
+            # get val loss and save to metrics
+            val_loss = 0
+            for loss_name, loss_value in self.val_loss.items():
+                avg_loss = sum(loss_value) / len(loss_value)
+                metrics[loss_name] = avg_loss
+                if 'loss' in loss_name:
+                    val_loss += avg_loss  # type: ignore
             metrics['val_loss'] = val_loss
 
         self.runner.call_hook('after_val_epoch', metrics=metrics)
@@ -473,20 +474,21 @@ class TestLoop(BaseLoop):
         self.runner.model.eval()
 
         # clear test loss
-        self.test_loss = dict()
+        self.test_loss.clear()
         for idx, data_batch in enumerate(self.dataloader):
             self.run_iter(idx, data_batch)
 
         # compute metrics
         metrics = self.evaluator.evaluate(len(self.dataloader.dataset))
-        # get test loss and save to metrics
-        test_loss = 0
-        for loss_name, loss_value in self.test_loss.items():
-            avg_loss = sum(loss_value) / len(loss_value)
-            metrics[loss_name] = avg_loss
-            if 'loss' in loss_name:
-                test_loss += avg_loss  # type: ignore
-        if len(self.test_loss.keys()) != 0:
+
+        if self.test_loss:
+            # get test loss and save to metricsexit()
+            test_loss = 0
+            for loss_name, loss_value in self.test_loss.items():
+                avg_loss = sum(loss_value) / len(loss_value)
+                metrics[loss_name] = avg_loss
+                if 'loss' in loss_name:
+                    test_loss += avg_loss  # type: ignore
             metrics['test_loss'] = test_loss
 
         self.runner.call_hook('after_test_epoch', metrics=metrics)

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -370,6 +370,9 @@ class ValLoop(BaseLoop):
         self.runner.call_hook('before_val')
         self.runner.call_hook('before_val_epoch')
         self.runner.model.eval()
+
+        # clear val loss
+        self.val_loss = dict()
         for idx, data_batch in enumerate(self.dataloader):
             self.run_iter(idx, data_batch)
 
@@ -382,7 +385,7 @@ class ValLoop(BaseLoop):
             metrics[loss_name] = avg_loss
             if 'loss' in loss_name:
                 val_loss += avg_loss  # type: ignore
-        if val_loss != 0:
+        if len(self.val_loss.keys()) != 0:
             metrics['val_loss'] = val_loss
 
         self.runner.call_hook('after_val_epoch', metrics=metrics)
@@ -468,6 +471,9 @@ class TestLoop(BaseLoop):
         self.runner.call_hook('before_test')
         self.runner.call_hook('before_test_epoch')
         self.runner.model.eval()
+
+        # clear test loss
+        self.test_loss = dict()
         for idx, data_batch in enumerate(self.dataloader):
             self.run_iter(idx, data_batch)
 
@@ -480,7 +486,7 @@ class TestLoop(BaseLoop):
             metrics[loss_name] = avg_loss
             if 'loss' in loss_name:
                 test_loss += avg_loss  # type: ignore
-        if test_loss != 0:
+        if len(self.test_loss.keys()) != 0:
             metrics['test_loss'] = test_loss
 
         self.runner.call_hook('after_test_epoch', metrics=metrics)

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -482,7 +482,7 @@ class TestLoop(BaseLoop):
         metrics = self.evaluator.evaluate(len(self.dataloader.dataset))
 
         if self.test_loss:
-            # get test loss and save to metricsexit()
+            # get test loss and save to metrics
             test_loss = 0
             for loss_name, loss_value in self.test_loss.items():
                 avg_loss = sum(loss_value) / len(loss_value)

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -402,7 +402,7 @@ class ValLoop(BaseLoop):
         with autocast(enabled=self.fp16):
             outputs = self.runner.model.val_step(data_batch)
         if isinstance(outputs[-1],
-                      BaseDataElement) and outputs.keys() == ['loss']:
+                      BaseDataElement) and outputs[-1].keys() == ['loss']:
             loss = outputs[-1].loss  # type: ignore
             outputs = outputs[:-1]
         else:
@@ -498,7 +498,7 @@ class TestLoop(BaseLoop):
         with autocast(enabled=self.fp16):
             outputs = self.runner.model.test_step(data_batch)
         if isinstance(outputs[-1],
-                      BaseDataElement) and outputs.keys() == ['loss']:
+                      BaseDataElement) and outputs[-1].keys() == ['loss']:
             loss = outputs[-1].loss  # type: ignore
             outputs = outputs[:-1]
         else:

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -504,7 +504,7 @@ def _parse_losses(losses: Dict[str, HistoryBuffer],
 
     Returns:
         dict[str, float]: The key is the loss name, and the value is the
-            average loss.
+        average loss.
     """
     all_loss = 0
     loss_dict: Dict[str, float] = dict()

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -8,7 +8,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from mmengine.evaluator import Evaluator
-from mmengine.logging import HistoryBuffer, print_log
+from mmengine.logging import print_log
 from mmengine.registry import LOOPS
 from mmengine.structures import BaseDataElement
 from mmengine.utils import is_list_of
@@ -363,7 +363,7 @@ class ValLoop(BaseLoop):
                 logger='current',
                 level=logging.WARNING)
         self.fp16 = fp16
-        self.val_loss: Dict[str, HistoryBuffer] = dict()
+        self.val_loss: Dict[str, list] = dict()
 
     def run(self) -> dict:
         """Launch validation."""
@@ -378,7 +378,7 @@ class ValLoop(BaseLoop):
         # get val loss and save to metrics
         val_loss = 0
         for loss_name, loss_value in self.val_loss.items():
-            avg_loss = loss_value.mean()
+            avg_loss = sum(loss_value) / len(loss_value)
             metrics[loss_name] = avg_loss
             if 'loss' in loss_name:
                 val_loss += avg_loss  # type: ignore
@@ -408,19 +408,13 @@ class ValLoop(BaseLoop):
         else:
             loss = dict()
         # get val loss and avoid breaking change
-        # similar to MessageHub
         for loss_name, loss_value in loss.items():
             if loss_name not in self.val_loss:
-                self.val_loss[loss_name] = HistoryBuffer()
+                self.val_loss[loss_name] = []
             if isinstance(loss_value, torch.Tensor):
-                loss_value = loss_value.mean().item()
+                self.val_loss[loss_name].append(loss_value.item())
             elif is_list_of(loss_value, torch.Tensor):
-                loss_value = sum([v.mean()
-                                  for v in loss_value]).item()  # type: ignore
-            else:
-                raise TypeError(
-                    f'{loss_name} is not a tensor or list of tensors')
-            self.val_loss[loss_name].update(loss_value)
+                self.val_loss[loss_name].extend([v.item() for v in loss_value])
 
         self.evaluator.process(data_samples=outputs, data_batch=data_batch)
         self.runner.call_hook(
@@ -466,7 +460,7 @@ class TestLoop(BaseLoop):
                 logger='current',
                 level=logging.WARNING)
         self.fp16 = fp16
-        self.test_loss: Dict[str, HistoryBuffer] = dict()
+        self.test_loss: Dict[str, list] = dict()
 
     def run(self) -> dict:
         """Launch test."""
@@ -481,7 +475,7 @@ class TestLoop(BaseLoop):
         # get test loss and save to metrics
         test_loss = 0
         for loss_name, loss_value in self.test_loss.items():
-            avg_loss = loss_value.mean()
+            avg_loss = sum(loss_value) / len(loss_value)
             metrics[loss_name] = avg_loss
             if 'loss' in loss_name:
                 test_loss += avg_loss  # type: ignore
@@ -510,19 +504,14 @@ class TestLoop(BaseLoop):
         else:
             loss = dict()
         # get val loss and avoid breaking change
-        # similar to MessageHub
         for loss_name, loss_value in loss.items():
             if loss_name not in self.test_loss:
-                self.test_loss[loss_name] = HistoryBuffer()
+                self.test_loss[loss_name] = []
             if isinstance(loss_value, torch.Tensor):
-                loss_value = loss_value.mean().item()
+                self.test_loss[loss_name].append(loss_value.item())
             elif is_list_of(loss_value, torch.Tensor):
-                loss_value = sum([v.mean()
-                                  for v in loss_value]).item()  # type: ignore
-            else:
-                raise TypeError(
-                    f'{loss_name} is not a tensor or list of tensors')
-            self.test_loss[loss_name].update(loss_value)
+                self.test_loss[loss_name].extend(
+                    [v.item() for v in loss_value])
 
         self.evaluator.process(data_samples=outputs, data_batch=data_batch)
         self.runner.call_hook(

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -400,7 +400,7 @@ class ValLoop(BaseLoop):
             'before_val_iter', batch_idx=idx, data_batch=data_batch)
         # outputs should be sequence of BaseDataElement
         with autocast(enabled=self.fp16):
-            outputs = self.runner.model.test_step(data_batch)
+            outputs = self.runner.model.val_step(data_batch)
         if isinstance(outputs[-1],
                       BaseDataElement) and outputs.keys() == ['loss']:
             loss = outputs[-1].loss  # type: ignore


### PR DESCRIPTION
# Background

Since early stopping requires validation loss as a possible metric, mmengine currently does not support calculating and parsing validation loss as a metric.

However, due to the inconsistency of model implementations and the fact that calculating validation loss is not a common requirement, the process of calculating validation loss should not be initiated by mmengine, but rather, initiated by the model and returned by mmengine with a convention to be parsed and returned as a metric. 

Thus this PR aims to implement this return-and-resolve convention without introducing breaking change.

# Design

In order not to introduce breaking change, we chose to return the loss computed by the model at `val_step` (`model.forward` with `mode='predict'` or `predict`) wrapped by `BaseDataElement` and append after the val step result.

Therefore, mmengine needs to get the last item of the result of `val_step` in `ValLoop` and determine whether it is validation loss or not. If it is validation loss, it will perform the relevant computation and return it at the end of the `ValLoop`, and then compute other metrics based on the items other than the validation  loss, e.g., the accuracy, etc. If it is not a val loss, it will not be processed.

# Adaptation

## Custom Model

Take https://github.com/open-mmlab/mmengine/blob/02f80e8bdd38f6713e04a872304861b02157905a/examples/distributed_training.py#L14-#L25 as an example. 

```diff
class MMResNet50(BaseModel):

    def __init__(self):
        super().__init__()
        self.resnet = torchvision.models.resnet50()

    def forward(self, imgs, labels, mode):
        x = self.resnet(imgs)
        if mode == 'loss':
            return {'loss': F.cross_entropy(x, labels)}
        elif mode == 'predict':
-          return x, labels
+          val_loss = {'loss': F.cross_entropy(x, labels)}
+          return x, labels, BaseDataElement(loss=val_loss)
```

## [MMPreTrain](https://github.com/open-mmlab/mmpretrain)

Take https://github.com/open-mmlab/mmpretrain/blob/17a886cb5825cd8c26df4e65f7112d404b99fe12/mmpretrain/models/classifiers/image.py#L248-L249 as an example.

```diff
    def predict(self,
                inputs: torch.Tensor,
                data_samples: Optional[List[DataSample]] = None,
                **kwargs) -> List[DataSample]:
        """Predict results from a batch of inputs.

        Args:
            inputs (torch.Tensor): The input tensor with shape
                (N, C, ...) in general.
            data_samples (List[DataSample], optional): The annotation
                data of every samples. Defaults to None.
            **kwargs: Other keyword arguments accepted by the ``predict``
                method of :attr:`head`.
        """
        feats = self.extract_feat(inputs)
-       return self.head.predict(feats, data_samples, **kwargs)
+       preds = self.head.predict(feats, data_samples, **kwargs)
+       loss = self.head.loss(feats, data_samples)
+       loss_sample = DataSample(loss=loss)
+       preds.append(loss_sample)
+       return preds
```

## [MMPose](https://github.com/open-mmlab/mmpose)

### Calculating loss in this way maybe not correct.

Take https://github.com/open-mmlab/mmpose/blob/5a3be9451bdfdad2053a90dc1199e3ff1ea1a409/mmpose/models/pose_estimators/topdown.py#L99-#L120 as an example.

```diff
    def predict(self, inputs: Tensor, data_samples: SampleList) -> SampleList:
        """Predict results from a batch of inputs and data samples with post-
        processing.

        Args:
            inputs (Tensor): Inputs with shape (N, C, H, W)
            data_samples (List[:obj:`PoseDataSample`]): The batch
                data samples

        Returns:
            list[:obj:`PoseDataSample`]: The pose estimation results of the
            input images. The return value is `PoseDataSample` instances with
            ``pred_instances`` and ``pred_fields``(optional) field , and
            ``pred_instances`` usually contains the following keys:

                - keypoints (Tensor): predicted keypoint coordinates in shape
                    (num_instances, K, D) where K is the keypoint number and D
                    is the keypoint dimension
                - keypoint_scores (Tensor): predicted keypoint scores in shape
                    (num_instances, K)
        """
        assert self.with_head, (
            'The model must have head to perform prediction.')

        if self.test_cfg.get('flip_test', False):
            _feats = self.extract_feat(inputs)
            _feats_flip = self.extract_feat(inputs.flip(-1))
            feats = [_feats, _feats_flip]
+           loss = self.head.loss(_feats, data_samples, train_cfg=self.train_cfg)
        else:
            feats = self.extract_feat(inputs)
+           loss = self.head.loss(feats, data_samples, train_cfg=self.train_cfg)

        preds = self.head.predict(feats, data_samples, test_cfg=self.test_cfg)

        if isinstance(preds, tuple):
            batch_pred_instances, batch_pred_fields = preds
        else:
            batch_pred_instances = preds
            batch_pred_fields = None

        results = self.add_pred_to_datasample(batch_pred_instances,
                                              batch_pred_fields, data_samples)
+       results.append(loss_sample)
        return results
```

In addition, you should add `dict(type='GenerateTarget', encoder=codec)` to `val_pipeline` similar to `train_pipeline`.