### PR TITLE
Programadorartificial/allow torch half models

### DIFF
--- a/mmengine/infer/infer.py
+++ b/mmengine/infer/infer.py
@@ -484,6 +484,9 @@ class BaseInferencer(metaclass=InferencerMeta):
         model.cfg = cfg
         self._load_weights_to_model(model, checkpoint, cfg)
         model.to(device)
+        if 'cuda' in device and checkpoint is not None and checkpoint.get(
+                'meta', {}).get('float16', False):
+            model.half()
         model.eval()
         return model
 

--- a/mmengine/runner/_flexible_runner.py
+++ b/mmengine/runner/_flexible_runner.py
@@ -1571,6 +1571,7 @@ class FlexibleRunner:
         elif not isinstance(meta, dict):
             raise TypeError(
                 f'meta should be a dict or None, but got {type(meta)}')
+        meta['float16'] = False
 
         if by_epoch:
             # self.epoch increments 1 after

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -2184,6 +2184,7 @@ class Runner:
         elif not isinstance(meta, dict):
             raise TypeError(
                 f'meta should be a dict or None, but got {type(meta)}')
+        meta['float16'] = False
 
         if by_epoch:
             # self.epoch increments 1 after

--- a/mmengine/utils/package_utils.py
+++ b/mmengine/utils/package_utils.py
@@ -69,11 +69,12 @@ def get_installed_path(package: str) -> str:
         else:
             raise e
 
-    possible_path = osp.join(pkg.location, package)
+    location = '' if pkg.location is None else pkg.location
+    possible_path = osp.join(location, package)
     if osp.exists(possible_path):
         return possible_path
     else:
-        return osp.join(pkg.location, package2module(package))
+        return osp.join(location, package2module(package))
 
 
 def package2module(package: str):


### PR DESCRIPTION
## Motivation

Running the model in float16 takes up less memory, less disk space and runs faster. So, I added an option to publish the model and run inference as float16.

## Modification

Added new information within the model to indicate, whether it was saved as float16, to load as well.
When loading the model, check if it is in CUDA and was saved as float16, if positive, load as float16, otherwise load normally.

Also fixed a bug when running pre-commit -> Argument 1 to "join" has incompatible type "Optional[str]"; expected "Union[str, _PathLike[str]]"


## BC-breaking (Optional)

-

## Use cases (Optional)

This PR was created and tested using pose estimators (MMPose) and a PR was created there too: https://github.com/open-mmlab/mmpose/pull/3130
PS: The code works even if one of the libraries (MMPose or MMEngine) is not updated with the new suggested changes.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues. **OK**
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness. **OK**
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain. **OK**
4. The documentation has been modified accordingly, like docstring or example tutorials. **OK**
