### PR TITLE
fix: make mlflow logging more stable

### DIFF
--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -781,7 +781,11 @@ class MLflowVisBackend(BaseVisBackend):
                 should be RGB.
             step (int): Global step value to record. Default to 0.
         """
-        self._mlflow.log_image(image, name)
+        try:
+            self._mlflow.log_image(image, name)
+        except self._mlflow.MlflowException as e:
+            msg = f'Could not log image {name} to mlflow, {e}'
+            print_log(msg, level=logging.WARNING)
 
     @force_init_env
     def add_scalar(self,
@@ -796,7 +800,11 @@ class MLflowVisBackend(BaseVisBackend):
             value (int, float, torch.Tensor, np.ndarray): Value to save.
             step (int): Global step value to record. Default to 0.
         """
-        self._mlflow.log_metric(name, value, step)
+        try:
+            self._mlflow.log_metric(name, value, step)
+        except self._mlflow.MlflowException as e:
+            msg = f'Could not log metric {name} to mlflow, {e}'
+            print_log(msg, level=logging.WARNING)
 
     @force_init_env
     def add_scalars(self,
@@ -816,7 +824,11 @@ class MLflowVisBackend(BaseVisBackend):
         assert isinstance(scalar_dict, dict)
         assert 'step' not in scalar_dict, 'Please set it directly ' \
                                           'through the step parameter'
-        self._mlflow.log_metrics(scalar_dict, step)
+        try:
+            self._mlflow.log_metrics(scalar_dict, step)
+        except self._mlflow.MlflowException as e:
+            msg = f'Could not log metrics to mlflow, {e}'
+            print_log(msg, level=logging.WARNING)
 
     def close(self) -> None:
         """Close the mlflow."""

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -5,4 +5,5 @@ pyyaml
 regex;sys_platform=='win32'
 rich
 termcolor
+torch<2.6.0
 yapf


### PR DESCRIPTION

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

Prevent training to error out on MLFlow logging exception. Instead of crashing, simply skip the log and continue training.

## Modification

Try/catch around mlflow logging statements.

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
