### PR TITLE
Update metric.py，support multi-server training with Ascend 910B

### DIFF
--- a/mmengine/evaluator/metric.py
+++ b/mmengine/evaluator/metric.py
@@ -5,12 +5,17 @@ from typing import Any, List, Optional, Sequence, Union
 
 from torch import Tensor
 
+import torch
+import torch_npu
+from torch_npu.contrib import transfer_to_npu
+
 from mmengine.dist import (broadcast_object_list, collect_results,
                            is_main_process)
 from mmengine.fileio import dump
 from mmengine.logging import print_log
 from mmengine.registry import METRICS
 from mmengine.structures import BaseDataElement
+from mmengine.device import is_npu_available
 
 
 class BaseMetric(metaclass=ABCMeta):
@@ -49,7 +54,10 @@ class BaseMetric(metaclass=ABCMeta):
                              "`collect_device='cpu'`")
 
         self._dataset_meta: Union[None, dict] = None
-        self.collect_device = collect_device
+        if is_npu_available():
+            self.collect_device = 'gpu'
+        else:
+            self.collect_device = collect_device
         self.results: List[Any] = []
         self.prefix = prefix or self.default_prefix
         self.collect_dir = collect_dir


### PR DESCRIPTION
Currently，when use more than two Ascned servers to run training, it would generate an error: "FileNotFoundError: [Errno 2] No such file or directory: '.dist_test/tmpjajv4wn5/part_8.pkl'". For this errir is because default training use collect_device=cpu, and it need tmpxxxxx.pkl files to sync training weights, and set collect_device to npu if is_npu_available is true，then training weights will sync by hccl，do not need to carete .dist_test directory and tmp pkl files.

Launch mutil-server training cmd:

export NNODES=2 NODE_RANK=0 PORT=29500 MASTER_ADDR="10.1.1.1" ; setsid /bin/bash tools/dist_train.sh configs/rtmdet/rtmdet_s_8xb32-300e_coco.py 8

export NNODES=2 NODE_RANK=1 PORT=29500 MASTER_ADDR="10.1.1.1" ; setsid /bin/bash tools/dist_train.sh configs/rtmdet/rtmdet_s_8xb32-300e_coco.py 8

NODE_RANK=0 is Master server, NNODES=2 means two servers training

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
