### PR TITLE
[Fix] add Config hyperparameters for clearml backend

### DIFF
--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -922,7 +922,7 @@ class ClearMLVisBackend(BaseVisBackend):
             config (Config): The Config object
         """
         self.cfg = config
-        self._task.connect_configuration(config.to_dict())
+        self._task.set_parameters_as_dict(config.to_dict())
 
     @force_init_env
     def add_image(self,


### PR DESCRIPTION

## Motivation

This PR allows to have better logging of hyperparameters when using ClearML backend.

## Modification

Currently, the clearml viz backend `add_cfg()` function calls `Task.connect_configuration())`.
As stated [in the clearml documentation](https://clear.ml/docs/latest/docs/fundamentals/hyperparameters/#connecting-configuration-objects) this will save the cfg file as a blog. This is useful for logging purposes but not much use beyond that.

By saving it with `Task.set_parameters_as_dict()` instead, clearml will be aware of the internal structure of the config dictionary and the hyperparameters in it can be used for visualization and evaluation (i.e. we can [compare experiments with respect to their hyperparameters](https://clear.ml/docs/latest/docs/webapp/webapp_exp_comparing/))

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
