### PR TITLE
[Fix] Speed up "--resume"

### DIFF
--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -297,7 +297,7 @@ class IterBasedTrainLoop(BaseLoop):
                 'that has already been trained',
                 logger='current',
                 level=logging.WARNING)
-            self.dataloader_iterator.skip_iter(self.iter)
+            self.dataloader_iterator.skip_iter(self._iter)
         while self._iter < self._max_iters and not self.stop_training:
             self.runner.model.train()
 

--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -297,8 +297,7 @@ class IterBasedTrainLoop(BaseLoop):
                 'that has already been trained',
                 logger='current',
                 level=logging.WARNING)
-            for _ in range(self._iter):
-                next(self.dataloader_iterator)
+            self.dataloader_iterator.skip_iter(self.iter)
         while self._iter < self._max_iters and not self.stop_training:
             self.runner.model.train()
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

In the current version, "--resume" will make engine loading data like regular training, but discard all of this data before reaching the specified iteration. Therefore, the time required for resuming will not be much faster than starting a new training session.

## Modification

Added a new method called `skip_iter` , which skips data without triggering data loading by calling the `_next_index` in the built-in iterator of DataLoader

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
