### PR TITLE
[BugFix]:  KeyError: 'Adafactor is already registered in optimizer at…

### DIFF
--- a/mmengine/optim/optimizer/builder.py
+++ b/mmengine/optim/optimizer/builder.py
@@ -170,7 +170,7 @@ def register_transformers_optimizers():
     except ImportError:
         pass
     else:
-        OPTIMIZERS.register_module(name='Adafactor', module=Adafactor)
+        OPTIMIZERS.register_module(name='Adafactor', module=Adafactor, force=True) # Same optimizer is introduced in PyTorch but transformers had it prior and forcing transformers one to keepup with backward compatibility.
         transformer_optimizers.append('Adafactor')
     return transformer_optimizers
 


### PR DESCRIPTION
… torch.optim'

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

For solving bug : 
![image](https://github.com/user-attachments/assets/3160a830-c371-43ec-a624-f262610d1aa9)


## Modification

While optimizers are registered, we force to update the optimizer from transformers library because this was the one used prior to same optimizer was introduced by PyTorch

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
Choice was made to force Adafactor from transformers to be used. Hence changes are backward-compatible.

## Use cases (Optional)

NA

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
