### PR TITLE
[Fix] SLURM distributed training in containers where `scontrol` is not available

### DIFF
--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -199,7 +199,7 @@ def _slurm_extract_first_node(slurm_nodelist):
     return first_node_name
 
 
-def is_scontrol_available():
+def _is_scontrol_available():
     try:
         subprocess.run(["scontrol", "-h"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
         return True
@@ -232,7 +232,7 @@ def _init_dist_slurm(backend,
     else:
         num_gpus = torch.cuda.device_count()
         local_rank = proc_id % num_gpus
-    if (is_scontrol_available()):
+    if (_is_scontrol_available()):
         addr = subprocess.getoutput(
             f'scontrol show hostname {node_list} | head -n1')
     else:


### PR DESCRIPTION

## Motivation

Distributed training with SLURM does not work if you run it in a containerized environment such as docker, enroot or apptainer/singularity on a HPC.

by checking if  `scontrol` is available and retreiving the master adress without it if necessary, training with SLURM is now possible on the HPC of research center juelich in germany (https://apps.fz-juelich.de/jsc/hps/juwels/booster-overview.html) within a containerized environment. This should generalize to all systems where containers do not have `scontrol` available. 

Additionally this PR fixes these issues:

https://github.com/open-mmlab/mmcv/pull/1970
https://github.com/open-mmlab/mmcv/issues/700

## Modification

two functions are added to `mmengine/dist/utils.py`:

`_slurm_extract_first_node(slurm_nodelist):` replaces scontrol to set the `addr` of the the master node if needed. this is checked via this function:
`_is_scontrol_available()`



## BC-breaking (Optional)

no breaking changes are introduced.

## Use cases (Optional)

HPC Training within containerized environments.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.

:heavy_check_mark: 
