### PR TITLE
[Fix] Handle extensionless MLflow image names

### DIFF
--- a/mmengine/visualization/vis_backend.py
+++ b/mmengine/visualization/vis_backend.py
@@ -781,6 +781,8 @@ class MLflowVisBackend(BaseVisBackend):
                 should be RGB.
             step (int): Global step value to record. Default to 0.
         """
+        if not osp.splitext(name)[1]:
+            name = f'{name}_{step}.png'
         self._mlflow.log_image(image, name)
 
     @force_init_env

--- a/tests/test_visualizer/test_vis_backend.py
+++ b/tests/test_visualizer/test_vis_backend.py
@@ -299,6 +299,7 @@ class TestMLflowVisBackend:
         image = np.random.randint(0, 256, size=(10, 10, 3)).astype(np.uint8)
         mlflow_vis_backend = MLflowVisBackend('temp_dir')
         mlflow_vis_backend.add_image('img.png', image)
+        mlflow_vis_backend.add_image('img', image, step=2)
 
     def test_add_scalar(self):
         mlflow_vis_backend = MLflowVisBackend('temp_dir')


### PR DESCRIPTION
## Motivation

`MLflowVisBackend.add_image` forwards its `name` directly to `mlflow.log_image`. Visualization hooks commonly use extensionless identifiers such as `val_img`, and MLflow passes that name to Pillow, which raises `ValueError: unknown file extension`.

Fixes #1681.

## Modification

- Preserve image names that already include an extension.
- For extensionless names, use the existing MMEngine image convention `<name>_<step>.png` before calling MLflow.
- Extend the MLflow backend unit test with an extensionless name at a nonzero step.

## BC-breaking

No. Explicit filenames such as `img.png` are unchanged. Names that previously failed now log successfully as PNG artifacts.

## Testing

- Confirmed the new regression assertion fails before the source change with `ValueError: unknown file extension`.
- `pytest tests/test_visualizer/test_vis_backend.py::TestMLflowVisBackend::test_add_image -q` (1 passed)
- `pytest tests/test_visualizer/test_vis_backend.py -q -k 'not TestDVCLiveVisBackend and not TestAimVisBackend'` (36 passed, 7 skipped, 14 deselected)
- `pre-commit run --files mmengine/visualization/vis_backend.py tests/test_visualizer/test_vis_backend.py` (all hooks passed)

The Aim and DVCLive classes were deselected because those optional dependencies are not installed; the same pre-change run failed only in those two classes for missing packages.

## Checklist

1. The complete repository pre-commit configuration passes on the changed files.
2. The modification is covered by the existing MLflow backend test.
3. No downstream API changes are introduced.
4. No documentation change is needed for this bug fix.
