### PR TITLE
[Fix] Correctly process `compile.disable` in config

### DIFF
--- a/mmengine/_strategy/base.py
+++ b/mmengine/_strategy/base.py
@@ -322,8 +322,8 @@ class BaseStrategy(metaclass=ABCMeta):
         Returns:
             nn.Module: Compiled model.
         """
-        if isinstance(compile, bool) and not compile or \
-           isinstance(compile, dict) and not compile.get('disable', False):
+        if (isinstance(compile, bool) and not compile) or \
+           (isinstance(compile, dict) and compile.get('disable', False)):
             return model
 
         assert digit_version(TORCH_VERSION) >= digit_version('2.0.0'), (


### PR DESCRIPTION
This is a sub-PR of #1665 

## Motivation

The `torch.compile` receives a lot args. And in mmengine, all contents in `compile` from any config file will be transferred to `torch.compile`.
The mmengine checks several dependencies when user specifies `compile` in their config file, and making `hasattr(config, compile)` as the flag of enabling `torch.compile`.
However this is not exact. The compile config can include an arg `disable` to state if the compiler is actually working. So the mmengine needs to carefully determine if the user is actually enabling the `torch.compile`. This caused a small modification in `mmengine/_strategy/base.py`

## Modification

When user specified `compile` with a dict type, the `compile_model` func will check if `disable` is set to `True`, and can directly return the model just like `compile` is set to `None`