### PR TITLE
[Fix] editable install in `python>=3.13`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,10 @@ def choose_requirement(primary, secondary):
 
 
 def get_version():
+    version_dict = {}
     with open(version_file) as f:
-        exec(compile(f.read(), version_file, 'exec'))
-    return locals()['__version__']
+        exec(compile(f.read(), version_file, 'exec'), version_dict)
+    return version_dict['__version__']
 
 
 def parse_requirements(fname='requirements/runtime.txt', with_version=True):


### PR DESCRIPTION
This is a sub-PR of #1665.

This PR fixes a compatibility issue in `get_version()` caused by relying on `exec()` to modify the local namespace.

The current implementation executes a version file with `exec(...)` and then attempts to retrieve `__version__` from `locals()`. While this may appear to work in `Python ≤3.12`, it breaks in `Python 3.13+` due to changes introduced by [PEP 667](https://peps.python.org/pep-0667/), which standardizes execution context behavior and prevents `exec()` from mutating a function’s local scope.

To ensure correctness and forward compatibility, this PR explicitly passes a dedicated dictionary as the global namespace to `exec()`, and safely reads `__version__` from that namespace.

Noted that `setup.py` is deprecated and we should include `pyproject.toml` according to the latest [PyPA](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/), and [PEP 621](https://peps.python.org/pep-0621/).