### PR TITLE
Removed config formatting and env logging (slow)

### DIFF
--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -397,7 +397,7 @@ class Config:
         cfg_text: Optional[str] = None,
         filename: Optional[Union[str, Path]] = None,
         env_variables: Optional[dict] = None,
-        format_python_code: bool = True,
+        format_python_code: bool = False
     ):
         filename = str(filename) if isinstance(filename, Path) else filename
         if cfg_dict is None:

--- a/mmengine/runner/runner.py
+++ b/mmengine/runner/runner.py
@@ -400,7 +400,7 @@ class Runner:
         self.logger = self.build_logger(log_level=log_level)
 
         # Collect and log environment information.
-        self._log_env(env_cfg)
+        # self._log_env(env_cfg)
 
         # Build `message_hub` for communication among components.
         # `message_hub` can store log scalars (loss, learning rate) and


### PR DESCRIPTION
## Motivation

Logging is really slow, especially while loading and preparing experiments, and saving checkpoints

## Modification

I profiled the `train.py` scripts using `py-spy`.

I then just commented out the lines that slow down the code as a proof of concept. The user should have the ability to alter these lines with config options.


