### PR TITLE
Avoid contiguous error for default_collate

### DIFF
--- a/mmengine/dataset/utils.py
+++ b/mmengine/dataset/utils.py
@@ -162,4 +162,6 @@ def default_collate(data_batch: Sequence) -> Any:
             for key in data_item
         })
     else:
+        if isinstance(data_item,np.ndarray):
+            data_batch=[np.ascontiguousarray(item) for item in data_batch]
         return torch_default_collate(data_batch)


### PR DESCRIPTION
## Motivation

Avoid contiguous error for default_collate. When input of type np array is not contiguous, torch default collate might throw error.
## Modification

Add an additional if that check if numpy then ensure it is contiguous before collate

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
