### PR TITLE
[Fix] Fix install from source issue where `get_version` raises KeyError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,10 @@ def choose_requirement(primary, secondary):
 
 def get_version():
     with open(version_file) as f:
-        exec(compile(f.read(), version_file, 'exec'))
-    return locals()['__version__']
+        code = compile(f.read(), version_file, 'exec')
+        namespace = {}
+        exec(code, namespace)
+    return namespace['__version__']
 
 
 def parse_requirements(fname='requirements/runtime.txt', with_version=True):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

Currently when installing `mmengine` from source, one might encounter such a error:
```bash
  from pkg_resources import DistributionNotFound, get_distribution
Traceback (most recent call last):
  File "/.../codebase/mmengine/setup.py", line 118, in <module>
    version=get_version(),
            ~~~~~~~~~~~^^
  File "/.../codebase/mmengine/setup.py", line 32, in get_version
    return locals()['__version__']
           ~~~~~~~~^^^^^^^^^^^^^^^
KeyError: '__version__'
```


## Modification

Modified `get_version` function in `setup.py`

## BC-breaking (Optional)

N/A

## Use cases (Optional)

N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
