### PR TITLE
Fix syncbn training state

### DIFF
--- a/mmengine/model/utils.py
+++ b/mmengine/model/utils.py
@@ -248,6 +248,7 @@ def convert_sync_batchnorm(module: nn.Module,
         module_output.running_mean = module.running_mean
         module_output.running_var = module.running_var
         module_output.num_batches_tracked = module.num_batches_tracked
+        module_output.training = module.training
         if hasattr(module, 'qconfig'):
             module_output.qconfig = module.qconfig
     for name, child in module.named_children():

--- a/tests/test_hooks/test_checkpoint_hook.py
+++ b/tests/test_hooks/test_checkpoint_hook.py
@@ -336,7 +336,6 @@ class TestCheckpointHook(RunnerTestCase):
         petrel_client = MagicMock()
         for by_epoch, cfg in [(True, self.epoch_based_cfg),
                               (False, self.iter_based_cfg)]:
-            isfile = MagicMock(return_value=True)
             self.clear_work_dir()
             with patch.dict(sys.modules, {'petrel_client': petrel_client}), \
                  patch('mmengine.fileio.backends.PetrelBackend.put') as put_mock, \

--- a/tests/test_model/test_convert_sync_batchnorm_training.py
+++ b/tests/test_model/test_convert_sync_batchnorm_training.py
@@ -1,0 +1,13 @@
+import torch.nn as nn
+
+from mmengine.model import convert_sync_batchnorm
+
+
+def test_convert_sync_batchnorm_keeps_training_state():
+    bn = nn.BatchNorm2d(4)
+    bn.eval()
+
+    sync_bn = convert_sync_batchnorm(bn)
+
+    assert isinstance(sync_bn, nn.SyncBatchNorm)
+    assert sync_bn.training is False

--- a/tests/test_model/test_convert_sync_batchnorm_training.py
+++ b/tests/test_model/test_convert_sync_batchnorm_training.py
@@ -11,4 +11,4 @@ def test_convert_sync_batchnorm_keeps_training_state():
     sync_bn = convert_sync_batchnorm(bn)
 
     assert isinstance(sync_bn, nn.SyncBatchNorm)
-    assert sync_bn.training is False
+    assert not sync_bn.training

--- a/tests/test_model/test_convert_sync_batchnorm_training.py
+++ b/tests/test_model/test_convert_sync_batchnorm_training.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 import torch.nn as nn
 
 from mmengine.model import convert_sync_batchnorm


### PR DESCRIPTION
## Motivation

Preserve the source module's training mode when converting `BatchNorm` to `SyncBatchNorm`. Without this, evaluation-mode layers are silently switched to training mode, which can cause incorrect fine-tuning behavior and NCCL timeouts. Fixes #1624.

## Modification

Copy `module.training` to the converted module and add a regression test for evaluation-mode conversion.

## BC-breaking

No.

## Checklist

1. Targeted lint checks pass.
2. Added `test_convert_sync_batchnorm_keeps_training_state`.
3. No downstream changes are required.
4. No documentation changes are needed.
