### PR TITLE
Fix validation epoch metadata for visual backends

### DIFF
--- a/mmengine/hooks/logger_hook.py
+++ b/mmengine/hooks/logger_hook.py
@@ -262,6 +262,7 @@ class LoggerHook(Hook):
                 epoch = 0
             else:
                 epoch = runner.epoch
+            tag['epoch'] = epoch
             runner.visualizer.add_scalars(
                 tag, step=epoch, file_path=self.json_log_path)
         else:

--- a/tests/test_hooks/test_logger_hook.py
+++ b/tests/test_hooks/test_logger_hook.py
@@ -120,6 +120,8 @@ class TestLoggerHook(RunnerTestCase):
     def test_after_val_epoch(self):
         logger_hook = LoggerHook()
         runner = MagicMock()
+        runner._train_loop = object()
+        runner.epoch = 3
         # Test when `log_metric_by_epoch` is True
         runner.log_processor.get_log_after_epoch = MagicMock(
             return_value=({
@@ -135,7 +137,8 @@ class TestLoggerHook(RunnerTestCase):
             call({
                 'time': 1,
                 'datatime': 1,
-                'acc': 0.8
+                'acc': 0.8,
+                'epoch': 3
             }, **args),
         ]
         self.assertEqual(
@@ -157,7 +160,8 @@ class TestLoggerHook(RunnerTestCase):
             call({
                 'time': 1,
                 'datatime': 1,
-                'acc': 0.8
+                'acc': 0.8,
+                'epoch': 3
             }, **args),
             call({
                 'time': 5,


### PR DESCRIPTION
## Summary
- include the validation epoch in the scalar payload when `log_metric_by_epoch=True`
- add regression coverage for the epoch-based validation logging path

This lets visualization backends such as `WandbVisBackend` define an epoch-based x-axis from the emitted scalar metadata. The scalar step remains unchanged.

Fixes #1692.

## Validation
- `pytest tests/test_hooks/test_logger_hook.py -q` → **7 passed**
- `git diff --check` → passed

The focused test run emitted existing PyTorch deprecation warnings only.