### PR TITLE
add weights_only argument for torch load to support new version of torch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
     rev: 5.11.5
     hooks:
       - id: isort
-  - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.32.0
+  - repo: https://github.com/google/yapf
+    rev: v0.43.0
     hooks:
       - id: yapf
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/mmengine/runner/checkpoint.py
+++ b/mmengine/runner/checkpoint.py
@@ -344,7 +344,8 @@ def load_from_local(filename, map_location):
     filename = osp.expanduser(filename)
     if not osp.isfile(filename):
         raise FileNotFoundError(f'{filename} can not be found.')
-    checkpoint = torch.load(filename, map_location=map_location)
+    checkpoint = torch.load(
+        filename, map_location=map_location, weights_only=False)
     return checkpoint
 
 
@@ -412,7 +413,8 @@ def load_from_pavi(filename, map_location=None):
     with TemporaryDirectory() as tmp_dir:
         downloaded_file = osp.join(tmp_dir, model.name)
         model.download(downloaded_file)
-        checkpoint = torch.load(downloaded_file, map_location=map_location)
+        checkpoint = torch.load(
+            downloaded_file, map_location=map_location, weights_only=False)
     return checkpoint
 
 
@@ -435,7 +437,8 @@ def load_from_ceph(filename, map_location=None, backend='petrel'):
     file_backend = get_file_backend(
         filename, backend_args={'backend': backend})
     with io.BytesIO(file_backend.get(filename)) as buffer:
-        checkpoint = torch.load(buffer, map_location=map_location)
+        checkpoint = torch.load(
+            buffer, map_location=map_location, weights_only=False)
     return checkpoint
 
 
@@ -504,7 +507,8 @@ def load_from_openmmlab(filename, map_location=None):
         filename = osp.join(_get_mmengine_home(), model_url)
         if not osp.isfile(filename):
             raise FileNotFoundError(f'{filename} can not be found.')
-        checkpoint = torch.load(filename, map_location=map_location)
+        checkpoint = torch.load(
+            filename, map_location=map_location, weights_only=False)
     return checkpoint
 
 
@@ -597,9 +601,10 @@ def _load_checkpoint_to_model(model,
     # strip prefix of state_dict
     metadata = getattr(state_dict, '_metadata', OrderedDict())
     for p, r in revise_keys:
-        state_dict = OrderedDict(
-            {re.sub(p, r, k): v
-             for k, v in state_dict.items()})
+        state_dict = OrderedDict({
+            re.sub(p, r, k): v
+            for k, v in state_dict.items()
+        })
     # Keep metadata in state_dict
     state_dict._metadata = metadata
 

--- a/mmengine/utils/dl_utils/hub.py
+++ b/mmengine/utils/dl_utils/hub.py
@@ -48,7 +48,8 @@ if TORCH_VERSION != 'parrots' and digit_version(TORCH_VERSION) < digit_version(
             f.extractall(model_dir)
             extraced_name = members[0].filename
             extracted_file = os.path.join(model_dir, extraced_name)
-        return torch.load(extracted_file, map_location=map_location)
+        return torch.load(
+            extracted_file, map_location=map_location, weights_only=False)
 
     def load_url(url,
                  model_dir=None,
@@ -114,7 +115,8 @@ if TORCH_VERSION != 'parrots' and digit_version(TORCH_VERSION) < digit_version(
             return _legacy_zip_load(cached_file, model_dir, map_location)
 
         try:
-            return torch.load(cached_file, map_location=map_location)
+            return torch.load(
+                cached_file, map_location=map_location, weights_only=False)
         except RuntimeError as error:
             if digit_version(TORCH_VERSION) < digit_version('1.5.0'):
                 warnings.warn(

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -458,13 +458,17 @@ class TestCheckpointHook(RunnerTestCase):
         cfg = copy.deepcopy(common_cfg)
         runner = self.build_runner(cfg)
         runner.train()
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
+        ckpt = torch.load(
+            osp.join(cfg.work_dir, f'{training_type}_11.pth'),
+            weights_only=False)
         self.assertIn('optimizer', ckpt)
 
         cfg.default_hooks.checkpoint.save_optimizer = False
         runner = self.build_runner(cfg)
         runner.train()
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
+        ckpt = torch.load(
+            osp.join(cfg.work_dir, f'{training_type}_11.pth'),
+            weights_only=False)
         self.assertNotIn('optimizer', ckpt)
 
         # Test save_param_scheduler=False
@@ -479,13 +483,17 @@ class TestCheckpointHook(RunnerTestCase):
         ]
         runner = self.build_runner(cfg)
         runner.train()
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
+        ckpt = torch.load(
+            osp.join(cfg.work_dir, f'{training_type}_11.pth'),
+            weights_only=False)
         self.assertIn('param_schedulers', ckpt)
 
         cfg.default_hooks.checkpoint.save_param_scheduler = False
         runner = self.build_runner(cfg)
         runner.train()
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
+        ckpt = torch.load(
+            osp.join(cfg.work_dir, f'{training_type}_11.pth'),
+            weights_only=False)
         self.assertNotIn('param_schedulers', ckpt)
 
         self.clear_work_dir()
@@ -533,7 +541,9 @@ class TestCheckpointHook(RunnerTestCase):
             self.assertFalse(
                 osp.isfile(osp.join(cfg.work_dir, f'{training_type}_{i}.pth')))
 
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
+        ckpt = torch.load(
+            osp.join(cfg.work_dir, f'{training_type}_11.pth'),
+            weights_only=False)
         self.assertEqual(ckpt['message_hub']['runtime_info']['keep_ckpt_ids'],
                          [9, 10, 11])
 
@@ -574,9 +584,11 @@ class TestCheckpointHook(RunnerTestCase):
         runner.train()
         best_ckpt_path = osp.join(cfg.work_dir,
                                   f'best_test_acc_{training_type}_5.pth')
-        best_ckpt = torch.load(best_ckpt_path)
+        best_ckpt = torch.load(best_ckpt_path, weights_only=False)
 
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_5.pth'))
+        ckpt = torch.load(
+            osp.join(cfg.work_dir, f'{training_type}_5.pth'),
+            weights_only=False)
         self.assertEqual(best_ckpt_path,
                          ckpt['message_hub']['runtime_info']['best_ckpt'])
 
@@ -603,11 +615,13 @@ class TestCheckpointHook(RunnerTestCase):
         runner.train()
         best_ckpt_path = osp.join(cfg.work_dir,
                                   f'best_test_acc_{training_type}_5.pth')
-        best_ckpt = torch.load(best_ckpt_path)
+        best_ckpt = torch.load(best_ckpt_path, weights_only=False)
 
         # if the current ckpt is the best, the interval will be ignored the
         # the ckpt will also be saved
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_5.pth'))
+        ckpt = torch.load(
+            osp.join(cfg.work_dir, f'{training_type}_5.pth'),
+            weights_only=False)
         self.assertEqual(best_ckpt_path,
                          ckpt['message_hub']['runtime_info']['best_ckpt'])
 

--- a/tests/test_hooks/test_ema_hook.py
+++ b/tests/test_hooks/test_ema_hook.py
@@ -230,7 +230,8 @@ class TestEMAHook(RunnerTestCase):
         self.assertTrue(
             isinstance(ema_hook.ema_model, ExponentialMovingAverage))
 
-        checkpoint = torch.load(osp.join(self.temp_dir.name, 'epoch_2.pth'))
+        checkpoint = torch.load(
+            osp.join(self.temp_dir.name, 'epoch_2.pth'), weights_only=False)
         self.assertTrue('ema_state_dict' in checkpoint)
         self.assertTrue(checkpoint['ema_state_dict']['steps'] == 8)
 
@@ -245,7 +246,8 @@ class TestEMAHook(RunnerTestCase):
         runner.test()
 
         # Test load checkpoint without ema_state_dict
-        checkpoint = torch.load(osp.join(self.temp_dir.name, 'epoch_2.pth'))
+        checkpoint = torch.load(
+            osp.join(self.temp_dir.name, 'epoch_2.pth'), weights_only=False)
         checkpoint.pop('ema_state_dict')
         torch.save(checkpoint,
                    osp.join(self.temp_dir.name, 'without_ema_state_dict.pth'))
@@ -274,7 +276,9 @@ class TestEMAHook(RunnerTestCase):
         runner = self.build_runner(cfg)
         runner.train()
         state_dict = torch.load(
-            osp.join(self.temp_dir.name, 'epoch_4.pth'), map_location='cpu')
+            osp.join(self.temp_dir.name, 'epoch_4.pth'),
+            map_location='cpu',
+            weights_only=False)
         self.assertIn('ema_state_dict', state_dict)
         for k, v in state_dict['state_dict'].items():
             assert_allclose(v, state_dict['ema_state_dict']['module.' + k])
@@ -287,12 +291,16 @@ class TestEMAHook(RunnerTestCase):
         runner = self.build_runner(cfg)
         runner.train()
         state_dict = torch.load(
-            osp.join(self.temp_dir.name, 'iter_4.pth'), map_location='cpu')
+            osp.join(self.temp_dir.name, 'iter_4.pth'),
+            map_location='cpu',
+            weights_only=False)
         self.assertIn('ema_state_dict', state_dict)
         for k, v in state_dict['state_dict'].items():
             assert_allclose(v, state_dict['ema_state_dict']['module.' + k])
         state_dict = torch.load(
-            osp.join(self.temp_dir.name, 'iter_5.pth'), map_location='cpu')
+            osp.join(self.temp_dir.name, 'iter_5.pth'),
+            map_location='cpu',
+            weights_only=False)
         self.assertIn('ema_state_dict', state_dict)
 
     def _test_swap_parameters(self, func_name, *args, **kwargs):

--- a/tests/test_optim/test_scheduler/test_param_scheduler.py
+++ b/tests/test_optim/test_scheduler/test_param_scheduler.py
@@ -685,7 +685,8 @@ class TestParameterScheduler(TestCase):
         scheduler_copy = construct2()
         torch.save(scheduler.state_dict(),
                    osp.join(self.temp_dir.name, 'tmp.pth'))
-        state_dict = torch.load(osp.join(self.temp_dir.name, 'tmp.pth'))
+        state_dict = torch.load(
+            osp.join(self.temp_dir.name, 'tmp.pth'), weights_only=False)
         scheduler_copy.load_state_dict(state_dict)
         for key in scheduler.__dict__.keys():
             if key != 'optimizer':

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -2272,7 +2272,7 @@ class TestRunner(TestCase):
         self.assertTrue(osp.exists(path))
         self.assertFalse(osp.exists(osp.join(self.temp_dir, 'epoch_4.pth')))
 
-        ckpt = torch.load(path)
+        ckpt = torch.load(path, weights_only=False)
         self.assertEqual(ckpt['meta']['epoch'], 3)
         self.assertEqual(ckpt['meta']['iter'], 12)
         self.assertEqual(ckpt['meta']['experiment_name'],
@@ -2444,7 +2444,7 @@ class TestRunner(TestCase):
         self.assertTrue(osp.exists(path))
         self.assertFalse(osp.exists(osp.join(self.temp_dir, 'epoch_13.pth')))
 
-        ckpt = torch.load(path)
+        ckpt = torch.load(path, weights_only=False)
         self.assertEqual(ckpt['meta']['epoch'], 0)
         self.assertEqual(ckpt['meta']['iter'], 12)
         assert isinstance(ckpt['optimizer'], dict)
@@ -2455,7 +2455,7 @@ class TestRunner(TestCase):
         self.assertEqual(message_hub.get_info('iter'), 11)
         # 2.1.2 check class attribute _statistic_methods can be saved
         HistoryBuffer._statistics_methods.clear()
-        ckpt = torch.load(path)
+        ckpt = torch.load(path, weights_only=False)
         self.assertIn('min', HistoryBuffer._statistics_methods)
 
         # 2.2 test `load_checkpoint`


### PR DESCRIPTION
## Motivation

torch.load start raise error in newer version if not specify weights_only=False, where the default behavior is True.

## Modification
- Update yapf using newer version to avoid `lib2to3` not support issue after python3.10 ref: https://github.com/google/yapf/issues/993
- Add weights_only=False to all torch.load calling in the codebase

## Checklist

- [X] Pre-commit or other linting tools are used to fix the potential lint issues.
- [X]  The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ]  If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
- [ ]  The documentation has been modified accordingly, like docstring or example tutorials.
