### PR TITLE
[Bug] Fix a MLflow vis backend bug when the config key is not `str`

### DIFF
--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -836,11 +836,11 @@ class MLflowVisBackend(BaseVisBackend):
 
         self._mlflow.end_run()
 
-    def _flatten(self, d, parent_key='', sep='.') -> dict:
+    def _flatten(self, d: Config, parent_key='', sep='.') -> dict:
         """Flatten the dict."""
         items = dict()
         for k, v in d.items():
-            new_key = parent_key + sep + k if parent_key else k
+            new_key = sep.join([parent_key, str(k)]) if parent_key else str(k)
             if isinstance(v, MutableMapping):
                 items.update(self._flatten(v, new_key, sep=sep))
             elif isinstance(v, list):


### PR DESCRIPTION
## Motivation

As title, when `Config` key object contains something other than `str`, this code would failed, a config example is in the RTMO in `mmpose`:
```PYTHON
        epoch_attributes={
            280: {
                "proxy_target_cc": True,
                "overlaps_power": 1.0,
                "loss_cls.loss_weight": 2.0,
                "loss_mle.loss_weight": 5.0,
                "loss_oks.loss_weight": 10.0,
            }
        },
```

## Modification

Fix this by converting it to `str` first

## Use cases (Optional)

This PR only works when using `MLflowVisBackend` in a config file like:
```PYTHON
vis_backends = [
    dict(type='MLflowVisBackend', save_dir='xxx', tracking_uri='http://xxx:xxx'),
    ...
]
```
