### PR TITLE
fix Adafactor optim on torch2.5 and fix compatibility

### DIFF
--- a/mmengine/optim/optimizer/builder.py
+++ b/mmengine/optim/optimizer/builder.py
@@ -25,7 +25,11 @@ def register_torch_optimizers() -> List[str]:
         _optim = getattr(torch.optim, module_name)
         if inspect.isclass(_optim) and issubclass(_optim,
                                                   torch.optim.Optimizer):
-            OPTIMIZERS.register_module(module=_optim)
+            if module_name == 'Adafactor':
+                OPTIMIZERS.register_module(
+                    name='torch_Adafactor', module=_optim)
+            else:
+                OPTIMIZERS.register_module(module=_optim)
             torch_optimizers.append(module_name)
     return torch_optimizers
 

--- a/mmengine/registry/build_functions.py
+++ b/mmengine/registry/build_functions.py
@@ -3,8 +3,10 @@ import inspect
 import logging
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+import torch
+
 from mmengine.config import Config, ConfigDict
-from mmengine.utils import ManagerMixin
+from mmengine.utils import ManagerMixin, digit_version
 from .registry import Registry
 
 if TYPE_CHECKING:
@@ -230,6 +232,18 @@ def build_model_from_cfg(
         return Sequential(*modules)
     else:
         return build_from_cfg(cfg, registry, default_args)
+
+
+def build_optimizer_from_cfg(
+        cfg: Union[dict, ConfigDict, Config],
+        registry: Registry,
+        default_args: Optional[Union[dict, ConfigDict, Config]] = None) -> Any:
+    if 'Adafactor' == cfg['type'] and digit_version(
+            torch.__version__) >= digit_version('2.5.0'):
+        from ..logging import print_log
+        print_log(
+            'the torch version of Adafactor is registered as torch_Adafactor')
+    return build_from_cfg(cfg, registry, default_args)
 
 
 def build_scheduler_from_cfg(

--- a/mmengine/registry/root.py
+++ b/mmengine/registry/root.py
@@ -6,8 +6,8 @@ More datails can be found at
 https://mmengine.readthedocs.io/en/latest/advanced_tutorials/registry.html.
 """
 
-from .build_functions import (build_model_from_cfg, build_runner_from_cfg,
-                              build_scheduler_from_cfg)
+from .build_functions import (build_model_from_cfg, build_optimizer_from_cfg,
+                              build_runner_from_cfg, build_scheduler_from_cfg)
 from .registry import Registry
 
 # manage all kinds of runners like `EpochBasedRunner` and `IterBasedRunner`
@@ -35,7 +35,7 @@ MODEL_WRAPPERS = Registry('model_wrapper')
 WEIGHT_INITIALIZERS = Registry('weight initializer')
 
 # mangage all kinds of optimizers like `SGD` and `Adam`
-OPTIMIZERS = Registry('optimizer')
+OPTIMIZERS = Registry('optimizer', build_func=build_optimizer_from_cfg)
 # manage optimizer wrapper
 OPTIM_WRAPPERS = Registry('optim_wrapper')
 # manage constructors that customize the optimization hyperparameters.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

The Adafactor optimizer in PyTorch 2.5 is not working correctly.

## Modification

Added hardcode to rename PyTorch's Adafactor optimizer to torch_Adafactor and added a warning for users using Adafactor.
## BC-breaking (Optional)

Compatible with PyTorch and versions below 2.4.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
