### PR TITLE
Add distributed training log filtering for master rank

### DIFF
--- a/mmengine/runner/checkpoint.py
+++ b/mmengine/runner/checkpoint.py
@@ -19,7 +19,7 @@ from mmengine.fileio import load as load_file
 from mmengine.logging import print_log
 from mmengine.model import BaseTTAModel, is_model_wrapper
 from mmengine.utils import (apply_to, deprecated_function, digit_version,
-                            mkdir_or_exist)
+                            mkdir_or_exist,)
 from mmengine.utils.dl_utils import load_url
 
 # `MMENGINE_HOME` is the highest priority directory to save checkpoints
@@ -810,6 +810,6 @@ def find_latest_checkpoint(path: str) -> Optional[str]:
         with open(save_file) as f:
             last_saved = f.read().strip()
     else:
-        print_log('Did not find last_checkpoint to be resumed.')
+        print_log('Did not find last_checkpoint to be resumed.', logger='current')
         last_saved = None
     return last_saved


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

During training, print_log function will log more than one time duplicate information, which will make the output stream looks confused. I want to print/log only once in the terminal output stream.

## Modification

1. Add a new FilterMasterRank for MMLoger.
2. Adjust find_latest_checkpoint to print_log only once.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
5. The documentation has been modified accordingly, like docstring or example tutorials.
