### PR TITLE
[fix] Handle case ClearML already been initialized

### DIFF
--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -905,7 +905,9 @@ class ClearMLVisBackend(BaseVisBackend):
 
         task_kwargs = self._init_kwargs or {}
         self._clearml = clearml
-        self._task = self._clearml.Task.init(**task_kwargs)
+        self._task = self._clearml.Task.current_task()
+        if self._task is None:
+            self._task = self._clearml.Task.init(**task_kwargs)
         self._logger = self._task.get_logger()
 
     @property  # type: ignore


### PR DESCRIPTION
Handle case where ClearML already been initialized ealier by the user.

## Modification

Check if clearml already been initialized and not try to re-initialize again as ClearML don't allow that. 

## Use cases

In some use case, user may want to initialized ClearML to track logs prior to running the Runner. Eg: logging all the prep steps.

