### PR TITLE
[Fix] Deprecate `torch.cuda.amp` API

### DIFF
--- a/mmengine/optim/optimizer/amp_optimizer_wrapper.py
+++ b/mmengine/optim/optimizer/amp_optimizer_wrapper.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from contextlib import contextmanager
+from functools import partial
 from typing import Union
 
 import torch
@@ -17,7 +18,8 @@ if is_npu_available():
 elif is_mlu_available():
     from torch.mlu.amp import GradScaler
 else:
-    from torch.cuda.amp import GradScaler
+    from torch.amp import GradScaler as amp_GradScaler
+    GradScaler = partial(amp_GradScaler, device='cuda')
 
 
 @OPTIM_WRAPPERS.register_module()

--- a/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
+++ b/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
@@ -426,13 +426,13 @@ class TestAmpOptimWrapper(TestCase):
     def test_init(self):
         # Test with default arguments.
         amp_optim_wrapper = AmpOptimWrapper(optimizer=self.optimizer)
-        self.assertIsInstance(amp_optim_wrapper.loss_scaler, GradScaler)
+        self.assertIsInstance(amp_optim_wrapper.loss_scaler, amp_GradScaler)
 
         # Test with dynamic.
         amp_optim_wrapper = AmpOptimWrapper(
             'dynamic', optimizer=self.optimizer)
         self.assertIsNone(amp_optim_wrapper._scale_update_param)
-        self.assertIsInstance(amp_optim_wrapper.loss_scaler, GradScaler)
+        self.assertIsInstance(amp_optim_wrapper.loss_scaler, amp_GradScaler)
 
         # Test with dtype float16
         amp_optim_wrapper = AmpOptimWrapper(
@@ -447,7 +447,7 @@ class TestAmpOptimWrapper(TestCase):
         # Test with dict loss_scale.
         amp_optim_wrapper = AmpOptimWrapper(
             dict(init_scale=1, growth_factor=2), optimizer=self.optimizer)
-        self.assertIsInstance(amp_optim_wrapper.loss_scaler, GradScaler)
+        self.assertIsInstance(amp_optim_wrapper.loss_scaler, amp_GradScaler)
         self.assertIsNone(amp_optim_wrapper._scale_update_param)
         with self.assertRaisesRegex(TypeError,
                                     'loss_scale must be of type float'):

--- a/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
+++ b/tests/test_optim/test_optimizer/test_optimizer_wrapper.py
@@ -1,5 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import os
+from functools import partial
+
 import unittest
 from unittest import TestCase
 from unittest.mock import MagicMock
@@ -8,7 +10,8 @@ import torch
 import torch.distributed as torch_dist
 import torch.nn as nn
 from parameterized import parameterized
-from torch.cuda.amp import GradScaler
+from torch.amp import GradScaler as amp_GradScaler
+GradScaler = partial(amp_GradScaler, device='cuda')
 from torch.nn.parallel.distributed import DistributedDataParallel
 from torch.optim import SGD, Adam, Optimizer
 


### PR DESCRIPTION
This is a sub-PR of #1665

## Brief

According to PyTorch:
> ``torch.cuda.amp.GradScaler(args...)`` is deprecated. Please use ``torch.amp.GradScaler("cuda", args...)`` instead.

This includes two related replacement:
1. `amp_optimizer_wrapper`
2. `test_optimizer_wrapper`

## PyTest Result

`pytest tests/test_optim/test_optimizer/test_optimizer_wrapper.py `

```python
========================================================== test session starts ===========================================================
platform linux -- Python 3.13.9, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/mgam/mgam_repos/mmengine
configfile: pytest.ini
plugins: anyio-4.9.0, hydra-core-1.3.2
collected 37 items                                                                                                                       

tests/test_optim/test_optimizer/test_optimizer_wrapper.py sssssssssssssssssss..................                                    [100%]

============================================================ warnings summary ============================================================
mmengine/utils/misc.py:477
  /home/mgam/mgam_repos/mmengine/mmengine/utils/misc.py:477: DeprecationWarning: 'maxsplit' is passed as positional argument
    summary_and_body = re.split(pattern, docstring, 1)

../../miniforge3/envs/pt/lib/python3.13/site-packages/pydantic/typing.py:400
  /home/mgam/miniforge3/envs/pt/lib/python3.13/site-packages/pydantic/typing.py:400: DeprecationWarning: Failing to pass a value to the 'type_params' parameter of 'typing._eval_type' is deprecated, as it leads to incorrect behaviour when calling typing._eval_type on a stringified annotation that references a PEP 695 type parameter. It will be disallowed in Python 3.15.
    value = _eval_type(value, base_globals, None)

tests/test_optim/test_optimizer/test_optimizer_wrapper.py::TestAmpOptimWrapper::test_optim_context_4
  /home/mgam/mgam_repos/mmengine/mmengine/runner/amp.py:119: DeprecationWarning: torch.get_autocast_gpu_dtype() is deprecated. Please use torch.get_autocast_dtype('cuda') instead. (Triggered internally at /pytorch/torch/csrc/autograd/init.cpp:887.)
    dtype = torch.get_autocast_gpu_dtype()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================= 18 passed, 19 skipped, 3 warnings in 86.75s (0:01:26) ==========================================
```