### PR TITLE
[Enhance] Move `import yapf` to function

### DIFF
--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -17,11 +17,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Optional, Sequence, Tuple, Union
 
-import yapf
 from addict import Dict
 from rich.console import Console
 from rich.text import Text
-from yapf.yapflib.yapf_api import FormatCode
 
 from mmengine.fileio import dump, load
 from mmengine.logging import print_log
@@ -1375,6 +1373,8 @@ class Config:
     @property
     def pretty_text(self) -> str:
         """Get formatted python config text."""
+        import yapf
+        from yapf.yapflib.yapf_api import FormatCode
 
         indent = 4
 


### PR DESCRIPTION
`import yapf` could raise unexpected error like this:

![image](https://github.com/user-attachments/assets/1e29886c-bee6-4db6-9708-1977bf2c9b88)

Just move the import logic in function to avoid this error if config is not used

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
