### PR TITLE
fix import torchvision when check_env

### DIFF
--- a/mmengine/utils/dl_utils/collect_env.py
+++ b/mmengine/utils/dl_utils/collect_env.py
@@ -157,6 +157,8 @@ def collect_env():
         env_info['TorchVision'] = torchvision.__version__
     except ModuleNotFoundError:
         pass
+    except RuntimeError:
+        pass
 
     try:
         import cv2


### PR DESCRIPTION
## Motivation

LMDeploy depends on mmengine
https://github.com/InternLM/lmdeploy/blob/a06174f836882d853d4eb18519c2245c2a7eae8c/requirements/runtime.txt#L17

When I want to check_env for LMDeploy
```bash
python3 -m lmdeploy check_env
```
I met this error
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.9/site-packages/lmdeploy/__main__.py", line 5, in <module>
    run()
  File "/usr/local/lib/python3.9/site-packages/lmdeploy/cli/entrypoint.py", line 37, in run
    args.run(args)
  File "/usr/local/lib/python3.9/site-packages/lmdeploy/cli/cli.py", line 195, in check_env
    env_info = collect_env()
  File "/usr/local/lib/python3.9/site-packages/mmengine/utils/dl_utils/collect_env.py", line 156, in collect_env
    import torchvision
  File "/usr/local/lib/python3.9/site-packages/torchvision/__init__.py", line 6, in <module>
    from torchvision import _meta_registrations, datasets, io, models, ops, transforms, utils
  File "/usr/local/lib/python3.9/site-packages/torchvision/_meta_registrations.py", line 164, in <module>
    def meta_nms(dets, scores, iou_threshold):
  File "/usr/local/lib/python3.9/site-packages/torch/library.py", line 467, in inner
    handle = entry.abstract_impl.register(func_to_register, source)
  File "/usr/local/lib/python3.9/site-packages/torch/_library/abstract_impl.py", line 30, in register
    if torch._C._dispatch_has_kernel_for_dispatch_key(self.qualname, "Meta"):
RuntimeError: operator torchvision::nms does not exist
```

For me, I only use LMDeploy for LLM inference and not for VLM inference, so `torchvision` is not needed. It is lazily import in LMDeploy. Therefore, when I check the environment, I don't care about the version of `torchvision`. I also don't want any issues with `torchvision` to cause my environment check to fail, so I have also handled RuntimeError exceptions.

May you help review this pr? Thanks. @fanqiNO1 @LZHgrla @zhouzaida cc @lvhan028 

## Modification

as titled

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
