### PR TITLE
[Fix] Fix IterBased Loop Training with Faster Resume

### DIFF
--- a/mmengine/runner/loops.py
+++ b/mmengine/runner/loops.py
@@ -3,6 +3,7 @@ import bisect
 import logging
 import time
 from typing import Dict, List, Optional, Sequence, Tuple, Union
+from itertools import islice
 
 import torch
 from torch.utils.data import DataLoader
@@ -280,8 +281,8 @@ class IterBasedTrainLoop(BaseLoop):
                 'that has already been trained',
                 logger='current',
                 level=logging.WARNING)
-            for _ in range(self._iter):
-                next(self.dataloader_iterator)
+            islice(self.dataloader_iterator, 0, self._iter)
+
         while self._iter < self._max_iters and not self.stop_training:
             self.runner.model.train()
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

Previous, [PR#1471](https://github.com/open-mmlab/mmengine/pull/1471) resolves the issue of IterBased loop resuming at the correct iteration. However, its approach requires processing through data loading and preprocessing, which significantly slows down the resume process. This PR introduces a more efficient solution that minimizes overhead while maintaining correctness. Compared to solutions proposed in [PR#1548](https://github.com/open-mmlab/mmengine/pull/1548) and [PR#1520](https://github.com/open-mmlab/mmengine/pull/1520), this solution achieves faster resume with fewer code changes.

## Modification

This solution leverages itertools.islice to skip iterations in the dataloader without actually triggering the data loading and preprocessing steps, significantly improving the speed of the resume process.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
