### PR TITLE
[Fix] Add missing dependencies: opencv-python-headless and expecttest

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,7 @@
 addict
 matplotlib
 numpy
+opencv-python-headless
 pyyaml
 regex;sys_platform=='win32'
 rich

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,6 +4,7 @@ clearml
 coverage
 dadaptation
 dvclive
+expecttest
 lion-pytorch
 lmdb
 mlflow


### PR DESCRIPTION
## Motivation

`ModuleNotFoundError` encountered when installing mmengine from source or running tests in a fresh environment.

Currently, the `requirements/runtime.txt` file is **missing** `opencv-python-headless`, which is present in `runtime_lite.txt` but not linked in the full runtime requirements. This causes `pip install .` to create an environment where `cv2` is missing.

Additionally, `expecttest` is required by the test suite but is missing from `requirements/tests.txt`.

## Modification

Added `opencv-python-headless` to `requirements/runtime.txt`

Added `expecttest` to `requirements/tests.txt`

## BC-breaking

No

This change only adds missing dependencies to ensure the environment is built correctly. It does not remove or change existing APIs.

## Use cases

### Case 1: Installing from source

User clones the repo and runs `pip install .`

**Before**: *ImportError: No module named `cv2`*

**After**: OpenCV is installed as part of MMEngine installation


### Case 2: Running tests

User runs `pytest tests`

**Before**: Failed tests with *ModuleNotFoundError: No module named `expecttest`*

**After**: Tests run properly



## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.

- [x] The modification is covered by complete unit tests. (N/A, this is a dependency fix)

- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain. (Safe, adds missing dependencies only)

- [x] The documentation has been modified accordingly, like docstring or example tutorials. (N/A)
