### PR TITLE
[Fix] support cfg overwrite by classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,4 +63,4 @@ repos:
               ^examples
               | ^docs
           )
-        additional_dependencies: ["types-setuptools", "types-requests", "types-PyYAML"]
+        additional_dependencies: ["setuptools", "types-setuptools", "types-requests", "types-PyYAML"]

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -2,6 +2,7 @@
 import ast
 import copy
 import difflib
+import inspect
 import os
 import os.path as osp
 import platform
@@ -53,6 +54,11 @@ def _lazy2string(cfg_dict, dict_type=None):
         return type(cfg_dict)(_lazy2string(v, dict_type) for v in cfg_dict)
     elif isinstance(cfg_dict, (LazyAttr, LazyObject)):
         return f'{cfg_dict.module}.{str(cfg_dict)}'
+    elif (inspect.isclass(cfg_dict) and hasattr(cfg_dict, '__module__')
+          and hasattr(cfg_dict, '__name__')
+          and cfg_dict.__module__ != 'builtins'):
+        # Handle regular class objects by converting to module path string
+        return f'{cfg_dict.__module__}.{cfg_dict.__name__}'
     else:
         return cfg_dict
 

--- a/mmengine/config/config.py
+++ b/mmengine/config/config.py
@@ -54,11 +54,12 @@ def _lazy2string(cfg_dict, dict_type=None):
         return type(cfg_dict)(_lazy2string(v, dict_type) for v in cfg_dict)
     elif isinstance(cfg_dict, (LazyAttr, LazyObject)):
         return f'{cfg_dict.module}.{str(cfg_dict)}'
-    elif (inspect.isclass(cfg_dict) and hasattr(cfg_dict, '__module__')
+    elif ((inspect.isclass(cfg_dict) or inspect.isfunction(cfg_dict))
+          and hasattr(cfg_dict, '__module__')
           and hasattr(cfg_dict, '__name__')
           and cfg_dict.__module__ != 'builtins'):
         # Handle regular class objects by converting to module path string
-        return f'{cfg_dict.__module__}.{cfg_dict.__name__}'
+        return f"{cfg_dict.__module__}.{cfg_dict.__name__}"
     else:
         return cfg_dict
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

The following code will raise an error because the overwritten model type can not be `pretty_text`. 
```
from models import ABCModel

cfg = Config.fromfile(config)
cfg.model.type = ABCModel

runner = Runner.from_cfg(cfg)
```



## Modification


So I changed the `_lazy2string` function to allow converting classes and functions to import path.


## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

NO

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
