### PR TITLE
[Feature] Support engine with Biren SUPA backend.

### DIFF
--- a/mmengine/device/__init__.py
+++ b/mmengine/device/__init__.py
@@ -1,12 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .utils import (get_device, get_max_cuda_memory, get_max_musa_memory,
-                    is_cuda_available, is_dipu_available, is_mlu_available,
-                    is_mps_available, is_musa_available, is_npu_available,
-                    is_npu_support_full_precision)
+                    get_max_supa_memory, is_cuda_available, is_dipu_available,
+                    is_mlu_available, is_mps_available, is_musa_available,
+                    is_npu_available, is_npu_support_full_precision,
+                    is_supa_available)
 
 __all__ = [
     'get_max_cuda_memory', 'get_device', 'is_cuda_available',
     'is_mlu_available', 'is_mps_available', 'is_npu_available',
     'is_dipu_available', 'get_max_musa_memory', 'is_musa_available',
-    'is_npu_support_full_precision'
+    'is_npu_support_full_precision', 'get_max_supa_memory', 'is_supa_available'
 ]

--- a/mmengine/device/utils.py
+++ b/mmengine/device/utils.py
@@ -17,6 +17,12 @@ except Exception:
     IS_NPU_AVAILABLE = False
 
 try:
+    import torch_supa  # noqa: F401
+    IS_SUPA_AVAILABLE = hasattr(torch, 'supa') and torch.supa.is_available()
+except Exception:
+    IS_SUPA_AVAILABLE = False
+
+try:
     import torch_mlu  # noqa: F401
     IS_MLU_AVAILABLE = hasattr(torch, 'mlu') and torch.mlu.is_available()
 except Exception:
@@ -61,6 +67,11 @@ def get_max_cuda_memory(device: Optional[torch.device] = None) -> int:
 def is_cuda_available() -> bool:
     """Returns True if cuda devices exist."""
     return torch.cuda.is_available()
+
+
+def is_supa_available() -> bool:
+    """Returns True if Biren SUPA devices exist."""
+    return IS_SUPA_AVAILABLE
 
 
 def is_npu_available() -> bool:
@@ -109,6 +120,16 @@ def get_max_musa_memory(device: Optional[torch.device] = None) -> int:
     return int(mem_mb.item())
 
 
+def get_max_supa_memory(device: Optional[torch.device] = None) -> int:
+    """Return peak tensor memory on a SUPA device in megabytes (MB)."""
+    mem = torch.supa.max_memory_allocated(device=device)
+    mem_mb = torch.tensor([int(mem) // (1024 * 1024)],
+                          dtype=torch.int,
+                          device=device)
+    torch.supa.reset_peak_memory_stats(device=device)
+    return int(mem_mb.item())
+
+
 def is_musa_available() -> bool:
     return IS_MUSA_AVAILABLE
 
@@ -123,6 +144,8 @@ def is_npu_support_full_precision() -> bool:
 DEVICE = 'cpu'
 if is_npu_available():
     DEVICE = 'npu'
+elif is_supa_available():
+    DEVICE = 'supa'
 elif is_cuda_available():
     DEVICE = 'cuda'
 elif is_mlu_available():
@@ -139,6 +162,6 @@ def get_device() -> str:
     """Returns the currently existing device type.
 
     Returns:
-        str: cuda | npu | mlu | mps | musa | cpu.
+        str: cuda | npu | mlu | mps | musa | supa | cpu.
     """
     return DEVICE

--- a/mmengine/dist/dist.py
+++ b/mmengine/dist/dist.py
@@ -416,6 +416,7 @@ def _broadcast_object_list(object_list: List[Any],
     is_hccl_backend = group_backend == 'hccl'
     is_cncl_backend = group_backend == 'cncl'
     is_mccl_backend = group_backend == 'mccl'
+    is_bccl_backend = group_backend == 'bccl'
     if is_hccl_backend:
         current_device = torch.device('npu', torch.npu.current_device())
         object_sizes_tensor = object_sizes_tensor.to(current_device)
@@ -424,6 +425,9 @@ def _broadcast_object_list(object_list: List[Any],
         object_sizes_tensor = object_sizes_tensor.to(current_device)
     elif is_mccl_backend:
         current_device = torch.device('musa', torch.musa.current_device())
+        object_sizes_tensor = object_sizes_tensor.to(current_device)
+    elif is_bccl_backend:
+        current_device = torch.device('supa', torch.supa.current_device())
         object_sizes_tensor = object_sizes_tensor.to(current_device)
     elif is_nccl_backend:
         # See note about using torch.cuda.current_device() here in
@@ -444,7 +448,8 @@ def _broadcast_object_list(object_list: List[Any],
             dtype=torch.uint8,
         )
 
-    if is_nccl_backend or is_hccl_backend or is_cncl_backend:
+    if (is_nccl_backend or is_hccl_backend or is_cncl_backend
+            or is_bccl_backend):
         object_tensor = object_tensor.to(current_device)
     torch_dist.broadcast(object_tensor, src=src, group=group)
     # Deserialize objects using their stored sizes.
@@ -629,7 +634,12 @@ def _all_gather_object(object_list: List[Any],
     current_device = torch.device('cpu')
     is_nccl_backend = group_backend == torch_dist.Backend.NCCL
     is_mccl_backend = group_backend == 'mccl'
-    if is_nccl_backend:
+    is_bccl_backend = group_backend == 'bccl'
+    if is_bccl_backend:
+        current_device = torch.device('supa', torch.supa.current_device())
+        input_tensor = input_tensor.to(current_device)
+        local_size = local_size.to(current_device)
+    elif is_nccl_backend:
         # See note about using torch.cuda.current_device() here in docstring.
         # We cannot simply use my_rank since rank == device is not necessarily
         # true.
@@ -789,7 +799,12 @@ def _gather_object(obj: Any,
     current_device = torch.device('cpu')
     is_nccl_backend = group_backend == torch_dist.Backend.NCCL
     is_mccl_backend = group_backend == 'mccl'
-    if is_nccl_backend:
+    is_bccl_backend = group_backend == 'bccl'
+    if is_bccl_backend:
+        current_device = torch.device('supa', torch.supa.current_device())
+        input_tensor = input_tensor.to(current_device)
+        local_size = local_size.to(current_device)
+    elif is_nccl_backend:
         current_device = torch.device('cuda', torch.cuda.current_device())
         input_tensor = input_tensor.to(current_device)
         local_size = local_size.to(current_device)

--- a/mmengine/dist/utils.py
+++ b/mmengine/dist/utils.py
@@ -12,7 +12,7 @@ from torch import Tensor
 from torch import distributed as torch_dist
 from torch.distributed import ProcessGroup
 from mmengine.device import (is_mlu_available, is_npu_available,
-                             is_musa_available)
+                             is_musa_available, is_supa_available)
 
 from collections.abc import Iterable, Mapping
 
@@ -62,8 +62,8 @@ def init_dist(launcher,
     Args:
         launcher (str): Way to launcher multi processes. Supported launchers
             are 'pytorch', 'mpi' and 'slurm'.
-        backend (str): Communication Backends. Supported backends are 'nccl',
-            'gloo' and 'mpi'. Defaults to 'nccl'.
+        backend (str): Communication Backends. Supported backends include
+            'nccl', 'bccl', 'gloo' and 'mpi'. Defaults to 'nccl'.
         **kwargs: keyword arguments are passed to ``init_process_group``.
     """
     timeout = kwargs.get('timeout', None)
@@ -95,8 +95,8 @@ def _init_dist_pytorch(backend, init_backend='torch', **kwargs) -> None:
     """Initialize distributed environment with PyTorch launcher.
 
     Args:
-        backend (str): Backend of torch.distributed. Supported backends are
-            'nccl', 'gloo' and 'mpi'. Defaults to 'nccl'.
+        backend (str): Backend of torch.distributed. Supported backends include
+            'nccl', 'bccl', 'gloo' and 'mpi'. Defaults to 'nccl'.
         **kwargs: keyword arguments are passed to ``init_process_group``.
     """
     rank = int(os.environ['RANK'])
@@ -115,6 +115,13 @@ def _init_dist_pytorch(backend, init_backend='torch', **kwargs) -> None:
         torch.npu.set_device(local_rank)
         torch_dist.init_process_group(
             backend='hccl',
+            rank=rank,
+            world_size=int(os.environ['WORLD_SIZE']),
+            **kwargs)
+    elif is_supa_available():
+        torch.supa.set_device(local_rank)
+        torch_dist.init_process_group(
+            backend='bccl',
             rank=rank,
             world_size=int(os.environ['WORLD_SIZE']),
             **kwargs)
@@ -161,7 +168,11 @@ def _init_dist_mpi(backend, **kwargs) -> None:
                 '/available_images.md#sagemaker-framework-containers'
                 '-sm-support-only') from e
     local_rank = int(os.environ['OMPI_COMM_WORLD_LOCAL_RANK'])
-    torch.cuda.set_device(local_rank)
+    if is_supa_available():
+        torch.supa.set_device(local_rank)
+        backend = 'bccl'
+    else:
+        torch.cuda.set_device(local_rank)
     if 'MASTER_PORT' not in os.environ:
         # 29500 is torch.distributed default port
         os.environ['MASTER_PORT'] = '29500'
@@ -194,7 +205,9 @@ def _init_dist_slurm(backend,
     if local_rank_env is not None:
         local_rank = int(local_rank_env)
     else:
-        num_gpus = torch.cuda.device_count()
+        num_gpus = (
+            torch.supa.device_count()
+            if is_supa_available() else torch.cuda.device_count())
         local_rank = proc_id % num_gpus
     addr = subprocess.getoutput(
         f'scontrol show hostname {node_list} | head -n1')
@@ -217,6 +230,9 @@ def _init_dist_slurm(backend,
         import torch_mlu  # noqa: F401
         torch.mlu.set_device(local_rank)
         torch_dist.init_process_group(backend='cncl', **kwargs)
+    elif is_supa_available():
+        torch.supa.set_device(local_rank)
+        torch_dist.init_process_group(backend='bccl', **kwargs)
     else:
         torch.cuda.set_device(local_rank)
 
@@ -529,6 +545,8 @@ def get_comm_device(group: Optional[ProcessGroup] = None) -> torch.device:
     if backend == 'hccl':
         import torch_npu  # noqa: F401
         return torch.device('npu', torch.npu.current_device())
+    elif backend == 'bccl':
+        return torch.device('supa', torch.supa.current_device())
     elif backend == torch_dist.Backend.NCCL:
         return torch.device('cuda', torch.cuda.current_device())
     elif backend == 'cncl':

--- a/mmengine/hooks/empty_cache_hook.py
+++ b/mmengine/hooks/empty_cache_hook.py
@@ -4,7 +4,7 @@ from typing import Optional, Sequence, Union
 import torch
 
 from mmengine.registry import HOOKS
-from ..device import is_cuda_available, is_musa_available
+from ..device import (is_cuda_available, is_musa_available, is_supa_available)
 from .hook import Hook
 
 DATA_BATCH = Optional[Union[dict, tuple, list]]
@@ -50,7 +50,9 @@ class EmptyCacheHook(Hook):
             mode (str): Current mode of runner. Defaults to 'train'.
         """
         if self._do_after_iter:
-            if is_cuda_available():
+            if is_supa_available():
+                torch.supa.empty_cache()
+            elif is_cuda_available():
                 torch.cuda.empty_cache()
             elif is_musa_available():
                 torch.musa.empty_cache()
@@ -63,7 +65,9 @@ class EmptyCacheHook(Hook):
             mode (str): Current mode of runner. Defaults to 'train'.
         """
         if self._do_before_epoch:
-            if is_cuda_available():
+            if is_supa_available():
+                torch.supa.empty_cache()
+            elif is_cuda_available():
                 torch.cuda.empty_cache()
             elif is_musa_available():
                 torch.musa.empty_cache()
@@ -76,7 +80,9 @@ class EmptyCacheHook(Hook):
             mode (str): Current mode of runner. Defaults to 'train'.
         """
         if self._do_after_epoch:
-            if is_cuda_available():
+            if is_supa_available():
+                torch.supa.empty_cache()
+            elif is_cuda_available():
                 torch.cuda.empty_cache()
             elif is_musa_available():
                 torch.musa.empty_cache()

--- a/mmengine/hooks/empty_cache_hook.py
+++ b/mmengine/hooks/empty_cache_hook.py
@@ -4,7 +4,7 @@ from typing import Optional, Sequence, Union
 import torch
 
 from mmengine.registry import HOOKS
-from ..device import (is_cuda_available, is_musa_available, is_supa_available)
+from ..device import is_cuda_available, is_musa_available, is_supa_available
 from .hook import Hook
 
 DATA_BATCH = Optional[Union[dict, tuple, list]]

--- a/mmengine/logging/logger.py
+++ b/mmengine/logging/logger.py
@@ -398,6 +398,23 @@ def _get_device_id():
     except ImportError:
         return 0
     else:
+        SUPA_AVAILABLE = False
+        try:
+            import torch_supa  # noqa: F401
+            SUPA_AVAILABLE = (
+                hasattr(torch, 'supa') and torch.supa.is_available())
+        except ImportError:
+            pass
+        if SUPA_AVAILABLE:
+            local_rank = int(os.getenv('LOCAL_RANK', '0'))
+            supa_visible_devices = os.getenv('SUPA_VISIBLE_DEVICES', None)
+            if supa_visible_devices is None:
+                num_device = torch.supa.device_count()
+                supa_visible_devices = list(range(num_device))
+            else:
+                supa_visible_devices = supa_visible_devices.split(',')
+            return int(supa_visible_devices[local_rank])
+
         MUSA_AVAILABLE = False
         try:
             import torch_musa

--- a/mmengine/model/base_model/data_preprocessor.py
+++ b/mmengine/model/base_model/data_preprocessor.py
@@ -113,6 +113,11 @@ class BaseDataPreprocessor(nn.Module):
         self._device = torch.device(torch.cuda.current_device())
         return super().cuda()
 
+    def supa(self, *args, **kwargs) -> nn.Module:
+        """Move the module to SUPA and record its current device."""
+        self._device = torch.device('supa', torch.supa.current_device())
+        return super().to(self._device)
+
     def musa(self, *args, **kwargs) -> nn.Module:
         """Overrides this method to set the :attr:`device`
 

--- a/mmengine/optim/optimizer/amp_optimizer_wrapper.py
+++ b/mmengine/optim/optimizer/amp_optimizer_wrapper.py
@@ -6,7 +6,8 @@ import torch
 import torch.nn as nn
 
 from mmengine.device import (is_cuda_available, is_mlu_available,
-                             is_musa_available, is_npu_available)
+                             is_musa_available, is_npu_available,
+                             is_supa_available)
 from mmengine.registry import OPTIM_WRAPPERS
 from mmengine.utils import digit_version
 from mmengine.utils.dl_utils import TORCH_VERSION
@@ -14,6 +15,8 @@ from .optimizer_wrapper import OptimWrapper
 
 if is_npu_available():
     from torch.npu.amp import GradScaler
+elif is_supa_available():
+    from torch.supa.amp import GradScaler
 elif is_mlu_available():
     from torch.mlu.amp import GradScaler
 else:
@@ -73,10 +76,11 @@ class AmpOptimWrapper(OptimWrapper):
                  **kwargs):
         assert digit_version(TORCH_VERSION) >= digit_version('1.6.0'), (
             '`torch.cuda.amp` is only available when pytorch version >= 1.6')
-        assert is_cuda_available() or is_npu_available() or is_mlu_available(
-        ) or is_musa_available(), (
-            '``AmpOptimizerWrapper`` is only available training '
-            'on gpu, npu, mlu or musa')
+        assert (is_cuda_available() or is_npu_available()
+                or is_supa_available() or is_mlu_available()
+                or is_musa_available()), (
+                    '``AmpOptimizerWrapper`` is only available training '
+                    'on gpu, npu, mlu or musa')
         super().__init__(**kwargs)
         self._scale_update_param = None
 

--- a/mmengine/runner/amp.py
+++ b/mmengine/runner/amp.py
@@ -6,7 +6,7 @@ from typing import Optional
 import torch
 
 from mmengine.device import (get_device, is_cuda_available, is_mlu_available,
-                             is_npu_available)
+                             is_npu_available, is_supa_available)
 from mmengine.logging import print_log
 from mmengine.utils import digit_version
 from mmengine.utils.dl_utils import TORCH_VERSION
@@ -92,6 +92,9 @@ def autocast(device_type: Optional[str] = None,
         if is_npu_available():
             with torch.npu.amp.autocast(enabled=enabled):
                 yield
+        elif is_supa_available():
+            with torch.supa.amp.autocast(enabled=enabled):
+                yield
         elif is_mlu_available():
             with torch.mlu.amp.autocast(enabled=enabled):
                 yield
@@ -124,6 +127,15 @@ def autocast(device_type: Optional[str] = None,
                     'Current CUDA Device does not support bfloat16. Please '
                     'switch dtype to float16.')
 
+        elif device_type == 'supa':
+            if dtype is None:
+                dtype = torch.float16
+            if (dtype == torch.bfloat16
+                    and not torch.supa.is_bf16_supported()):
+                raise RuntimeError(
+                    'Current SUPA device does not support bfloat16. Please '
+                    'switch dtype to float16.')
+
         elif device_type == 'cpu':
             if dtype is None:
                 dtype = torch.bfloat16
@@ -151,7 +163,8 @@ def autocast(device_type: Optional[str] = None,
                 return
             else:
                 raise ValueError('User specified autocast device_type must be '
-                                 f'cuda or cpu, but got {device_type}')
+                                 'cuda, supa or cpu, but got '
+                                 f'{device_type}')
 
         with torch.autocast(
                 device_type=device_type,

--- a/mmengine/runner/log_processor.py
+++ b/mmengine/runner/log_processor.py
@@ -10,7 +10,8 @@ import numpy as np
 import torch
 
 from mmengine.device import (get_max_cuda_memory, get_max_musa_memory,
-                             is_cuda_available, is_musa_available)
+                             get_max_supa_memory, is_cuda_available,
+                             is_musa_available, is_supa_available)
 from mmengine.registry import LOG_PROCESSORS
 
 
@@ -229,7 +230,7 @@ class LogProcessor:
 
         # If cuda/musa is available,
         # the max memory occupied should be calculated.
-        if is_cuda_available() or is_musa_available():
+        if (is_supa_available() or is_cuda_available() or is_musa_available()):
             max_memory = self._get_max_memory(runner)
             log_str += f'memory: {max_memory}  '
             tag['memory'] = max_memory
@@ -502,6 +503,8 @@ class LogProcessor:
 
         device = getattr(runner.model, 'output_device', None)
 
+        if is_supa_available():
+            return get_max_supa_memory(device)
         if is_musa_available():
             return get_max_musa_memory(device)
         return get_max_cuda_memory(device)

--- a/mmengine/runner/utils.py
+++ b/mmengine/runner/utils.py
@@ -7,7 +7,8 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
-from mmengine.device import is_cuda_available, is_musa_available
+from mmengine.device import (is_cuda_available, is_musa_available,
+                             is_supa_available)
 from mmengine.dist import get_rank, sync_random_seed
 from mmengine.logging import print_log
 from mmengine.utils import digit_version, is_list_of
@@ -70,7 +71,9 @@ def set_random_seed(seed: Optional[int] = None,
     np.random.seed(seed)
     torch.manual_seed(seed)
     # torch.cuda.manual_seed(seed)
-    if is_cuda_available():
+    if is_supa_available():
+        torch.supa.manual_seed_all(seed)
+    elif is_cuda_available():
         torch.cuda.manual_seed_all(seed)
     elif is_musa_available():
         torch.musa.manual_seed_all(seed)

--- a/mmengine/utils/dl_utils/collect_env.py
+++ b/mmengine/utils/dl_utils/collect_env.py
@@ -10,7 +10,8 @@ import numpy as np
 import torch
 
 import mmengine
-from mmengine.device import is_cuda_available, is_musa_available
+from mmengine.device import (is_cuda_available, is_musa_available,
+                             is_supa_available)
 from .parrots_wrapper import TORCH_VERSION, get_build_config, is_rocm_pytorch
 
 
@@ -58,12 +59,20 @@ def collect_env():
     env_info['Python'] = sys.version.replace('\n', '')
 
     cuda_available = is_cuda_available()
+    supa_available = is_supa_available()
     musa_available = is_musa_available()
     env_info['CUDA available'] = cuda_available
+    env_info['SUPA available'] = supa_available
     env_info['MUSA available'] = musa_available
     env_info['numpy_random_seed'] = np.random.get_state()[1][0]
 
-    if cuda_available:
+    if supa_available:
+        devices = defaultdict(list)
+        for k in range(torch.supa.device_count()):
+            devices[torch.supa.get_device_name(k)].append(str(k))
+        for name, device_ids in devices.items():
+            env_info['SUPA ' + ','.join(device_ids)] = name
+    elif cuda_available:
         devices = defaultdict(list)
         for k in range(torch.cuda.device_count()):
             devices[torch.cuda.get_device_name(k)].append(str(k))

--- a/mmengine/utils/dl_utils/time_counter.py
+++ b/mmengine/utils/dl_utils/time_counter.py
@@ -4,7 +4,8 @@ from typing import Optional, Union
 
 import torch
 
-from mmengine.device import is_cuda_available, is_musa_available
+from mmengine.device import (is_cuda_available, is_musa_available,
+                             is_supa_available)
 from mmengine.dist.utils import master_only
 from mmengine.logging import MMLogger, print_log
 
@@ -86,7 +87,9 @@ class TimeCounter:
             self.__count += 1
 
             if self.with_sync:
-                if is_cuda_available():
+                if is_supa_available():
+                    torch.supa.synchronize()
+                elif is_cuda_available():
                     torch.cuda.synchronize()
                 elif is_musa_available():
                     torch.musa.synchronize()
@@ -95,7 +98,9 @@ class TimeCounter:
             result = fn(*args, **kwargs)
 
             if self.with_sync:
-                if is_cuda_available():
+                if is_supa_available():
+                    torch.supa.synchronize()
+                elif is_cuda_available():
                     torch.cuda.synchronize()
                 elif is_musa_available():
                     torch.musa.synchronize()
@@ -115,14 +120,20 @@ class TimeCounter:
 
         self.__count += 1
 
-        if self.with_sync and torch.cuda.is_available():
-            torch.cuda.synchronize()
+        if self.with_sync:
+            if is_supa_available():
+                torch.supa.synchronize()
+            elif is_cuda_available():
+                torch.cuda.synchronize()
         self.__start_time = time.perf_counter()
 
     @master_only
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.with_sync and torch.cuda.is_available():
-            torch.cuda.synchronize()
+        if self.with_sync:
+            if is_supa_available():
+                torch.supa.synchronize()
+            elif is_cuda_available():
+                torch.cuda.synchronize()
         elapsed = time.perf_counter() - self.__start_time
         self.print_time(elapsed)
 

--- a/tests/test_device/test_device.py
+++ b/tests/test_device/test_device.py
@@ -1,13 +1,15 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from mmengine.device import (get_device, is_cuda_available, is_mlu_available,
                              is_mps_available, is_musa_available,
-                             is_npu_available)
+                             is_npu_available, is_supa_available)
 
 
 def test_get_device():
     device = get_device()
     if is_npu_available():
         assert device == 'npu'
+    elif is_supa_available():
+        assert device == 'supa'
     elif is_cuda_available():
         assert device == 'cuda'
     elif is_mlu_available():


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers. By the way, if you're not familiar with how to use pre-commit to fix lint issues or add unit tests, please refer to [Contributing to OpenMMLab](https://mmengine.readthedocs.io/en/latest/notes/contributing.html).

## Motivation

Added biren supa device support 

## Modification

        modified:   mmengine/device/__init__.py
        modified:   mmengine/device/utils.py
        modified:   mmengine/dist/dist.py
        modified:   mmengine/dist/utils.py
        modified:   mmengine/hooks/empty_cache_hook.py
        modified:   mmengine/logging/logger.py
        modified:   mmengine/model/base_model/data_preprocessor.py
        modified:   mmengine/optim/optimizer/amp_optimizer_wrapper.py
        modified:   mmengine/runner/amp.py
        modified:   mmengine/runner/log_processor.py
        modified:   mmengine/runner/utils.py
        modified:   mmengine/utils/dl_utils/collect_env.py
        modified:   mmengine/utils/dl_utils/time_counter.py
        modified:   tests/test_device/test_device.py

This PR just add device backend api adaptor, don't include any new function

## BC-breaking (Optional)
None

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

See  `tests/test_device/test_device.py`

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMPretrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
