### PR TITLE
[Fix] explicitly disable weights_only in torch.load to fix tests 

### DIFF
--- a/mmengine/runner/checkpoint.py
+++ b/mmengine/runner/checkpoint.py
@@ -344,7 +344,7 @@ def load_from_local(filename, map_location):
     filename = osp.expanduser(filename)
     if not osp.isfile(filename):
         raise FileNotFoundError(f'{filename} can not be found.')
-    checkpoint = torch.load(filename, map_location=map_location)
+    checkpoint = torch.load(filename, map_location=map_location, weights_only = False)
     return checkpoint
 
 
@@ -412,7 +412,7 @@ def load_from_pavi(filename, map_location=None):
     with TemporaryDirectory() as tmp_dir:
         downloaded_file = osp.join(tmp_dir, model.name)
         model.download(downloaded_file)
-        checkpoint = torch.load(downloaded_file, map_location=map_location)
+        checkpoint = torch.load(downloaded_file, map_location=map_location, weights_only = False)
     return checkpoint
 
 
@@ -435,7 +435,7 @@ def load_from_ceph(filename, map_location=None, backend='petrel'):
     file_backend = get_file_backend(
         filename, backend_args={'backend': backend})
     with io.BytesIO(file_backend.get(filename)) as buffer:
-        checkpoint = torch.load(buffer, map_location=map_location)
+        checkpoint = torch.load(buffer, map_location=map_location, weights_only = False)
     return checkpoint
 
 
@@ -504,7 +504,7 @@ def load_from_openmmlab(filename, map_location=None):
         filename = osp.join(_get_mmengine_home(), model_url)
         if not osp.isfile(filename):
             raise FileNotFoundError(f'{filename} can not be found.')
-        checkpoint = torch.load(filename, map_location=map_location)
+        checkpoint = torch.load(filename, map_location=map_location, weights_only = False)
     return checkpoint
 
 

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -458,13 +458,13 @@ class TestCheckpointHook(RunnerTestCase):
         cfg = copy.deepcopy(common_cfg)
         runner = self.build_runner(cfg)
         runner.train()
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
+        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'), weights_only=False)
         self.assertIn('optimizer', ckpt)
 
         cfg.default_hooks.checkpoint.save_optimizer = False
         runner = self.build_runner(cfg)
         runner.train()
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
+        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'), weights_only=False)
         self.assertNotIn('optimizer', ckpt)
 
         # Test save_param_scheduler=False
@@ -479,13 +479,13 @@ class TestCheckpointHook(RunnerTestCase):
         ]
         runner = self.build_runner(cfg)
         runner.train()
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
+        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'), weights_only=False)
         self.assertIn('param_schedulers', ckpt)
 
         cfg.default_hooks.checkpoint.save_param_scheduler = False
         runner = self.build_runner(cfg)
         runner.train()
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
+        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'), weights_only=False)
         self.assertNotIn('param_schedulers', ckpt)
 
         self.clear_work_dir()
@@ -533,7 +533,7 @@ class TestCheckpointHook(RunnerTestCase):
             self.assertFalse(
                 osp.isfile(osp.join(cfg.work_dir, f'{training_type}_{i}.pth')))
 
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'))
+        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_11.pth'), weights_only=False)
         self.assertEqual(ckpt['message_hub']['runtime_info']['keep_ckpt_ids'],
                          [9, 10, 11])
 
@@ -574,9 +574,9 @@ class TestCheckpointHook(RunnerTestCase):
         runner.train()
         best_ckpt_path = osp.join(cfg.work_dir,
                                   f'best_test_acc_{training_type}_5.pth')
-        best_ckpt = torch.load(best_ckpt_path)
+        best_ckpt = torch.load(best_ckpt_path, weights_only=False)
 
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_5.pth'))
+        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_5.pth'), weights_only=False)
         self.assertEqual(best_ckpt_path,
                          ckpt['message_hub']['runtime_info']['best_ckpt'])
 
@@ -603,11 +603,11 @@ class TestCheckpointHook(RunnerTestCase):
         runner.train()
         best_ckpt_path = osp.join(cfg.work_dir,
                                   f'best_test_acc_{training_type}_5.pth')
-        best_ckpt = torch.load(best_ckpt_path)
+        best_ckpt = torch.load(best_ckpt_path, weights_only=False)
 
         # if the current ckpt is the best, the interval will be ignored the
         # the ckpt will also be saved
-        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_5.pth'))
+        ckpt = torch.load(osp.join(cfg.work_dir, f'{training_type}_5.pth'), weights_only=False)
         self.assertEqual(best_ckpt_path,
                          ckpt['message_hub']['runtime_info']['best_ckpt'])
 

--- a/tests/test_hooks/test_ema_hook.py
+++ b/tests/test_hooks/test_ema_hook.py
@@ -230,7 +230,7 @@ class TestEMAHook(RunnerTestCase):
         self.assertTrue(
             isinstance(ema_hook.ema_model, ExponentialMovingAverage))
 
-        checkpoint = torch.load(osp.join(self.temp_dir.name, 'epoch_2.pth'))
+        checkpoint = torch.load(osp.join(self.temp_dir.name, 'epoch_2.pth'), weights_only = False)
         self.assertTrue('ema_state_dict' in checkpoint)
         self.assertTrue(checkpoint['ema_state_dict']['steps'] == 8)
 
@@ -245,7 +245,7 @@ class TestEMAHook(RunnerTestCase):
         runner.test()
 
         # Test load checkpoint without ema_state_dict
-        checkpoint = torch.load(osp.join(self.temp_dir.name, 'epoch_2.pth'))
+        checkpoint = torch.load(osp.join(self.temp_dir.name, 'epoch_2.pth'), weights_only = False)
         checkpoint.pop('ema_state_dict')
         torch.save(checkpoint,
                    osp.join(self.temp_dir.name, 'without_ema_state_dict.pth'))
@@ -274,7 +274,7 @@ class TestEMAHook(RunnerTestCase):
         runner = self.build_runner(cfg)
         runner.train()
         state_dict = torch.load(
-            osp.join(self.temp_dir.name, 'epoch_4.pth'), map_location='cpu')
+            osp.join(self.temp_dir.name, 'epoch_4.pth'), map_location='cpu', weights_only = False)
         self.assertIn('ema_state_dict', state_dict)
         for k, v in state_dict['state_dict'].items():
             assert_allclose(v, state_dict['ema_state_dict']['module.' + k])
@@ -287,12 +287,12 @@ class TestEMAHook(RunnerTestCase):
         runner = self.build_runner(cfg)
         runner.train()
         state_dict = torch.load(
-            osp.join(self.temp_dir.name, 'iter_4.pth'), map_location='cpu')
+            osp.join(self.temp_dir.name, 'iter_4.pth'), map_location='cpu', weights_only = False)
         self.assertIn('ema_state_dict', state_dict)
         for k, v in state_dict['state_dict'].items():
             assert_allclose(v, state_dict['ema_state_dict']['module.' + k])
         state_dict = torch.load(
-            osp.join(self.temp_dir.name, 'iter_5.pth'), map_location='cpu')
+            osp.join(self.temp_dir.name, 'iter_5.pth'), map_location='cpu', weights_only = False)
         self.assertIn('ema_state_dict', state_dict)
 
     def _test_swap_parameters(self, func_name, *args, **kwargs):

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -2272,7 +2272,7 @@ class TestRunner(TestCase):
         self.assertTrue(osp.exists(path))
         self.assertFalse(osp.exists(osp.join(self.temp_dir, 'epoch_4.pth')))
 
-        ckpt = torch.load(path)
+        ckpt = torch.load(path, weights_only = False)
         self.assertEqual(ckpt['meta']['epoch'], 3)
         self.assertEqual(ckpt['meta']['iter'], 12)
         self.assertEqual(ckpt['meta']['experiment_name'],
@@ -2444,7 +2444,7 @@ class TestRunner(TestCase):
         self.assertTrue(osp.exists(path))
         self.assertFalse(osp.exists(osp.join(self.temp_dir, 'epoch_13.pth')))
 
-        ckpt = torch.load(path)
+        ckpt = torch.load(path, weights_only = False)
         self.assertEqual(ckpt['meta']['epoch'], 0)
         self.assertEqual(ckpt['meta']['iter'], 12)
         assert isinstance(ckpt['optimizer'], dict)
@@ -2455,7 +2455,7 @@ class TestRunner(TestCase):
         self.assertEqual(message_hub.get_info('iter'), 11)
         # 2.1.2 check class attribute _statistic_methods can be saved
         HistoryBuffer._statistics_methods.clear()
-        ckpt = torch.load(path)
+        ckpt = torch.load(path, weights_only = False)
         self.assertIn('min', HistoryBuffer._statistics_methods)
 
         # 2.2 test `load_checkpoint`


### PR DESCRIPTION
## Motivation

Since [pytorch v2.6.0](https://github.com/pytorch/pytorch/releases/tag/v2.6.0), the `weights_only` parameter of `torch.load` defaults to `True`.
This causes some failures in the `mmengine` test suite:
```
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint.
    (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
    (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
    WeightsUnpickler error: Unsupported global: GLOBAL mmengine.logging.history_buffer.HistoryBuffer was not an allowed global by default. Please use `torch.serialization.add_safe_globals([HistoryBuffer])` or the `torch.serialization.safe_globals([HistoryBuffer])` context manager to allowlist this global if you trust this class/function.

Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
```

We now need to explicitly disable `weights_only` when calling `torch.load`.


## Modification

Add `weights_only=False` to `torch.load` calls where needed.

## BC-breaking (Optional)

No.

## Use cases (Optional)

No.
